### PR TITLE
Extract shared familyKey and optimize selectorFamily

### DIFF
--- a/packages/valdres/src/lib/createAtomFamily.ts
+++ b/packages/valdres/src/lib/createAtomFamily.ts
@@ -3,16 +3,7 @@ import type { AtomFamilyDefaultValue } from "../types/AtomFamilyDefaultValue"
 import type { AtomOptions } from "../types/AtomOptions"
 import { isSelectorFamily } from "../utils/isSelectorFamily"
 import { equal } from "./equal"
-import { stringifyFamilyArgs } from "./stringifyFamilyArgs"
-
-const familyKey = (args: any[]) => {
-    if (args.length === 1) {
-        const a = args[0]
-        const t = typeof a
-        if (t === "string" || t === "number" || t === "boolean") return a
-    }
-    return stringifyFamilyArgs(args)
-}
+import { familyKey } from "./familyKey"
 
 export const createAtomFamily = <
     Value extends any,

--- a/packages/valdres/src/lib/familyKey.ts
+++ b/packages/valdres/src/lib/familyKey.ts
@@ -1,0 +1,10 @@
+import { stringifyFamilyArgs } from "./stringifyFamilyArgs"
+
+export const familyKey = (args: any[]) => {
+    if (args.length === 1) {
+        const a = args[0]
+        const t = typeof a
+        if (t === "string" || t === "number" || t === "boolean") return a
+    }
+    return stringifyFamilyArgs(args)
+}

--- a/packages/valdres/src/lib/familyKey.ts
+++ b/packages/valdres/src/lib/familyKey.ts
@@ -1,10 +1,13 @@
 import { stringifyFamilyArgs } from "./stringifyFamilyArgs"
 
-export const familyKey = (args: any[]) => {
+export type FamilyKey = string | number | boolean
+
+export const familyKey = (args: readonly unknown[]): FamilyKey => {
     if (args.length === 1) {
         const a = args[0]
         const t = typeof a
-        if (t === "string" || t === "number" || t === "boolean") return a
+        if (t === "string" || t === "number" || t === "boolean")
+            return a as FamilyKey
     }
-    return stringifyFamilyArgs(args)
+    return stringifyFamilyArgs(args as any[])
 }

--- a/packages/valdres/src/selectorFamily.ts
+++ b/packages/valdres/src/selectorFamily.ts
@@ -1,5 +1,5 @@
 import { equal } from "./lib/equal"
-import { stringifyFamilyArgs } from "./lib/stringifyFamilyArgs"
+import { familyKey } from "./lib/familyKey"
 import type { GetValue } from "./types/GetValue"
 import type { SelectorFamily } from "./types/SelectorFamily"
 import type { SelectorOptions } from "./types/SelectorOptions"
@@ -15,10 +15,12 @@ export const selectorFamily = <
     const hasName = !!options?.name
 
     const selectorFamily = (...args: Args) => {
-        const argsStringified = stringifyFamilyArgs(args)
-        if (map.has(argsStringified)) return map.get(argsStringified)
+        const key = familyKey(args)
 
-        // Build selector in a single allocation — no intermediate objects
+        // Single Map.get + undefined check instead of has() + get()
+        const cached = map.get(key)
+        if (cached !== undefined) return cached
+
         const get = (selectorArgs: GetValue) => callback(...args)(selectorArgs)
         const newSelector = {
             equal,
@@ -26,18 +28,17 @@ export const selectorFamily = <
             get,
             family: selectorFamily,
             familyArgs: args,
-            familyArgsStringified: argsStringified,
+            familyArgsStringified: key,
             name: hasName
-                ? options!.name + "_" + argsStringified
+                ? options!.name + "_" + key
                 : undefined,
         }
 
-        map.set(argsStringified, newSelector)
+        map.set(key, newSelector)
         return newSelector
     }
     selectorFamily.__valdresSelectorFamilyMap = map
-    selectorFamily.release = (...args: Args) =>
-        map.delete(stringifyFamilyArgs(args))
+    selectorFamily.release = (...args: Args) => map.delete(familyKey(args))
     if (hasName)
         Object.defineProperty(selectorFamily, "name", {
             value: options!.name,

--- a/packages/valdres/src/types/AtomFamily.ts
+++ b/packages/valdres/src/types/AtomFamily.ts
@@ -1,3 +1,4 @@
+import type { FamilyKey } from "../lib/familyKey"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { EqualFunc } from "./EqualFunc"
 
@@ -10,5 +11,5 @@ export type AtomFamily<
     equal: EqualFunc<Value>
     name?: string
     mutable?: boolean
-    __valdresAtomFamilyMap: Map<string, AtomFamilyAtom<Value, Args>>
+    __valdresAtomFamilyMap: Map<FamilyKey, AtomFamilyAtom<Value, Args>>
 }

--- a/packages/valdres/src/types/SelectorFamily.ts
+++ b/packages/valdres/src/types/SelectorFamily.ts
@@ -1,7 +1,8 @@
+import type { FamilyKey } from "../lib/familyKey"
 import type { Selector } from "./Selector"
 
 export type SelectorFamily<Value extends any, Args extends [any, ...any[]]> = {
     (...args: Args): Selector<Value, Args>
     release: (...args: Args) => boolean
-    __valdresSelectorFamilyMap: Map<string, Selector<Value, Args>>
+    __valdresSelectorFamilyMap: Map<FamilyKey, Selector<Value, Args>>
 }


### PR DESCRIPTION
## Summary
- Extracts `familyKey()` to a shared module (`src/lib/familyKey.ts`) used by both `createAtomFamily` and `selectorFamily`, removing duplicated logic
- Optimizes `selectorFamily` hot path: single `Map.get()` + undefined check instead of `has()` + `get()` (eliminates redundant hash lookup)
- Adds primitive fast-path for single-arg families (skips `stringifyFamilyArgs` for string/number/boolean keys)

## Test plan
- [x] All 227 selectorFamily/atomFamily unit tests pass
- [x] Benchmarks show no regression (selectorFamily ~245ns vs jotai ~255ns)
- [x] Memory leak tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)