### PR TITLE
Add opt-in schema validation for atoms and selectors

### DIFF
--- a/.changeset/schema-validation.md
+++ b/.changeset/schema-validation.md
@@ -1,0 +1,67 @@
+---
+"valdres": minor
+---
+
+Add opt-in runtime schema validation for atoms and selectors.
+
+Pass a `schema` to an atom, selector, or family. Any **Standard Schema**
+(https://standard-schema.dev — Zod 3.24+/4, Valibot, ArkType, …) works, as does
+any classic validator with a `parse(value)` method. The schema also drives type
+inference, so `atom(undefined, { schema: z.string() })` is typed as
+`Atom<string>` without a generic. The schema is readable back off any atom,
+selector, or family object via `.schema` (families expose it without
+materializing a member), so consumers like devtools or a sync layer can
+validate values against a state's declared shape.
+
+```ts
+const user = atom({ name: "Ada", age: 36 }, {
+    schema: z.object({ name: z.string(), age: z.number().min(0) }),
+})
+
+// validation is opt-in per store, off by default
+const s = store({ schemaValidation: true })
+s.set(user, { name: "Bob", age: -1 }) // throws SchemaValidationError
+```
+
+Design:
+
+- **Opt-in, inherited like `enumerable`.** Off by default; enable per store with
+  `store({ schemaValidation: true })`. Scopes inherit it from their parent, so it
+  stays off the hot path for the common (production) case and serves as a
+  development-time safety net. An individual atom/selector can override the store
+  with its own `schemaValidation: true` (always validate a boundary atom, even in
+  a store with validation off) or `schemaValidation: false` (exempt a hot one).
+
+- **Validate-only.** The schema runs purely for its rejecting side effect; the
+  original value is stored unchanged. A store with validation on therefore stores
+  the same value as one with it off — no dev/prod divergence. Note this means a
+  transforming/coercing schema (`z.coerce.number()`, `z.string().trim()`,
+  `z.string().default(...)`) validates but does **not** transform; avoid those
+  here (the inferred type follows the schema's output while the stored value is
+  the input).
+
+- **Validated at the write boundaries.** Atom init (static, function, async, and
+  selector defaults), atom `set` (sync + async), selector evaluation (sync +
+  async), deleted-family-member reads, and `store.txn()` — transaction writes
+  validate at staging time, so an invalid value throws in the txn body and aborts
+  the whole transaction (atomic). Batched stores validate too.
+
+- **Errors name the culprit.** Sync failures throw a `SchemaValidationError`
+  (exported) that names the offending atom/selector and keeps the library-native
+  error (e.g. a Zod `ZodError`) on `cause`, instead of a raw error from deep
+  inside the store. Async failures (a promise resolving to an invalid value)
+  can't be thrown to the caller, so they're reported via `console.error` and the
+  invalid value is never committed.
+
+Known limitations:
+
+- A **promise set inside `store.txn()`** is stored as-is and not auto-resolved
+  by the transaction (pre-existing behavior), so it is not validated on resolve.
+  Validate before setting, or set outside a transaction.
+- An invalid **async default/selector** drops its value (so a re-read re-inits) —
+  the same as a rejecting async default. Under React Suspense a component that
+  keeps re-reading will re-init/re-fetch; validate at the data boundary rather
+  than relying on async-default validation under Suspense.
+- Asynchronous schema validation (an async Standard Schema, or a Zod schema with
+  an async refinement) is not supported on the synchronous validation path and
+  surfaces as an error; use synchronous schemas.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
               run: bun run build
             - name: Build types
               run: bun run build:types
+            - name: Typecheck type-level tests
+              run: bun --filter 'valdres' typecheck:types
             - name: Verify publish (dry-run)
               run: DRY_RUN=1 bash scripts/ci-publish.sh
             - name: Test

--- a/bun.lock
+++ b/bun.lock
@@ -492,6 +492,7 @@
         "recoil": "0.7.7",
         "typescript": "5.9.2",
         "vitest": "^3.1.1",
+        "zod": "^4.3.6",
       },
     },
     "packages/valdres-angular": {
@@ -2184,6 +2185,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zone.js": ["zone.js@0.15.1", "", {}, "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w=="],
 

--- a/docs/content/guides/schema-validation.mdx
+++ b/docs/content/guides/schema-validation.mdx
@@ -1,0 +1,166 @@
+---
+title: Schema Validation
+description: Opt-in runtime validation for atoms and selectors with schema-driven type inference
+---
+
+# Schema Validation
+
+Atoms and selectors accept an optional `schema` that validates values at
+runtime — and types your state without a generic. Validation is **opt-in per
+store** and off by default, so it adds zero cost unless you turn it on.
+
+```ts
+import { atom, store } from "valdres"
+import { z } from "zod"
+
+const userAtom = atom(
+    { name: "Ada", age: 36 },
+    {
+        name: "userAtom",
+        schema: z.object({ name: z.string(), age: z.number().min(0) }),
+    },
+)
+
+const s = store({ schemaValidation: true })
+
+s.set(userAtom, { name: "Bob", age: -1 })
+// SchemaValidationError: Schema validation failed for 'userAtom': …
+```
+
+## Two features in one
+
+1. **Type inference.** The schema is the single source of truth for the atom's
+   type — `atom(undefined, { schema: z.string() })` is `Atom<string>`, no
+   generic needed. This works even when validation is off.
+2. **Runtime validation.** With validation enabled, every value entering the
+   store is checked against the schema — catching the bugs TypeScript can't see
+   (API responses with the wrong shape, form input, data crossing team
+   boundaries).
+
+## Enabling validation
+
+Validation is off by default. Enable it per store:
+
+```ts
+const devStore = store({ schemaValidation: true })
+```
+
+Scoped stores inherit the setting from their parent. A typical setup enables it
+everywhere except production:
+
+```ts
+const appStore = store({ schemaValidation: import.meta.env.DEV })
+```
+
+An individual atom or selector can override the store's setting:
+
+```ts
+// Always validated — even in a store with validation off.
+// Useful for true boundary atoms (API responses, URL params).
+const apiResponseAtom = atom(undefined, {
+    schema: responseSchema,
+    schemaValidation: true,
+})
+
+// Never validated — even in a store with validation on.
+const hotPathAtom = atom(0, {
+    schema: z.number(),
+    schemaValidation: false,
+})
+```
+
+## Supported schema libraries
+
+Any [Standard Schema](https://standard-schema.dev) works — Zod 3.24+/4,
+Valibot, ArkType, and others — as well as any classic validator with a
+`parse(value)` method.
+
+```ts
+import * as v from "valibot"
+
+const nameAtom = atom("Ada", { schema: v.string() })
+```
+
+When a schema offers both interfaces (like Zod), the `parse` path is used so
+the library's native error (e.g. a `ZodError`) is preserved on the thrown
+error's `cause`.
+
+## Validate-only semantics
+
+The schema runs purely as a check — **the original value is stored unchanged**.
+A store with validation on holds exactly the same values as one with it off, so
+enabling validation in development can never make behavior diverge from
+production.
+
+The flip side: transforming or coercing schemas (`z.coerce.number()`,
+`z.string().trim()`, `z.string().default(...)`) validate but do **not**
+transform. Avoid them here — the inferred type follows the schema's output
+while the stored value stays the input. Do coercion at your data boundary
+(form handler, fetch layer) and give the atom a plain validator instead.
+
+## What gets validated
+
+With validation enabled, values are checked at every write boundary:
+
+| Boundary | On failure |
+|----------|-----------|
+| `store.set(atom, value)` | throws `SchemaValidationError` |
+| Atom defaults (static, function, selector) | throws on first read |
+| Selector results | throws on evaluation |
+| `store.txn(...)` writes | throws inside the txn body — the whole transaction aborts, nothing is committed |
+| Async values (a promise resolving to an invalid value) | reported via `console.error`; the invalid value is **never committed** |
+
+Async failures can't throw to the original caller (the promise was already
+returned), which is why they're reported instead. For an async `set`, the atom
+reverts to its previous value; for an async default, the value is dropped so a
+later read retries.
+
+## Error handling
+
+Sync failures throw a `SchemaValidationError` (exported from `valdres`) that
+names the offending atom or selector and keeps the underlying error on `cause`:
+
+```ts
+import { SchemaValidationError } from "valdres"
+
+try {
+    s.set(userAtom, badValue)
+} catch (err) {
+    if (err instanceof SchemaValidationError) {
+        console.log(err.message) // Schema validation failed for 'userAtom': …
+        console.log(err.cause)   // the ZodError (or library-native error)
+    }
+}
+```
+
+Give your atoms a `name` — it's what makes these errors debuggable in an app
+with hundreds of atoms.
+
+## Limitations
+
+- **Promises set inside a transaction** are stored as-is and not auto-resolved
+  by the transaction, so they aren't validated on resolve. Validate before
+  setting, or set async values outside transactions.
+- **Async defaults under React Suspense:** an invalid async default drops its
+  value (like a rejected one), so a component that keeps re-reading will
+  re-initialize and re-fetch. Validate at the fetch boundary rather than
+  relying on async-default validation under Suspense.
+- **Asynchronous schemas** (an async Standard Schema, or a Zod schema with an
+  async `refine`) are not supported — validation runs synchronously and
+  surfaces a clear error. Use synchronous schemas.
+
+## When to use it
+
+Most internal state doesn't need runtime validation — TypeScript already covers
+a `countAtom`. Schemas earn their keep at **system boundaries**: API responses,
+form input, URL/storage-hydrated state, and atoms one team owns while another
+writes. A good default: type inference everywhere you like, runtime validation
+on boundary atoms via the per-atom override, and the store-wide flag on in
+development as a safety net.
+
+## See also
+
+- [Core Concepts](/guides/core-concepts) — atoms, selectors, and stores
+- [TypeScript](/guides/typescript) — more on type inference
+- The `atom`, `selector`, and `store` API pages document the `schema` and
+  `schemaValidation` options in detail

--- a/docs/content/nav.ts
+++ b/docs/content/nav.ts
@@ -24,6 +24,7 @@ const introduction: NavGroup = {
         { title: "Patterns & Recipes", route: "/guides/patterns" },
         { title: "Transactions", route: "/guides/transactions" },
         { title: "Scoped Stores", route: "/guides/scoped-stores" },
+        { title: "Schema Validation", route: "/guides/schema-validation" },
         { title: "TypeScript", route: "/guides/typescript" },
         { title: "Works Everywhere", route: "/guides/outside-react" },
         { title: "Performance", route: "/guides/performance" },

--- a/packages/valdres/package.json
+++ b/packages/valdres/package.json
@@ -21,6 +21,7 @@
     "scripts": {
         "build": "NODE_ENV=production bun run build.ts",
         "build:types": "rm -rf dist/types && bunx tsgo",
+        "typecheck:types": "bunx tsc -p tsconfig.types-test.json",
         "test": "bun test --reporter=dots --parallel",
         "test:bench": "rm -f test/performance/bench-results.ndjson && NODE_ENV=production bun test --timeout 60000 --concurrency 1 ./test/performance/*.bench.ts",
         "test:bench:node": "rm -f test/performance/bench-results-node.ndjson && NODE_ENV=production npx vitest run --config vitest.bench.config.ts"
@@ -29,11 +30,12 @@
         "@testing-library/react": "16.3.0",
         "jotai": "2.19.0",
         "mitata": "^1.0.34",
-        "vitest": "^3.1.1",
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "recoil": "0.7.7",
-        "typescript": "5.9.2"
+        "typescript": "5.9.2",
+        "vitest": "^3.1.1",
+        "zod": "^4.3.6"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/valdres/src/atom.mdx
+++ b/packages/valdres/src/atom.mdx
@@ -29,8 +29,8 @@ const userAtom = atom(() =>
     fetch("/api/user").then(res => res.json())
 )
 
-// With a label for debugging
-const nameAtom = atom("default", { label: "nameAtom" })
+// With a name for debugging and error messages
+const nameAtom = atom("default", { name: "nameAtom" })
 ```
 
 ## Parameters
@@ -38,7 +38,9 @@ const nameAtom = atom("default", { label: "nameAtom" })
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `defaultValue` | `T \| () => T \| Promise<T>` | Initial value, or a function that returns one |
-| `options.label` | `string` | Optional label for debugging and devtools |
+| `options.name` | `string` | Optional name for debugging, devtools, and validation error messages |
+| `options.schema` | `Schema<T>` | Schema for runtime validation and type inference. A no-op unless validation is enabled. See [Schema Validation](/guides/schema-validation). |
+| `options.schemaValidation` | `boolean` | Per-atom override of the store's `schemaValidation` flag — `true` always validates this atom, `false` exempts it |
 | `options.maxAge` | `Reactive<number>` | Re-fetch interval in milliseconds (requires async default). Accepts a number, atom, or selector. |
 | `options.staleWhileRevalidate` | `Reactive<number>` | Serve stale data for this many ms while re-fetching. Accepts a number, atom, or selector. |
 | `options.staleIfError` | `Reactive<number>` | Serve stale data for this many ms after re-fetch errors. Accepts a number, atom, or selector. |
@@ -229,8 +231,32 @@ Returns `null` for atoms that don't have `maxAge` configured.
 
 <div id="cache-demo" className="not-prose" />
 
+## Schema validation
+
+Pass a `schema` — any [Standard Schema](https://standard-schema.dev) (Zod,
+Valibot, ArkType, …) or `parse()`-style validator — to validate the atom's
+values at runtime and infer its type without a generic:
+
+```ts
+import { atom, store } from "valdres"
+import { z } from "zod"
+
+// Typed Atom<string> from the schema — no generic needed
+const nameAtom = atom(undefined, { name: "nameAtom", schema: z.string() })
+
+// Validation is opt-in per store (off by default)
+const s = store({ schemaValidation: true })
+s.set(nameAtom, 42) // throws SchemaValidationError naming 'nameAtom'
+```
+
+Validation is validate-only (the original value is stored unchanged) and can be
+overridden per atom via `schemaValidation: true | false`. See the
+[Schema Validation guide](/guides/schema-validation) for error handling, async
+behavior, and limitations.
+
 ## See also
 
 - [atomFamily](/valdres/atomFamily) — create a collection of atoms keyed by a parameter
 - [selector](/valdres/selector) — derive computed state from atoms
+- [Schema Validation](/guides/schema-validation) — runtime validation and type inference
 - [useAtom](/react/useAtom) — read and write an atom in your components

--- a/packages/valdres/src/errors/SchemaValidationError.ts
+++ b/packages/valdres/src/errors/SchemaValidationError.ts
@@ -1,0 +1,31 @@
+import type { Atom } from "../types/Atom"
+import type { Selector } from "../types/Selector"
+
+/**
+ * Thrown when a value fails its atom/selector `schema` while schema validation
+ * is enabled. The underlying validation error (e.g. a Zod `ZodError`) is kept on
+ * `cause`, and the offending atom/selector is named in the message so a failure
+ * is debuggable in an app with hundreds of atoms — rather than surfacing a raw
+ * `ZodError` from deep inside `setAtom`/`initSelector` with no context.
+ */
+export class SchemaValidationError extends Error {
+    state: Atom<any> | Selector<any>
+
+    constructor(cause: unknown, state: Atom<any> | Selector<any>) {
+        super()
+        // Set name so logs, error reporters (Sentry, etc.), and `String(err)`
+        // show "SchemaValidationError: …" instead of the default "Error: …".
+        this.name = "SchemaValidationError"
+        this.cause = cause
+        this.state = state
+    }
+
+    public get message(): string {
+        const name = this.state?.name ?? "anonymous atom/selector"
+        const detail =
+            this.cause instanceof Error
+                ? this.cause.message
+                : String(this.cause)
+        return `Schema validation failed for '${name}': ${detail}`
+    }
+}

--- a/packages/valdres/src/index.ts
+++ b/packages/valdres/src/index.ts
@@ -22,6 +22,7 @@ export { selector } from "./selector"
 export { selectorFamily } from "./selectorFamily"
 export { store } from "./store"
 
+export { SchemaValidationError } from "./errors/SchemaValidationError"
 export { deepFreeze } from "./utils/deepFreeze"
 export { isAtom } from "./utils/isAtom"
 export { isAtomFamily } from "./utils/isAtomFamily"
@@ -53,6 +54,8 @@ export type { SnapshotEntry } from "./types/SnapshotEntry"
 export type { SetAtomValue } from "./types/SetAtomValue"
 export type { SyncSetAtom } from "./types/SyncSetAtom"
 export type { State } from "./types/State"
+export type { Schema } from "./types/Schema"
+export type { StandardSchemaV1 } from "./types/StandardSchemaV1"
 export type { Store } from "./types/Store"
 export type {
     AtomChange,

--- a/packages/valdres/src/lib/createAtomFamily.ts
+++ b/packages/valdres/src/lib/createAtomFamily.ts
@@ -107,5 +107,10 @@ export const createAtomFamily = <
             map.delete(familyKey(args))
         },
         equal,
+        // Exposed on the family object too (members carry them via ...options)
+        // so a consumer (devtools, sync) can read a family's schema without
+        // materializing a member.
+        schema: options?.schema,
+        schemaValidation: options?.schemaValidation,
     }) as AtomFamily<Value, Args>
 }

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -39,6 +39,10 @@ export type CreateStoreDataOptions = {
      *  can list the store's current state. Off by default; see `Store.snapshot`.
      *  Scopes inherit it from their parent. */
     enumerable?: boolean
+    /** Validate atom/selector values against their `schema` (if any) on init,
+     *  set, and selector evaluation. Off by default — opt in per store for
+     *  development-time safety. Scopes inherit it from their parent. */
+    schemaValidation?: boolean
 }
 
 export function createStoreData(
@@ -63,6 +67,11 @@ export function createStoreData(
     if (options?.batchUpdates) {
         data.batchUpdates = true
     }
+    // Opt-in, inherited down the scope chain like `enumerable` — chosen once
+    // here, never re-checked on get/set.
+    const schemaValidation =
+        options?.schemaValidation ?? parent?.schemaValidation ?? false
+    if (schemaValidation) data.schemaValidation = true
     if (parent) {
         data.parent = parent
         data.scopeConsumers = new Set()

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -16,6 +16,8 @@ import { initSelector } from "./initSelector"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { resolveAtomDefaultValue } from "./resolveAtomDefaultValue"
 import { setValueInData } from "./setValueInData"
+import { validateResolvedValue } from "./validateResolvedValue"
+import { validateSchema } from "./validateSchema"
 import {
     createAtomFamilyIndex,
     renderAtomFamilyIndex,
@@ -86,6 +88,10 @@ export function getState<
                         data,
                         initializedAtomsSet,
                     )
+                    // Validate the deleted-member default like any other
+                    // boundary: sync values throw here; the async value is
+                    // validated on resolve below.
+                    if (!isPromiseLike(value)) validateSchema(state, value, data)
                     const cached = setValueInData(state, value, data)
                     // Async default: mirror getAtomInitValue and swap the cached
                     // promise for its resolved value once it settles, so later
@@ -99,6 +105,14 @@ export function getState<
                         cached.then(
                             resolvedValue => {
                                 if (data.values.get(state) !== cached) return
+                                if (!validateResolvedValue(state, resolvedValue, data)) {
+                                    // Invalid: failure reported; drop so a later
+                                    // read re-inits rather than committing it.
+                                    if (data.values.get(state) === cached) {
+                                        data.values.delete(state)
+                                    }
+                                    return
+                                }
                                 setValueInData(state, resolvedValue, data)
                                 propagateAtomUpdate(
                                     [state],

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -7,6 +7,8 @@ import { getState } from "./getState"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { setValueInData } from "./setValueInData"
+import { validateResolvedValue } from "./validateResolvedValue"
+import { validateSchema } from "./validateSchema"
 
 export const getAtomInitValue = <V = any>(
     atom: Atom<V>,
@@ -31,6 +33,16 @@ export const getAtomInitValue = <V = any>(
                     // replaced our promise as the cached value, swallow
                     // this resolution. Mirrors setAtom.handlePromise.
                     if (data.values.get(atom) !== value) return
+                    if (!validateResolvedValue(atom, resolvedValue, data)) {
+                        // Invalid: failure already reported; drop the stored
+                        // promise so a re-subscribe re-inits, rather than
+                        // committing the invalid value or leaving the atom
+                        // stuck on an unvalidated promise.
+                        if (data.values.get(atom) === value) {
+                            data.values.delete(atom)
+                        }
+                        return
+                    }
                     // @ts-ignore @ts-todo
                     setValueInData(atom, resolvedValue, data)
                     propagateAtomUpdate([atom], data, false, undefined, "async-set")
@@ -44,12 +56,37 @@ export const getAtomInitValue = <V = any>(
                     }
                 },
             )
+            return value
         }
-        return value
+        return validateSchema(atom, value, data)
     } else if (isSelector(atom.defaultValue)) {
-        return getState(atom.defaultValue, data, initializedAtomsSet)
+        const value = getState(atom.defaultValue, data, initializedAtomsSet)
+        if (isPromiseLike(value)) {
+            // The atom's value IS the source selector's promise (consumers await
+            // it). The source selector validates against its OWN schema, if any;
+            // here we additionally validate the resolved value against THIS
+            // atom's schema and report on failure — so an async selector default
+            // is covered like every other boundary. Unlike the function-default
+            // branch above we neither re-land the value (it's the shared
+            // promise, not a freshly-set atom value) nor drop the atom's cache
+            // on failure (re-init would just re-read the selector's cached
+            // result, so dropping buys nothing — awaiters of the shared promise
+            // see the raw resolved value either way; the report is the signal).
+            // Gated on schema presence so schema-less atoms pay no handler
+            // allocation (validateResolvedValue re-checks the full gate).
+            if (atom.schema) {
+                value.then(
+                    resolved => validateResolvedValue(atom, resolved, data),
+                    () => {}, // genuine rejection is handled by the selector's path
+                )
+            }
+            return value
+        }
+        return validateSchema(atom, value, data)
     } else {
-        return atom.defaultValue
+        // Narrowed: not undefined, not a function, not a selector — so the
+        // default is a plain value of type V.
+        return validateSchema(atom, atom.defaultValue as V, data)
     }
 }
 

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -1,3 +1,4 @@
+import { SchemaValidationError } from "../errors/SchemaValidationError"
 import { SelectorCircularDependencyError } from "../errors/SelectorCircularDependencyError"
 import { SelectorEvaluationError } from "../errors/SelectorEvaluationError"
 import type { Atom } from "../types/Atom"
@@ -23,7 +24,10 @@ import {
     propagateAtomUpdate,
     propagateDirtySelectors,
 } from "./propagateUpdatedAtoms"
+import { reportAsyncSchemaError } from "./reportAsyncSchemaError"
 import { setValueInData } from "./setValueInData"
+import { validateResolvedValue } from "./validateResolvedValue"
+import { validateSchema } from "./validateSchema"
 
 export { isSuspendError } from "./asyncDependencyTracking"
 
@@ -276,8 +280,12 @@ export const handleSelectorResult = <Value>(
                 propagateAtomUpdate([...initializedAtomsSet], data, false, undefined, "async-set")
             }
             return res
-        }).catch(() => {
+        }).catch(err => {
             cleanUpRejectedPromise(selector, data, promise)
+            // Report schema validation failures (thrown from the sync
+            // re-evaluation inside initSelector) instead of swallowing them,
+            // consistent with the native-promise path below.
+            if (err instanceof SchemaValidationError) reportAsyncSchemaError(err)
         })
         return promise
     } else if (isPromiseLike(value)) {
@@ -317,6 +325,14 @@ export const handleSelectorResult = <Value>(
                 }
             }
 
+            // Async validation can't throw to a caller; on failure it's
+            // reported and we clean up so the invalid value never commits.
+            // Consistent with the atom async paths.
+            if (!validateResolvedValue(selector, resolved, data)) {
+                pendingAsyncDeps.delete(value as Promise<any>)
+                cleanUpRejectedPromise(selector, data, value as Promise<any>)
+                return
+            }
             // @ts-ignore
             setValueInData(selector, resolved, data)
             const dependents = data.stateDependents.get(selector)
@@ -365,7 +381,7 @@ export const handleSelectorResult = <Value>(
         if ((selector.get as (...args: any[]) => any).length >= 2) {
             data.abortControllers.set(selector, false)
         }
-        return value
+        return validateSchema(selector, value, data)
     }
 }
 

--- a/packages/valdres/src/lib/reportAsyncSchemaError.ts
+++ b/packages/valdres/src/lib/reportAsyncSchemaError.ts
@@ -1,0 +1,18 @@
+/**
+ * Report a schema validation failure that occurred on an async path (a promise
+ * resolving to an invalid value).
+ *
+ * Sync validation throws straight out of `store.set`/`store.get`, so the caller
+ * sees it. An async failure can't be thrown to that caller — the promise was
+ * already handed back — and turning it into an unhandled rejection is hostile
+ * (it crashes strict Node processes and Bun's test runner). So it's surfaced
+ * here as a `console.error` instead (a notch louder than valdres's other
+ * dev-time `console.warn` diagnostics, since invalid state is an error, not a
+ * caveat). The caller does not commit the invalid value.
+ *
+ * Centralized so that a future programmatic hook (e.g. an `onSchemaError` store
+ * option) is a single-file change rather than touching every async boundary.
+ */
+export const reportAsyncSchemaError = (error: unknown) => {
+    console.error(error)
+}

--- a/packages/valdres/src/lib/schemaValidation.test.ts
+++ b/packages/valdres/src/lib/schemaValidation.test.ts
@@ -1,0 +1,693 @@
+import { describe, test, expect, spyOn } from "bun:test"
+import { z } from "zod"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
+import { selectorFamily } from "../selectorFamily"
+import { store } from "../store"
+import { wait } from "../../test/utils/wait"
+import { SchemaValidationError } from "../errors/SchemaValidationError"
+import type { StandardSchemaV1 } from "../types/StandardSchemaV1"
+
+// A minimal Standard Schema (https://standard-schema.dev) with NO `parse`
+// method — stands in for Valibot/ArkType to exercise the `~standard` path.
+const standardString: StandardSchemaV1<string> = {
+    "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: value =>
+            typeof value === "string"
+                ? { value }
+                : { issues: [{ message: "expected string" }] },
+        types: undefined,
+    },
+}
+
+/**
+ * Run `fn`, then collect everything reported to `console.error` while its async
+ * work settles. Async validation failures can't be thrown to the caller, so
+ * they're reported via console.error (matching valdres's other dev-time
+ * diagnostics); this lets a test assert that a SchemaValidationError surfaced.
+ */
+const captureConsoleErrors = async (fn: () => void): Promise<unknown[]> => {
+    const spy = spyOn(console, "error").mockImplementation(() => {})
+    try {
+        fn()
+        await wait(20)
+        return spy.mock.calls.map(call => call[0])
+    } finally {
+        spy.mockRestore()
+    }
+}
+
+// Schema validation is opt-in per store: pass `{ schemaValidation: true }` to
+// enable it. Most tests below create such a store; the "schemaValidation store
+// option" block covers the default-off behavior and inheritance.
+describe("schema validation", () => {
+    describe("atom", () => {
+        test("valid default value passes", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("invalid default value throws", () => {
+            const store1 = store({ schemaValidation: true })
+            // @ts-expect-error - intentionally passing wrong type
+            const nameAtom = atom(123, { schema: z.string() })
+            expect(() => store1.get(nameAtom)).toThrow()
+        })
+
+        test("valid set passes", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            store1.set(nameAtom, "world")
+            expect(store1.get(nameAtom)).toBe("world")
+        })
+
+        test("invalid set throws", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(nameAtom, 123)).toThrow()
+        })
+
+        test("valid set with updater function passes", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            store1.set(nameAtom, prev => prev + " world")
+            expect(store1.get(nameAtom)).toBe("hello world")
+        })
+
+        test("invalid set with updater function throws", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally returning wrong type
+            expect(() => store1.set(nameAtom, () => 123)).toThrow()
+        })
+
+        test("complex schema validation", () => {
+            const store1 = store({ schemaValidation: true })
+            const userSchema = z.object({
+                name: z.string(),
+                age: z.number().min(0),
+            })
+            const userAtom = atom(
+                { name: "Alice", age: 30 },
+                { schema: userSchema },
+            )
+            expect(store1.get(userAtom)).toEqual({ name: "Alice", age: 30 })
+
+            store1.set(userAtom, { name: "Bob", age: 25 })
+            expect(store1.get(userAtom)).toEqual({ name: "Bob", age: 25 })
+
+            expect(() =>
+                // @ts-expect-error - intentionally passing wrong type
+                store1.set(userAtom, { name: "Charlie" }),
+            ).toThrow()
+        })
+
+        test("async default value is validated on resolve", async () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom(() => Promise.resolve("hello"), {
+                schema: z.string(),
+            })
+            // Triggers init, value starts as a promise
+            store1.get(nameAtom)
+            await wait(10)
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("function default value is validated", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom(() => "hello", { schema: z.string() })
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("invalid function default value throws", () => {
+            const store1 = store({ schemaValidation: true })
+            // @ts-expect-error - intentionally returning wrong type
+            const nameAtom = atom(() => 123, { schema: z.string() })
+            expect(() => store1.get(nameAtom)).toThrow()
+        })
+
+        test("selector default value is validated against atom schema", () => {
+            const store1 = store({ schemaValidation: true })
+            const source = selector(get => "hello")
+            const nameAtom = atom(source, { schema: z.string() })
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("invalid selector default value throws against atom schema", () => {
+            const store1 = store({ schemaValidation: true })
+            const source = selector(get => 123)
+            // @ts-expect-error - selector returns number but atom schema expects string
+            const nameAtom = atom(source, { schema: z.string() })
+            expect(() => store1.get(nameAtom)).toThrow()
+        })
+    })
+
+    describe("selector", () => {
+        test("valid selector value passes", () => {
+            const store1 = store({ schemaValidation: true })
+            const numAtom = atom(5)
+            const doubleSelector = selector(get => get(numAtom) * 2, {
+                schema: z.number(),
+            })
+            expect(store1.get(doubleSelector)).toBe(10)
+        })
+
+        test("invalid selector value throws", () => {
+            const store1 = store({ schemaValidation: true })
+            const numAtom = atom(5)
+            const badSelector = selector(
+                // @ts-expect-error - intentionally returning wrong type
+                get => String(get(numAtom)),
+                { schema: z.number() },
+            )
+            expect(() => store1.get(badSelector)).toThrow()
+        })
+
+        test("schema validates on re-evaluation", () => {
+            const store1 = store({ schemaValidation: true })
+            const numAtom = atom<number | string>(5)
+            const doubleSelector = selector(
+                get => {
+                    const val = get(numAtom)
+                    if (typeof val === "number") return val * 2
+                    return val // returns string — should fail validation
+                },
+                { schema: z.number() },
+            )
+            expect(store1.get(doubleSelector)).toBe(10)
+
+            // This should cause the selector to return a string, failing validation
+            expect(() => {
+                store1.set(numAtom, "not a number")
+                store1.get(doubleSelector)
+            }).toThrow()
+        })
+    })
+
+    describe("atomFamily", () => {
+        test("schema is accessible on the family object and its members", () => {
+            const schema = z.string()
+            const fam = atomFamily<string, [string]>("default", {
+                schema,
+                schemaValidation: true,
+            })
+            // Family object itself exposes the schema (e.g. so a sync engine
+            // can validate an incoming (family, key, value) payload without
+            // materializing the member first).
+            expect(fam.schema).toBe(schema)
+            expect(fam.schemaValidation).toBe(true)
+            // Members share the same reference
+            expect(fam("k").schema).toBe(schema)
+        })
+
+        test("schema is applied to family members", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameFamily = atomFamily<string, [string]>("default", {
+                schema: z.string(),
+            })
+            const nameAtom = nameFamily("key1")
+            expect(store1.get(nameAtom)).toBe("default")
+
+            store1.set(nameAtom, "updated")
+            expect(store1.get(nameAtom)).toBe("updated")
+
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(nameAtom, 123)).toThrow()
+        })
+    })
+
+    describe("selectorFamily", () => {
+        test("schema is accessible on the family object", () => {
+            const schema = z.number()
+            const fam = selectorFamily<number, [number]>(
+                () => () => 1,
+                { schema, schemaValidation: true },
+            )
+            expect(fam.schema).toBe(schema)
+            expect(fam.schemaValidation).toBe(true)
+            expect(fam(1).schema).toBe(schema)
+        })
+
+        test("schema is applied to family members", () => {
+            const store1 = store({ schemaValidation: true })
+            const numAtom = atom(5)
+            const multiplyFamily = selectorFamily<number, [number]>(
+                (factor: number) => get => get(numAtom) * factor,
+                { schema: z.number() },
+            )
+            expect(store1.get(multiplyFamily(2))).toBe(10)
+            expect(store1.get(multiplyFamily(3))).toBe(15)
+        })
+    })
+
+    describe("atom without schema", () => {
+        test("no validation when schema is not provided", () => {
+            const store1 = store({ schemaValidation: true })
+            const anyAtom = atom<any>("hello")
+            store1.set(anyAtom, 123)
+            store1.set(anyAtom, { foo: "bar" })
+            expect(store1.get(anyAtom)).toEqual({ foo: "bar" })
+        })
+    })
+
+    describe("schemaValidation store option", () => {
+        test("validation is skipped by default (opt-in)", () => {
+            const store1 = store()
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            store1.set(nameAtom, 123)
+            expect(store1.get(nameAtom)).toBe(123)
+        })
+
+        test("validation is skipped when schemaValidation is false", () => {
+            const store1 = store({ schemaValidation: false })
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            store1.set(nameAtom, 123)
+            expect(store1.get(nameAtom)).toBe(123)
+        })
+
+        test("validation runs when schemaValidation is true", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(nameAtom, 123)).toThrow()
+        })
+
+        test("selector validation is skipped by default", () => {
+            const store1 = store()
+            const numAtom = atom(5)
+            const badSelector = selector(
+                // @ts-expect-error - intentionally returning wrong type
+                get => String(get(numAtom)),
+                { schema: z.number() },
+            )
+            expect(store1.get(badSelector)).toBe("5")
+        })
+
+        test("scoped store inherits schemaValidation: true from parent", () => {
+            const parent = store({ schemaValidation: true })
+            const child = parent.scope("child")
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => child.set(nameAtom, 123)).toThrow()
+        })
+
+        test("scoped store stays off by default", () => {
+            const parent = store()
+            const child = parent.scope("child")
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            child.set(nameAtom, 123)
+            expect(child.get(nameAtom)).toBe(123)
+        })
+    })
+
+    // #4 — failures throw a SchemaValidationError that names the offending
+    // atom/selector and carries the underlying error on `cause`.
+    describe("error context", () => {
+        test("throws SchemaValidationError naming the atom", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", {
+                name: "userName",
+                schema: z.string(),
+            })
+            try {
+                // @ts-expect-error - intentionally passing wrong type
+                store1.set(nameAtom, 123)
+                throw new Error("expected throw")
+            } catch (err) {
+                expect(err).toBeInstanceOf(SchemaValidationError)
+                expect((err as Error).message).toContain("userName")
+                expect((err as SchemaValidationError).cause).toBeDefined()
+            }
+        })
+
+        test("names the selector", () => {
+            const store1 = store({ schemaValidation: true })
+            const numAtom = atom(5)
+            const badSelector = selector(
+                // @ts-expect-error - intentionally returning wrong type
+                get => String(get(numAtom)),
+                { name: "stringified", schema: z.number() },
+            )
+            try {
+                store1.get(badSelector)
+                throw new Error("expected throw")
+            } catch (err) {
+                expect(err).toBeInstanceOf(SchemaValidationError)
+                expect((err as Error).message).toContain("stringified")
+            }
+        })
+
+        test("falls back gracefully when unnamed", () => {
+            const store1 = store({ schemaValidation: true })
+            // @ts-expect-error - intentionally wrong default
+            const a = atom(5, { schema: z.string() })
+            try {
+                store1.get(a)
+                throw new Error("expected throw")
+            } catch (err) {
+                expect(err).toBeInstanceOf(SchemaValidationError)
+                expect((err as Error).message).toContain("anonymous")
+            }
+        })
+    })
+
+    // #3 — validate-only: schema.parse runs for its throwing side effect, but
+    // the ORIGINAL value is stored. A transforming schema must not change the
+    // stored value, so a store with validation on stores the same value as one
+    // with it off (no dev/prod divergence).
+    describe("validate-only (no transform)", () => {
+        test("transform does not mutate the stored set value", () => {
+            const store1 = store({ schemaValidation: true })
+            const trimmed = atom("init", {
+                schema: z.string().transform(s => s.trim()),
+            })
+            store1.set(trimmed, "  hello  ")
+            expect(store1.get(trimmed)).toBe("  hello  ")
+        })
+
+        test("transform does not mutate the stored default value", () => {
+            const store1 = store({ schemaValidation: true })
+            const trimmed = atom("  hi  ", {
+                schema: z.string().transform(s => s.trim()),
+            })
+            expect(store1.get(trimmed)).toBe("  hi  ")
+        })
+
+        test("stored value is identical whether validation is on or off", () => {
+            const schema = z.string().transform(s => s.toUpperCase())
+            const on = store({ schemaValidation: true })
+            const off = store({ schemaValidation: false })
+            const a = atom("init", { schema })
+            on.set(a, "abc")
+            off.set(a, "abc")
+            expect(on.get(a)).toBe(off.get(a))
+            expect(on.get(a)).toBe("abc")
+        })
+
+        test("invalid value still throws even though transform is ignored", () => {
+            const store1 = store({ schemaValidation: true })
+            const a = atom("init", {
+                schema: z.string().transform(s => s.trim()),
+            })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(a, 123)).toThrow(SchemaValidationError)
+        })
+    })
+
+    // #1 — transactions validate at set()-time, so an invalid value throws
+    // inside the txn body and the whole transaction is aborted (atomic).
+    describe("transactions", () => {
+        test("invalid txn set throws and aborts the whole transaction", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            const otherAtom = atom("a", { schema: z.string() })
+            expect(() =>
+                store1.txn(txn => {
+                    txn.set(otherAtom, "b") // valid, staged first
+                    // @ts-expect-error - intentionally passing wrong type
+                    txn.set(nameAtom, 123) // invalid → throws here
+                }),
+            ).toThrow(SchemaValidationError)
+            // Atomic: neither write committed
+            expect(store1.get(nameAtom)).toBe("hello")
+            expect(store1.get(otherAtom)).toBe("a")
+        })
+
+        test("valid txn set commits", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            store1.txn(txn => {
+                txn.set(nameAtom, "world")
+            })
+            expect(store1.get(nameAtom)).toBe("world")
+        })
+
+        test("txn updater function is validated", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            expect(() =>
+                store1.txn(txn => {
+                    // @ts-expect-error - intentionally returning wrong type
+                    txn.set(nameAtom, () => 123)
+                }),
+            ).toThrow(SchemaValidationError)
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("batched store set is validated (routes through a txn)", () => {
+            const store1 = store({ batchUpdates: true, schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(nameAtom, 123)).toThrow(SchemaValidationError)
+        })
+    })
+
+    // #2 — async validation failures never commit the invalid value and are
+    // reported via console.error (consistent across set/default/selector),
+    // rather than being silently swallowed or thrown as unhandled rejections.
+    describe("async surfacing", () => {
+        test("async atom set: invalid resolved value is reported and not committed", async () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            store1.get(nameAtom)
+            const errors = await captureConsoleErrors(() => {
+                // resolves to a number, which violates z.string()
+                store1.set(nameAtom, Promise.resolve(123 as any))
+            })
+            expect(errors.some(e => e instanceof SchemaValidationError)).toBe(
+                true,
+            )
+            // invalid value not committed — reverted to prior valid value
+            expect(store1.get(nameAtom)).toBe("hello")
+        })
+
+        test("async atom default: invalid resolved value is reported", async () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom(() => Promise.resolve(123 as any), {
+                schema: z.string(),
+            })
+            const errors = await captureConsoleErrors(() => {
+                store1.get(nameAtom)
+            })
+            expect(errors.some(e => e instanceof SchemaValidationError)).toBe(
+                true,
+            )
+            // The invalid value is dropped (not committed); a re-read would
+            // re-init and re-fail, which is the intended retry semantics, so we
+            // don't re-get here.
+        })
+
+        test("async selector: invalid resolved value is reported", async () => {
+            const store1 = store({ schemaValidation: true })
+            const src = atom(1)
+            const badSelector = selector(
+                get => Promise.resolve(String(get(src)) as any),
+                { schema: z.number() },
+            )
+            const errors = await captureConsoleErrors(() => {
+                store1.sub(badSelector, () => {})
+                store1.get(badSelector)
+            })
+            expect(errors.some(e => e instanceof SchemaValidationError)).toBe(
+                true,
+            )
+        })
+
+        test("genuine async rejection is NOT reported as a schema error", async () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", { schema: z.string() })
+            store1.get(nameAtom)
+            const errors = await captureConsoleErrors(() => {
+                store1.set(
+                    nameAtom,
+                    Promise.reject(new Error("network")) as any,
+                )
+            })
+            expect(errors.some(e => e instanceof SchemaValidationError)).toBe(
+                false,
+            )
+        })
+    })
+
+    // #5 — per-atom override: an atom/selector can opt into (or out of)
+    // validation independently of the store flag.
+    describe("per-state schemaValidation override", () => {
+        test("atom override validates even when the store flag is off", () => {
+            const store1 = store() // off by default
+            const nameAtom = atom("hello", {
+                schema: z.string(),
+                schemaValidation: true,
+            })
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(nameAtom, 123)).toThrow(SchemaValidationError)
+        })
+
+        test("atom override disables validation even when the store flag is on", () => {
+            const store1 = store({ schemaValidation: true })
+            const nameAtom = atom("hello", {
+                schema: z.string(),
+                schemaValidation: false,
+            })
+            // @ts-expect-error - intentionally passing wrong type
+            store1.set(nameAtom, 123)
+            expect(store1.get(nameAtom)).toBe(123)
+        })
+
+        test("selector override validates even when the store flag is off", () => {
+            const store1 = store()
+            const numAtom = atom(5)
+            const badSelector = selector(
+                // @ts-expect-error - intentionally returning wrong type
+                get => String(get(numAtom)),
+                { schema: z.number(), schemaValidation: true },
+            )
+            expect(() => store1.get(badSelector)).toThrow(SchemaValidationError)
+        })
+
+        test("family member inherits per-atom override (store off)", () => {
+            const store1 = store() // off by default
+            const nameFamily = atomFamily<string, [string]>("default", {
+                schema: z.string(),
+                schemaValidation: true,
+            })
+            const member = nameFamily("k")
+            // @ts-expect-error - intentionally passing wrong type
+            expect(() => store1.set(member, 123)).toThrow(SchemaValidationError)
+        })
+    })
+
+    // Tripwire: every value-entry boundary must run validation. If a new write
+    // path is added without routing through validateSchema/validateResolvedValue,
+    // one of these should fail. (Sync set/default/selector + txn + batched are
+    // covered above; these cover the boundaries the review found unguarded.)
+    describe("boundary coverage", () => {
+        test("M1: async selector default is validated against the atom schema", async () => {
+            const store1 = store({ schemaValidation: true })
+            const src = selector(() => Promise.resolve(123 as any))
+            const fromSelector = atom<string>(src as any, {
+                name: "fromSelector",
+                schema: z.string(),
+            })
+            const errors = await captureConsoleErrors(() => {
+                store1.get(fromSelector)
+            })
+            expect(errors.some(e => e instanceof SchemaValidationError)).toBe(
+                true,
+            )
+        })
+
+        test("S3: deleted family-member read is validated", () => {
+            // Invalid default; the member is deleted before any read, so the
+            // read goes through the deleted-member branch in getState.
+            const fam = atomFamily<string, [number]>(() => 123 as any, {
+                schema: z.string(),
+                schemaValidation: true,
+            })
+            const store1 = store()
+            store1.del(fam(1))
+            expect(() => store1.get(fam(1))).toThrow(SchemaValidationError)
+        })
+
+        test("validation runs BEFORE the equality check — an equal-but-invalid set still throws", () => {
+            // Pins a deliberate ordering decision in setAtom: validate-first
+            // gives a deterministic "set(invalid) always throws" contract.
+            // With an always-equal atom, equality-first would silently no-op
+            // the invalid set; validate-first must throw.
+            const store1 = store({ schemaValidation: true })
+            const alwaysEqual = atom<any>("hello", {
+                schema: z.string(),
+                equal: () => true,
+            })
+            expect(store1.get(alwaysEqual)).toBe("hello")
+            expect(() => store1.set(alwaysEqual, 123)).toThrow(
+                SchemaValidationError,
+            )
+        })
+
+        test("M5: error has name 'SchemaValidationError'", () => {
+            const store1 = store({ schemaValidation: true })
+            const a = atom("x", { name: "n", schema: z.string() })
+            try {
+                // @ts-expect-error - intentionally passing wrong type
+                store1.set(a, 123)
+                throw new Error("expected throw")
+            } catch (err) {
+                expect((err as Error).name).toBe("SchemaValidationError")
+                expect(String(err)).toContain("SchemaValidationError")
+            }
+        })
+    })
+
+    // S6 — any Standard Schema works, not just Zod's classic `{ parse }`.
+    describe("Standard Schema support", () => {
+        test("validates via a parse-less Standard Schema (Valibot-style)", () => {
+            const store1 = store({ schemaValidation: true })
+            const a = atom("hello", { name: "std", schema: standardString })
+            store1.set(a, "world")
+            expect(store1.get(a)).toBe("world")
+            // @ts-expect-error - wrong type
+            expect(() => store1.set(a, 123)).toThrow(SchemaValidationError)
+        })
+
+        test("Standard Schema failure message includes the issue", () => {
+            const store1 = store({ schemaValidation: true })
+            const a = atom("hello", { name: "std", schema: standardString })
+            try {
+                // @ts-expect-error - wrong type
+                store1.set(a, 123)
+                throw new Error("expected throw")
+            } catch (err) {
+                expect((err as Error).message).toContain("expected string")
+                expect((err as Error).message).toContain("std")
+            }
+        })
+
+        test("rejects an asynchronous Standard Schema with a clear error", () => {
+            const store1 = store({ schemaValidation: true })
+            const asyncSchema: StandardSchemaV1<string> = {
+                "~standard": {
+                    version: 1,
+                    vendor: "test",
+                    validate: async value => ({ value: value as string }),
+                    types: undefined,
+                },
+            }
+            const a = atom("hello", { schema: asyncSchema })
+            expect(() => store1.set(a, "world")).toThrow(
+                /Asynchronous schema validation is not supported/,
+            )
+        })
+
+        test("Zod async refinement surfaces (does not silently pass)", () => {
+            const store1 = store({ schemaValidation: true })
+            // An async refine forces Zod's sync parse() to throw — we surface it
+            // rather than letting a valid-looking value through unchecked.
+            const a = atom("hello", {
+                schema: z.string().refine(async () => true),
+            })
+            expect(() => store1.set(a, "world")).toThrow(SchemaValidationError)
+        })
+
+        test("Zod still reports a ZodError on `cause` (parse path preferred)", () => {
+            const store1 = store({ schemaValidation: true })
+            const a = atom("hello", { name: "z", schema: z.string() })
+            try {
+                // @ts-expect-error - wrong type
+                store1.set(a, 123)
+                throw new Error("expected throw")
+            } catch (err) {
+                const cause = (err as SchemaValidationError).cause as any
+                // Zod's error carries structured `issues`; a generic Error wouldn't.
+                expect(cause?.issues ?? cause?.name).toBeDefined()
+            }
+        })
+    })
+})

--- a/packages/valdres/src/lib/schemaValidation.types.test.ts
+++ b/packages/valdres/src/lib/schemaValidation.types.test.ts
@@ -1,0 +1,102 @@
+import { test } from "bun:test"
+import { z } from "zod"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
+import { selectorFamily } from "../selectorFamily"
+import type { Atom } from "../types/Atom"
+import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+import type { Selector } from "../types/Selector"
+import type { StandardSchemaV1 } from "../types/StandardSchemaV1"
+
+// Type test utilities — a failing assertion produces a TS error at compile time
+type Expect<T extends true> = T
+type Equal<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+        ? true
+        : false
+
+test("atom infers type from schema", () => {
+    const stringAtom = atom(undefined, { schema: z.string() })
+    type _1 = Expect<Equal<typeof stringAtom, Atom<string>>>
+
+    const numberAtom = atom(42, { schema: z.number() })
+    type _2 = Expect<Equal<typeof numberAtom, Atom<number>>>
+
+    // Schema prevents setting wrong type
+    // @ts-expect-error - number is not assignable to string schema
+    atom("hello", { schema: z.number() })
+})
+
+test("atom infers complex type from schema", () => {
+    const userSchema = z.object({ name: z.string(), age: z.number() })
+    const userAtom = atom({ name: "Alice", age: 30 }, { schema: userSchema })
+    type _1 = Expect<Equal<typeof userAtom, Atom<{ name: string; age: number }>>>
+})
+
+test("selector infers type from schema", () => {
+    const numAtom = atom(5)
+    const derived = selector(get => get(numAtom) * 2, {
+        schema: z.number(),
+    })
+    type _1 = Expect<Equal<typeof derived, Selector<number>>>
+})
+
+test("atom without schema still infers from default value", () => {
+    const plainAtom = atom("hello")
+    type _1 = Expect<Equal<typeof plainAtom, Atom<string>>>
+})
+
+test("selector without schema still infers from get function", () => {
+    const plainAtom = atom("hello")
+    const plainSelector = selector(get => get(plainAtom).toUpperCase())
+    type _1 = Expect<Equal<typeof plainSelector, Selector<string>>>
+})
+
+test("atomFamily with schema", () => {
+    const family = atomFamily<string, [string]>("default", {
+        schema: z.string(),
+    })
+    const familyAtom = family("key")
+    type _1 = Expect<Equal<typeof familyAtom, AtomFamilyAtom<string, [string]>>>
+})
+
+test("selectorFamily with schema", () => {
+    const numAtom = atom(5)
+    const selFamily = selectorFamily<number, [number]>(
+        (factor: number) => get => get(numAtom) * factor,
+        { schema: z.number() },
+    )
+    const selFamilyMember = selFamily(2)
+    type _1 = Expect<Equal<typeof selFamilyMember, Selector<number, [number]>>>
+})
+
+test("schemaValidation option is accepted and preserves inference", () => {
+    // The per-atom/selector override is an accepted option and does not disturb
+    // the type inferred from the schema/default.
+    const a = atom("hello", { schema: z.string(), schemaValidation: true })
+    type _1 = Expect<Equal<typeof a, Atom<string>>>
+
+    const numAtom = atom(5)
+    const s = selector(get => get(numAtom) * 2, {
+        schema: z.number(),
+        schemaValidation: false,
+    })
+    type _2 = Expect<Equal<typeof s, Selector<number>>>
+})
+
+test("infers from a Standard Schema (Valibot/ArkType-style, no parse)", () => {
+    const standardNumber: StandardSchemaV1<number> = {
+        "~standard": {
+            version: 1,
+            vendor: "test",
+            validate: value =>
+                typeof value === "number"
+                    ? { value }
+                    : { issues: [{ message: "expected number" }] },
+            types: undefined,
+        },
+    }
+    const a = atom(undefined, { schema: standardNumber })
+    type _1 = Expect<Equal<typeof a, Atom<number>>>
+})

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -7,6 +7,8 @@ import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
+import { validateResolvedValue } from "./validateResolvedValue"
+import { validateSchema } from "./validateSchema"
 
 const handlePromise = <Value>(
     atom: Atom<Value>,
@@ -20,6 +22,16 @@ const handlePromise = <Value>(
         .then(resolvedValue => {
             // Stale promise guard: if another set() overwrote us, bail
             if (data.values.get(atom) !== promise) return
+            // Async validation can't throw to the original caller (the promise
+            // was already returned), so it's reported and we revert — the
+            // invalid value never lands. Sync sets throw from store.set directly.
+            if (!validateResolvedValue(atom, resolvedValue, data)) {
+                if (data.values.get(atom) === promise) {
+                    setValueInData(atom, currentValue, data)
+                    propagateAtomUpdate([atom], data, false, undefined, "async-set")
+                }
+                return
+            }
             setValueInData(atom, resolvedValue, data)
             if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
             resolvePendingDefault(atom, data, resolvedValue)
@@ -73,7 +85,7 @@ export const setAtom = <Value = any>(
     }
     // Past the isPromiseLike branch newValue is guaranteed to be a plain
     // Value (TypeScript can't narrow out PromiseLike fully, so we restate it).
-    let syncValue = newValue as Value
+    let syncValue = validateSchema(atom, newValue as Value, data)
     const areEqual = isPromiseLike(currentValue)
         ? currentValue === syncValue
         : atom.equal(currentValue, syncValue)

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -222,7 +222,12 @@ export function storeFromStoreData(
             if (data.scopes.has(scopeId)) {
                 scopedStoreData = data.scopes.get(scopeId)!
             } else {
-                scopedStoreData = createStoreData(scopeId, data, data.batchUpdates ? { batchUpdates: true } : undefined)
+                // schemaValidation and enumerable are inherited from the parent
+                // inside createStoreData; only batchUpdates needs forwarding here.
+                const scopeOptions = data.batchUpdates
+                    ? { batchUpdates: true }
+                    : undefined
+                scopedStoreData = createStoreData(scopeId, data, scopeOptions)
                 data.scopes.set(scopeId, scopedStoreData)
             }
             const consumers = scopedStoreData.scopeConsumers!

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -6,6 +6,7 @@ import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
 import { deepFreeze } from "../utils/deepFreeze"
+import { validateSchema } from "./validateSchema"
 import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
@@ -204,6 +205,13 @@ export class Transaction {
         if (!atom.mutable && !IS_PROD && resolved !== null && (typeof resolved === "object" || typeof resolved === "function")) {
             resolved = deepFreeze(resolved) as V
         }
+        // Validate at staging time (inside the txn body), not at commit: a
+        // failure throws here, so the user's callback aborts and commit never
+        // runs — the transaction stays atomic. This also covers batched stores,
+        // whose set() routes through here. Caveat: a PROMISE value is skipped by
+        // validateSchema, and (unlike the non-txn setAtom path) the txn commit
+        // does NOT resolve it — the promise is stored as-is and never validated.
+        resolved = validateSchema(atom, resolved, this.data)
         this._atomMap.set(atom, resolved)
         // A set supersedes an unset of the same atom buffered earlier in this txn
         // (last write wins, regardless of order). Symmetric to `unset` dropping
@@ -239,7 +247,9 @@ export class Transaction {
             }
             index.created.set(atom, performance.now())
             if (index.deleted.has(atom)) index.deleted.delete(atom)
-            this._atomMap.set(atom, value)
+            // Validate like Transaction.set so this path can't become an
+            // unvalidated hole (promises are skipped by validateSchema).
+            this._atomMap.set(atom, validateSchema(atom, value, this.data))
             this._unsetSet?.delete(atom)
         }
         index.rendered = null

--- a/packages/valdres/src/lib/validateResolvedValue.ts
+++ b/packages/valdres/src/lib/validateResolvedValue.ts
@@ -1,0 +1,34 @@
+import type { Atom } from "../types/Atom"
+import type { Selector } from "../types/Selector"
+import type { StoreData } from "../types/StoreData"
+import { reportAsyncSchemaError } from "./reportAsyncSchemaError"
+import { validateSchema } from "./validateSchema"
+
+/**
+ * Validate a value that arrived asynchronously (a promise resolved to it).
+ *
+ * Returns `true` when the value is valid (or validation is off) — the caller
+ * commits it. Returns `false` when it's invalid: the failure has already been
+ * reported via `reportAsyncSchemaError`, and the caller MUST NOT commit the
+ * value (it runs its own cleanup — revert / drop / cleanUpRejectedPromise).
+ *
+ * Every async validate-on-resolve boundary routes through here — atom set, atom
+ * function default, atom selector default, selector evaluation, and the
+ * deleted-family-member read in getState — so a new boundary can't silently
+ * skip validation. (Async validation can't throw to the original caller, which
+ * is why the failure is reported rather than thrown; sync boundaries call
+ * `validateSchema` directly and it throws to the caller.)
+ */
+export const validateResolvedValue = (
+    state: Atom<any> | Selector<any>,
+    value: unknown,
+    data: StoreData,
+): boolean => {
+    try {
+        validateSchema(state, value, data)
+        return true
+    } catch (err) {
+        reportAsyncSchemaError(err)
+        return false
+    }
+}

--- a/packages/valdres/src/lib/validateSchema.ts
+++ b/packages/valdres/src/lib/validateSchema.ts
@@ -1,0 +1,85 @@
+import { SchemaValidationError } from "../errors/SchemaValidationError"
+import type { Atom } from "../types/Atom"
+import type { Selector } from "../types/Selector"
+import type { StandardSchemaV1 } from "../types/StandardSchemaV1"
+import type { StoreData } from "../types/StoreData"
+import { isPromiseLike } from "../utils/isPromiseLike"
+
+// Render Standard Schema issues into a single readable message (a vendor like
+// Valibot/ArkType reports `issues` rather than throwing a rich error object).
+const standardIssuesError = (
+    issues: ReadonlyArray<StandardSchemaV1.Issue>,
+): Error => {
+    const message = issues
+        .map(issue => {
+            const path = issue.path
+                ?.map(seg =>
+                    typeof seg === "object" && seg !== null
+                        ? String(seg.key)
+                        : String(seg),
+                )
+                .join(".")
+            return path ? `${path}: ${issue.message}` : issue.message
+        })
+        .join("; ")
+    return new Error(message)
+}
+
+/**
+ * Validate `value` against the atom/selector's `schema` when validation is
+ * enabled, returning the value unchanged.
+ *
+ * Validate-only: the schema runs purely for its rejecting side effect; its
+ * (possibly transformed/coerced) output is intentionally discarded so the
+ * stored value is identical whether validation is on or off. This keeps schema
+ * validation a pure correctness aid with no dev/prod behavioral divergence —
+ * a transform like `z.string().trim()` validates but never mutates state.
+ *
+ * Enablement is per-state-then-store: an atom/selector's own `schemaValidation`
+ * (if set) wins over the store's; both default off.
+ *
+ * Promises are skipped — async values are validated once they resolve (see the
+ * async paths in setAtom/initAtom/initSelector), never the in-flight promise.
+ *
+ * Two schema shapes are accepted. A `parse(value)` method is preferred (it
+ * throws a library-native error — e.g. Zod's `ZodError` — which is kept on
+ * `cause`); otherwise a Standard Schema (`~standard`) is used (Valibot,
+ * ArkType, …). Either way the failure is wrapped in a SchemaValidationError
+ * naming the offending atom/selector. Asynchronous validation (an async
+ * `~standard.validate`) is rejected — validation runs on the synchronous path.
+ */
+export const validateSchema = <V>(
+    state: Atom<any> | Selector<any>,
+    value: V,
+    data: StoreData,
+): V => {
+    const enabled = state.schemaValidation ?? data.schemaValidation ?? false
+    const schema = state.schema
+    if (enabled && schema && !isPromiseLike(value)) {
+        if ("parse" in schema) {
+            try {
+                schema.parse(value)
+            } catch (cause) {
+                throw new SchemaValidationError(cause, state)
+            }
+        } else {
+            const result = schema["~standard"].validate(value)
+            if (isPromiseLike(result)) {
+                throw new SchemaValidationError(
+                    new Error(
+                        "Asynchronous schema validation is not supported; " +
+                            "use a synchronous schema.",
+                    ),
+                    state,
+                )
+            }
+            if (result.issues) {
+                throw new SchemaValidationError(
+                    standardIssuesError(result.issues),
+                    state,
+                )
+            }
+        }
+    }
+    return value
+}

--- a/packages/valdres/src/selector.mdx
+++ b/packages/valdres/src/selector.mdx
@@ -36,20 +36,41 @@ const fullNameSelector = selector(get => {
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `getter` | `(get: GetFn) => T` | A function that computes the derived value. Use `get()` to read atoms or other selectors. |
+| `options.name` | `string` | Optional name for debugging, devtools, and validation error messages |
+| `options.schema` | `Schema<T>` | Schema for runtime validation of the selector's result, and type inference. A no-op unless validation is enabled. See [Schema Validation](/guides/schema-validation). |
+| `options.schemaValidation` | `boolean` | Per-selector override of the store's `schemaValidation` flag — `true` always validates this selector, `false` exempts it |
 
 ## Async selectors
 
-Selectors can also be async. They work with `Suspense` in React.
+Selectors can return a promise. They work with `Suspense` in React. Note that
+the getter itself must be a sync function that *returns* a promise — `selector()`
+rejects `async` functions at creation time:
 
 ```ts
-const userDataSelector = selector(async get => {
+const userDataSelector = selector(get => {
     const userId = get(userIdAtom)
-    const res = await fetch(`/api/users/${userId}`)
-    return res.json()
+    return fetch(`/api/users/${userId}`).then(res => res.json())
 })
 ```
+
+## Schema validation
+
+A selector's `schema` validates its computed result on every evaluation — a
+runtime contract that catches a selector drifting from its declared shape:
+
+```ts
+const fullNameSelector = selector(
+    get => `${get(firstNameAtom)} ${get(lastNameAtom)}`,
+    { name: "fullName", schema: z.string() },
+)
+```
+
+Validation is opt-in per store (`store({ schemaValidation: true })`) or per
+selector (`schemaValidation: true`). See the
+[Schema Validation guide](/guides/schema-validation).
 
 ## See also
 
 - [selectorFamily](/valdres/selectorFamily) — create a collection of selectors keyed by a parameter
+- [Schema Validation](/guides/schema-validation) — runtime validation and type inference
 - [useValue](/react/useValue) — read a selector value in your components

--- a/packages/valdres/src/selectorFamily.ts
+++ b/packages/valdres/src/selectorFamily.ts
@@ -42,6 +42,10 @@ export const selectorFamily = <
     }
     selectorFamily.__valdresSelectorFamilyMap = map
     selectorFamily.release = (...args: Args) => map.delete(familyKey(args))
+    // Exposed on the family object too (members carry them via ...options) so
+    // a consumer can read a family's schema without materializing a member.
+    selectorFamily.schema = options?.schema
+    selectorFamily.schemaValidation = options?.schemaValidation
     if (hasName)
         Object.defineProperty(selectorFamily, "name", {
             value: options!.name,

--- a/packages/valdres/src/store.mdx
+++ b/packages/valdres/src/store.mdx
@@ -7,7 +7,7 @@ description: Create and interact with a valdres store
 
 <div className="not-prose mb-8 rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 p-4">
   <div className="text-xs font-medium text-zinc-400 dark:text-zinc-500 mb-2 uppercase tracking-wider">Signature</div>
-  <code className="text-sm font-mono text-accent-500">store(): Store</code>
+  <code className="text-sm font-mono text-accent-500">store(id?: string, options?: StoreOptions): Store</code>
   <div className="mt-3 text-xs text-zinc-500 dark:text-zinc-400">
     <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-zinc-200 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 font-medium mr-2">valdres</span>
     Create a store to hold all state
@@ -23,6 +23,19 @@ import { atom, store } from "valdres"
 
 const myStore = store()
 const countAtom = atom(0)
+```
+
+## Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `batchUpdates` | `boolean` | Batch sequential `set()` calls within a tick into one notification pass (recommended for React) |
+| `enumerable` | `boolean` | Retain values enumerably so `store.snapshot()` can list current state |
+| `schemaValidation` | `boolean` | Validate atom/selector values against their `schema` (off by default). Inherited by scoped stores. See [Schema Validation](/guides/schema-validation). |
+
+```ts
+// Enable schema validation (e.g. outside production)
+const devStore = store({ schemaValidation: import.meta.env.DEV })
 ```
 
 ## Reading state
@@ -86,3 +99,4 @@ Inside a component you normally read and write through your framework's provider
 
 - [Provider](/react/Provider) — provide a store to your component tree
 - [useStore](/react/useStore) — access the current store in your components
+- [Schema Validation](/guides/schema-validation) — opt-in runtime validation via the `schemaValidation` option

--- a/packages/valdres/src/types/Atom.ts
+++ b/packages/valdres/src/types/Atom.ts
@@ -4,6 +4,7 @@ import type { AtomOnMount } from "./AtomOnMount"
 import type { AtomOnSet } from "./AtomOnSet"
 import type { EqualFunc } from "./EqualFunc"
 import type { Reactive } from "./Reactive"
+import type { Schema } from "./Schema"
 import type { Selector } from "./Selector"
 
 export type CacheMeta = {
@@ -18,6 +19,9 @@ export type Atom<Value = unknown> = {
     equal: EqualFunc<Value>
     defaultValue?: AtomDefaultValue<Value>
     name?: string
+    schema?: Schema<Value>
+    /** Per-atom override of the store's `schemaValidation` flag (see AtomOptions). */
+    schemaValidation?: boolean
     /** Internal cross-store sync hook for global atoms. Not user-facing. */
     onInit?: AtomOnInit<Value>
     onSet?: AtomOnSet<Value>

--- a/packages/valdres/src/types/AtomFamily.ts
+++ b/packages/valdres/src/types/AtomFamily.ts
@@ -1,6 +1,7 @@
 import type { FamilyKey } from "../lib/familyKey"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { EqualFunc } from "./EqualFunc"
+import type { Schema } from "./Schema"
 
 export type AtomFamily<
     Value extends any,
@@ -11,6 +12,11 @@ export type AtomFamily<
     equal: EqualFunc<Value>
     name?: string
     mutable?: boolean
+    /** The schema members validate against, readable from the family itself —
+     *  members carry the same reference via their options. */
+    schema?: Schema<Value>
+    /** Per-family `schemaValidation` override, mirrored from the options. */
+    schemaValidation?: boolean
     /** AtomFamily itself is not mountable; these are declared `never` to keep
      *  the State union's dynamic mount-check uniform without runtime casts. */
     onMount?: never

--- a/packages/valdres/src/types/AtomOptions.ts
+++ b/packages/valdres/src/types/AtomOptions.ts
@@ -2,10 +2,21 @@ import type { AtomOnMount } from "./AtomOnMount"
 import type { AtomOnSet } from "./AtomOnSet"
 import type { EqualFunc } from "./EqualFunc"
 import type { Reactive } from "./Reactive"
+import type { Schema } from "./Schema"
 
 export type AtomOptions<Value = unknown> = {
     global?: boolean
     name?: string
+    /** Schema to validate this atom's value against. A no-op unless validation
+     *  is enabled — set `store({ schemaValidation: true })` or this atom's own
+     *  `schemaValidation: true`. Validate-only: the value is checked but stored
+     *  unchanged (transforms/coercions do not apply). See {@link Schema}. */
+    schema?: Schema<Value>
+    /** Per-atom override of the store's `schemaValidation` flag. When set, it
+     *  wins over the store-level setting — use `true` to always validate a
+     *  boundary atom (even in a store with validation off), or `false` to
+     *  exempt a hot atom. Defaults to the store's setting. */
+    schemaValidation?: boolean
     onSet?: AtomOnSet<Value>
     onMount?: AtomOnMount
     maxAge?: Reactive<number>

--- a/packages/valdres/src/types/Schema.ts
+++ b/packages/valdres/src/types/Schema.ts
@@ -1,0 +1,23 @@
+import type { StandardSchemaV1 } from "./StandardSchemaV1"
+
+/**
+ * A schema usable for runtime validation of an atom/selector value.
+ *
+ * Accepts either:
+ *  - a **Standard Schema** (https://standard-schema.dev) via its `~standard`
+ *    property — Zod 3.24+/4, Valibot 1+, ArkType 2+, etc.; or
+ *  - a classic **parser** with a `parse(value)` method (an older Zod schema or
+ *    any custom validator).
+ *
+ * Validation is **validate-only**: the value is checked but the original input
+ * is stored unchanged. With a plain validator (`z.string()`) input and output
+ * coincide, so the inferred atom type matches the stored value. But a
+ * transforming/coercing schema (`z.coerce.number()`, `z.string().trim()`,
+ * `z.string().default(...)`) validates without altering stored state — and its
+ * inferred type follows the schema's *output* while the stored value stays the
+ * *input*. Avoid transform/coerce/default schemas here: the type would not
+ * describe what's actually stored.
+ */
+export type Schema<V = unknown> =
+    | StandardSchemaV1<V>
+    | { parse: (value: unknown) => V }

--- a/packages/valdres/src/types/Selector.ts
+++ b/packages/valdres/src/types/Selector.ts
@@ -1,6 +1,7 @@
 import type { AtomOnMount } from "./AtomOnMount"
 import type { EqualFunc } from "./EqualFunc"
 import type { GetValue } from "./GetValue"
+import type { Schema } from "./Schema"
 import type { SelectorFamily } from "./SelectorFamily"
 
 export type SelectorGetOptions = {
@@ -15,6 +16,9 @@ export type Selector<
     get: (get: GetValue, options: SelectorGetOptions) => Value | Promise<Value>
     equal: EqualFunc<Value>
     name?: string
+    schema?: Schema<Value>
+    /** Per-selector override of the store's `schemaValidation` flag (see SelectorOptions). */
+    schemaValidation?: boolean
     family?: SelectorFamily<Value, FamilyArgs>
     familyArgs?: FamilyArgs
     onMount?: AtomOnMount

--- a/packages/valdres/src/types/SelectorFamily.ts
+++ b/packages/valdres/src/types/SelectorFamily.ts
@@ -1,8 +1,14 @@
 import type { FamilyKey } from "../lib/familyKey"
+import type { Schema } from "./Schema"
 import type { Selector } from "./Selector"
 
 export type SelectorFamily<Value extends any, Args extends [any, ...any[]]> = {
     (...args: Args): Selector<Value, Args>
     release: (...args: Args) => boolean
+    /** The schema members validate against, readable from the family itself —
+     *  members carry the same reference via their options. */
+    schema?: Schema<Value>
+    /** Per-family `schemaValidation` override, mirrored from the options. */
+    schemaValidation?: boolean
     __valdresSelectorFamilyMap: Map<FamilyKey, Selector<Value, Args>>
 }

--- a/packages/valdres/src/types/SelectorOptions.ts
+++ b/packages/valdres/src/types/SelectorOptions.ts
@@ -1,6 +1,17 @@
 import type { EqualFunc } from "./EqualFunc"
+import type { Schema } from "./Schema"
 
 export type SelectorOptions<Value extends any> = {
     name?: string
+    /** Schema to validate this selector's result against. A no-op unless
+     *  validation is enabled — set `store({ schemaValidation: true })` or this
+     *  selector's own `schemaValidation: true`. Validate-only: the value is
+     *  checked but returned unchanged. See {@link Schema}. */
+    schema?: Schema<Value>
+    /** Per-selector override of the store's `schemaValidation` flag. When set,
+     *  it wins over the store-level setting — use `true` to always validate a
+     *  boundary selector (even in a store with validation off), or `false` to
+     *  exempt a hot selector. Defaults to the store's setting. */
+    schemaValidation?: boolean
     equal?: EqualFunc<Value>
 }

--- a/packages/valdres/src/types/StandardSchemaV1.ts
+++ b/packages/valdres/src/types/StandardSchemaV1.ts
@@ -1,0 +1,54 @@
+/**
+ * The Standard Schema v1 interface (https://standard-schema.dev) — the
+ * cross-library validation contract implemented by Zod 3.24+/4, Valibot 1+,
+ * ArkType 2+, Effect Schema, and others. Vendored verbatim (the spec is
+ * designed to be copied) so valdres accepts any standard-compliant schema
+ * without taking a dependency on it.
+ */
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+    readonly "~standard": StandardSchemaV1.Props<Input, Output>
+}
+
+export declare namespace StandardSchemaV1 {
+    export interface Props<Input = unknown, Output = Input> {
+        readonly version: 1
+        readonly vendor: string
+        readonly validate: (
+            value: unknown,
+        ) => Result<Output> | Promise<Result<Output>>
+        readonly types?: Types<Input, Output> | undefined
+    }
+
+    export type Result<Output> = SuccessResult<Output> | FailureResult
+
+    export interface SuccessResult<Output> {
+        readonly value: Output
+        readonly issues?: undefined
+    }
+
+    export interface FailureResult {
+        readonly issues: ReadonlyArray<Issue>
+    }
+
+    export interface Issue {
+        readonly message: string
+        readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined
+    }
+
+    export interface PathSegment {
+        readonly key: PropertyKey
+    }
+
+    export interface Types<Input = unknown, Output = Input> {
+        readonly input: Input
+        readonly output: Output
+    }
+
+    export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
+        Schema["~standard"]["types"]
+    >["input"]
+
+    export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
+        Schema["~standard"]["types"]
+    >["output"]
+}

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -52,6 +52,7 @@ export type StoreData = {
     enumerable?: boolean
     scopes: Map<string, StoreData>
     batchUpdates?: boolean
+    schemaValidation?: boolean
     scopeValueIndex: WeakMap<WeakKey, Set<StoreData>>
     /** Present iff this is a scoped store. Root stores have `parent: undefined`. */
     parent?: StoreData

--- a/packages/valdres/tsconfig.types-test.json
+++ b/packages/valdres/tsconfig.types-test.json
@@ -1,0 +1,8 @@
+{
+    "//": "Typecheck lane for the schema type-assertion tests. The package's main tsconfig only includes src/index.ts (it emits .d.ts), so type-level tests would otherwise never be checked. Run via `bun run typecheck:types`.",
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": ["src/lib/schemaValidation.types.test.ts"]
+}


### PR DESCRIPTION
Adds an optional `schema` to atoms, selectors, and families for runtime value validation. Accepts any [Standard Schema](https://standard-schema.dev) (Zod 3.24+/4, Valibot, ArkType, …) or any classic `parse(value)` validator. The schema also drives type inference: `atom(undefined, { schema: z.string() })` is `Atom<string>` — no generic needed.

```ts
const user = atom({ name: "Ada", age: 36 }, {
    name: "userAtom",
    schema: z.object({ name: z.string(), age: z.number().min(0) }),
})

const s = store({ schemaValidation: true }) // opt-in, off by default
s.set(user, { name: "Bob", age: -1 }) // throws SchemaValidationError naming 'userAtom'
```

## Design

- **Opt-in, inherited like `enumerable`.** Off by default; enable per store with `store({ schemaValidation: true })`, inherited by scopes. Per-atom/selector `schemaValidation` overrides the store (always-validate a boundary atom, or exempt a hot one).
- **Validate-only.** The schema runs for its rejecting side effect; the original value is stored unchanged — a store with validation on holds identical values to one with it off (no dev/prod divergence). Transform/coerce schemas validate but don't transform (documented).
- **Validated at the write boundaries.** Atom init (static/function/async/selector defaults), atom set (sync + async resolve), selector eval (sync + async), deleted-family-member reads, and `store.txn()` staging — a failure throws in the txn body, aborting the whole transaction atomically. Batched stores route through the same path. All async validate-on-resolve boundaries share one helper (`validateResolvedValue`) with a tripwire test, so a new write path can't silently skip validation.
- **Errors name the culprit.** Sync failures throw `SchemaValidationError` (exported, `name` set for log/Sentry grouping) with the library-native error (e.g. `ZodError`) on `cause`. Async failures can't throw to the caller, so they're reported via `console.error` and the invalid value is never committed (set → reverts; default → drops so a re-read retries).
- **Zero cost when off.** The gate is two property reads + a branch on the hot set path; worktree A/B vs main measured no delta (65ns vs 65ns set path).

## Docs

- New guide: [/guides/schema-validation](https://valdres.dev/guides/schema-validation) (nav: Introduction section)
- `atom` / `selector` / `store` API pages document the new options
- Fixed two pre-existing docs bugs in passing: `atom` documented a nonexistent `label` option (it's `name`), and `selector`'s async example used `async get => …`, which `selector()` rejects at creation

## CI

- New `typecheck:types` lane (scoped tsconfig) so the type-level assertions in `schemaValidation.types.test.ts` are actually checked — they previously weren't covered by any typecheck.

## Known limitations (documented in changeset + guide)

- Promises set inside a `store.txn()` are stored as-is (pre-existing txn behavior — never auto-resolved), so they aren't validated on resolve.
- An invalid async default drops its value like a rejected one; under React Suspense a re-reading component will re-init/re-fetch. Validate at the fetch boundary for Suspense flows.
- Async schemas (async Standard Schema / Zod async `refine`) aren't supported on the sync validation path and surface a clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)