### PR TITLE
Fix global atom maxAge duplicate revalidation intervals

### DIFF
--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1036,4 +1036,47 @@ describe("subscriber error handling", () => {
 
         expect(() => store1.set(countAtom, 1)).toThrow("subscriber error")
     })
+
+    test("atom with maxAge async: in-flight promise should not update store after unsubscribe", async () => {
+        const store1 = store()
+        let resolver: (v: number) => void
+        let fetchCount = 0
+        const atomCallback = () => {
+            fetchCount++
+            return new Promise<number>(resolve => {
+                resolver = resolve
+            })
+        }
+        // Use SWR so the stale value stays visible during revalidation
+        const atom1 = atom(atomCallback, {
+            maxAge: 20,
+            staleWhileRevalidate: 1000,
+        })
+
+        const callback = mock(() => {})
+        const unsubscribe = store1.sub(atom1, callback)
+
+        // Resolve the initial defaultValue call
+        resolver!(1)
+        await wait(1)
+        expect(store1.get(atom1)).toBe(1)
+
+        // Wait for the interval to fire — this calls defaultValue() again,
+        // creating a new in-flight promise. With SWR the store keeps value 1.
+        await wait(25)
+        expect(fetchCount).toBe(2)
+        expect(store1.get(atom1)).toBe(1)
+
+        // Unsubscribe while the second promise is still pending.
+        // Cleanup runs: clears the interval and pending timeouts.
+        unsubscribe()
+
+        // Now resolve the in-flight promise AFTER cleanup
+        resolver!(999)
+        await wait(1)
+
+        // The resolved value should NOT have been written to the store,
+        // because the subscription (and its interval) was cleaned up.
+        expect(store1.get(atom1)).toBe(1)
+    })
 })

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1079,4 +1079,30 @@ describe("subscriber error handling", () => {
         // because the subscription (and its interval) was cleaned up.
         expect(store1.get(atom1)).toBe(1)
     })
+
+    test("atom with maxAge: last subscriber unsubscribing clears interval even if it was not the first", async () => {
+        const setIntervalSpy = spyOn(global, "setInterval")
+        const clearIntervalSpy = spyOn(global, "clearInterval")
+        const store1 = store()
+        const atom1 = atom(() => Date.now(), { maxAge: 50 })
+
+        // First subscription creates the interval
+        const unsub1 = store1.sub(atom1, () => {})
+        expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+        // Second subscription does NOT create a new interval
+        const unsub2 = store1.sub(atom1, () => {})
+        expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+        // Unsub the first subscriber — still one left, interval should stay
+        unsub1()
+        expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
+
+        // Unsub the last subscriber — interval should be cleaned up
+        unsub2()
+        expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+
+        setIntervalSpy.mockRestore()
+        clearIntervalSpy.mockRestore()
+    })
 })

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock } from "bun:test"
 import { store } from "../store"
 import { atom } from "../atom"
 import { selector } from "../selector"
+import { wait } from "../../test/utils/wait"
 
 describe("globalAtom", () => {
     test("set in one store, read from both", () => {
@@ -237,5 +238,74 @@ describe("globalAtom", () => {
         expect(store1.get(testAtom)).toBe(0)
         expect(store2.get(testAtom)).toBe(0)
         expect(store3.get(testAtom)).toBe(0)
+    })
+
+    test("global atom with maxAge only calls defaultValue once per interval across stores", async () => {
+        let callCount = 0
+        const testAtom = atom(
+            () => {
+                callCount++
+                return callCount
+            },
+            { global: true, maxAge: 50 },
+        )
+
+        const store1 = store()
+        const store2 = store()
+
+        const cb1 = mock(() => {})
+        const cb2 = mock(() => {})
+
+        // Subscribe in both stores — bug causes two independent intervals
+        const unsub1 = store1.sub(testAtom, cb1)
+        const unsub2 = store2.sub(testAtom, cb2)
+
+        // Initial defaultValue call happened once during init
+        const countAfterInit = callCount
+
+        // Wait long enough for exactly one revalidation cycle (50ms interval)
+        await wait(75)
+
+        // With the bug, each store starts its own interval so defaultValue
+        // gets called twice per cycle. It should only be called once.
+        const revalidationCalls = callCount - countAfterInit
+        expect(revalidationCalls).toBe(1)
+
+        // Both stores should have the updated value
+        expect(store1.get(testAtom)).toBe(store2.get(testAtom))
+
+        unsub1()
+        unsub2()
+    })
+
+    test("resetSelf clears maxAge interval for global atom", async () => {
+        let callCount = 0
+        const testAtom = atom(
+            () => {
+                callCount++
+                return callCount
+            },
+            { global: true, maxAge: 50 },
+        )
+
+        const store1 = store()
+        const store2 = store()
+
+        const unsub1 = store1.sub(testAtom, () => {})
+        const unsub2 = store2.sub(testAtom, () => {})
+
+        const countAfterInit = callCount
+
+        // Reset should clear the interval
+        testAtom.resetSelf()
+
+        // Wait past when the interval would have fired
+        await wait(75)
+
+        // No revalidation calls should have happened after reset
+        expect(callCount - countAfterInit).toBe(0)
+
+        unsub1()
+        unsub2()
     })
 })

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -55,6 +55,7 @@ export const globalAtom = <Value = unknown>(
         initialized = false
         if (atom.maxAgeInterval) {
             atom.maxAgeInterval.cleanup()
+            atom.maxAgeInterval.refCount = 0
             atom.maxAgeInterval = undefined
         }
         // Snapshot to avoid mutating during iteration

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -53,6 +53,10 @@ export const globalAtom = <Value = unknown>(
     const resetSelf: GlobalAtomResetSelfFunc = () => {
         value = undefined
         initialized = false
+        if (atom._maxAgeInterval) {
+            atom._maxAgeInterval.cleanup()
+            atom._maxAgeInterval = undefined
+        }
         // Snapshot to avoid mutating during iteration
         const snapshot = [...stores]
         let firstError: unknown
@@ -90,6 +94,7 @@ export const globalAtom = <Value = unknown>(
         get stores() {
             return stores
         },
+        _maxAgeInterval: undefined,
     }
     return atom
 }

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -53,9 +53,9 @@ export const globalAtom = <Value = unknown>(
     const resetSelf: GlobalAtomResetSelfFunc = () => {
         value = undefined
         initialized = false
-        if (atom._maxAgeInterval) {
-            atom._maxAgeInterval.cleanup()
-            atom._maxAgeInterval = undefined
+        if (atom.maxAgeInterval) {
+            atom.maxAgeInterval.cleanup()
+            atom.maxAgeInterval = undefined
         }
         // Snapshot to avoid mutating during iteration
         const snapshot = [...stores]
@@ -94,7 +94,7 @@ export const globalAtom = <Value = unknown>(
         get stores() {
             return stores
         },
-        _maxAgeInterval: undefined,
+        maxAgeInterval: undefined,
     }
     return atom
 }

--- a/packages/valdres/src/lib/maxAgeCleanups.ts
+++ b/packages/valdres/src/lib/maxAgeCleanups.ts
@@ -1,0 +1,30 @@
+import type { StoreData } from "../types/StoreData"
+
+// Per-store maxAge cleanup functions, keyed by (data, state).
+// Stored here so any subscription's unsub can trigger cleanup when
+// the last subscriber leaves, not just the first subscriber's unsub.
+const maxAgeCleanups = new WeakMap<StoreData, WeakMap<WeakKey, () => void>>()
+
+export const setMaxAgeCleanup = (
+    data: StoreData,
+    state: WeakKey,
+    cleanup: () => void,
+) => {
+    let storeMap = maxAgeCleanups.get(data)
+    if (!storeMap) {
+        storeMap = new WeakMap()
+        maxAgeCleanups.set(data, storeMap)
+    }
+    storeMap.set(state, cleanup)
+}
+
+export const getMaxAgeCleanup = (
+    data: StoreData,
+    state: WeakKey,
+): (() => void) | undefined => {
+    return maxAgeCleanups.get(data)?.get(state)
+}
+
+export const deleteMaxAgeCleanup = (data: StoreData, state: WeakKey) => {
+    maxAgeCleanups.get(data)?.delete(state)
+}

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -116,6 +116,7 @@ export const subscribe = <V>(
             } else {
                 const pendingTimeouts = new Set<Timer>()
                 let revalidating = false
+                let cancelled = false
                 let lastSuccessTime = Date.now()
                 const NO_VALUE = Symbol()
                 let lastGoodValue: any = NO_VALUE
@@ -173,6 +174,7 @@ export const subscribe = <V>(
                                 (resolved: any) => {
                                     clearTimeout(t)
                                     pendingTimeouts.delete(t)
+                                    if (cancelled) return
                                     revalidating = false
                                     lastSuccessTime = Date.now()
                                     lastGoodValue = resolved
@@ -181,6 +183,7 @@ export const subscribe = <V>(
                                 () => {
                                     clearTimeout(t)
                                     pendingTimeouts.delete(t)
+                                    if (cancelled) return
                                     revalidating = false
                                     if (
                                         state.staleIfError &&
@@ -195,12 +198,14 @@ export const subscribe = <V>(
                             setAndPropagate(state, value)
                             value.then(
                                 (resolved: any) => {
+                                    if (cancelled) return
                                     revalidating = false
                                     lastSuccessTime = Date.now()
                                     lastGoodValue = resolved
                                     setAndPropagate(state, resolved)
                                 },
                                 () => {
+                                    if (cancelled) return
                                     revalidating = false
                                     if (
                                         !isPastStaleIfErrorWindow() &&
@@ -219,6 +224,7 @@ export const subscribe = <V>(
                 }, state.maxAge)
 
                 const cleanup = () => {
+                    cancelled = true
                     clearInterval(interval)
                     for (const t of pendingTimeouts) clearTimeout(t)
                     pendingTimeouts.clear()

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -1,5 +1,6 @@
 import type { Atom } from "../types/Atom"
 import type { Family } from "../types/Family"
+import type { GlobalAtom } from "../types/GlobalAtom"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Subscription } from "../types/Subscription"
@@ -14,7 +15,6 @@ import { initSelector } from "./initSelector"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 import { mountTransitiveDeps } from "./mountAtom"
-import { storeFromStoreData } from "./storeFromStoreData"
 import { unsubscribe } from "./unsubscribe"
 
 const initSubscribers = <V>(state: State<V> | Family<V>, data: StoreData) => {
@@ -96,99 +96,145 @@ export const subscribe = <V>(
     let maxAgeCleanup: any
     if (subscribers.size === 1) {
         if (isAtom(state) && state.maxAge) {
-            const pendingTimeouts = new Set<Timer>()
-            let revalidating = false
-            let lastSuccessTime = Date.now()
-            const NO_VALUE = Symbol()
-            let lastGoodValue: any = NO_VALUE
-            const isPastStaleIfErrorWindow = () => {
-                if (!state.staleIfError) return true
-                const elapsed = Date.now() - lastSuccessTime
-                return elapsed >= state.maxAge! + state.staleIfError
-            }
-            const interval = setInterval(() => {
-                if (revalidating) return
-                if (typeof state.defaultValue !== "function") return
-                if (data.values.has(state)) {
-                    const currentValue = data.values.get(state)
-                    if (!isPromiseLike(currentValue)) {
-                        lastGoodValue = currentValue
+            const isGlobal = "stores" in state
+            const existing = isGlobal
+                ? (state as GlobalAtom)._maxAgeInterval
+                : undefined
+
+            if (existing) {
+                // Another store already owns the interval — just bump refCount
+                existing.refCount++
+                maxAgeCleanup = () => {
+                    existing.refCount--
+                    if (existing.refCount === 0) {
+                        existing.cleanup()
+                        ;(state as GlobalAtom)._maxAgeInterval = undefined
                     }
                 }
-                const value = state.defaultValue()
-                if (isPromiseLike(value)) {
-                    revalidating = true
-                    if (state.staleWhileRevalidate) {
-                        // SWR: keep stale value visible during revalidation
-                        const t = setTimeout(() => {
-                            pendingTimeouts.delete(t)
-                        }, state.staleWhileRevalidate)
-                        pendingTimeouts.add(t)
-                        value.then(
-                            (resolved: any) => {
-                                clearTimeout(t)
-                                pendingTimeouts.delete(t)
-                                revalidating = false
-                                lastSuccessTime = Date.now()
-                                lastGoodValue = resolved
-                                setValueInData(state, resolved, data)
-                                propagateUpdatedAtoms([state], data)
-                            },
-                            () => {
-                                clearTimeout(t)
-                                pendingTimeouts.delete(t)
-                                revalidating = false
-                                if (
-                                    state.staleIfError &&
-                                    isPastStaleIfErrorWindow()
-                                ) {
-                                    // Past staleIfError window: replace stale
-                                    // value with rejected promise so consumers
-                                    // see the error
-                                    setValueInData(state, value, data)
-                                    propagateUpdatedAtoms([state], data)
-                                }
-                                // No staleIfError or within window: keep stale
-                            },
-                        )
+            } else {
+                const pendingTimeouts = new Set<Timer>()
+                let revalidating = false
+                let lastSuccessTime = Date.now()
+                const NO_VALUE = Symbol()
+                let lastGoodValue: any = NO_VALUE
+                const isPastStaleIfErrorWindow = () => {
+                    if (!state.staleIfError) return true
+                    const elapsed = Date.now() - lastSuccessTime
+                    return elapsed >= state.maxAge! + state.staleIfError
+                }
+
+                // For global atoms, propagate to all stores; for regular atoms, just this store
+                const setAndPropagate = (atom: Atom, val: any) => {
+                    if (isGlobal) {
+                        const globalAtom = state as any
+                        for (const store of globalAtom.stores) {
+                            setValueInData(atom, val, store)
+                            propagateUpdatedAtoms([atom], store)
+                        }
                     } else {
-                        // No SWR: show loading state during revalidation
-                        setValueInData(state, value, data)
-                        propagateUpdatedAtoms([state], data)
-                        value.then(
-                            (resolved: any) => {
-                                revalidating = false
-                                lastSuccessTime = Date.now()
-                                lastGoodValue = resolved
-                                setValueInData(state, resolved, data)
-                                propagateUpdatedAtoms([state], data)
-                            },
-                            () => {
-                                revalidating = false
-                                if (
-                                    !isPastStaleIfErrorWindow() &&
-                                    lastGoodValue !== NO_VALUE
-                                ) {
-                                    // Within staleIfError window: restore last good value
-                                    setValueInData(state, lastGoodValue, data)
-                                    propagateUpdatedAtoms([state], data)
-                                }
-                                // Past window (or no staleIfError): leave
-                                // rejected promise in store; interval retries
-                            },
-                        )
+                        setValueInData(atom, val, data)
+                        propagateUpdatedAtoms([atom], data)
+                    }
+                }
+
+                // For global atoms, read the current value from any
+                // store in the set rather than the closed-over `data`
+                // which may become stale if that store is detached.
+                const getValueStore = (): StoreData => {
+                    if (isGlobal) {
+                        const stores = (state as any).stores as Set<StoreData>
+                        for (const s of stores) return s
+                    }
+                    return data
+                }
+
+                const interval = setInterval(() => {
+                    if (revalidating) return
+                    if (typeof state.defaultValue !== "function") return
+                    const valueStore = getValueStore()
+                    if (valueStore.values.has(state)) {
+                        const currentValue = valueStore.values.get(state)
+                        if (!isPromiseLike(currentValue)) {
+                            lastGoodValue = currentValue
+                        }
+                    }
+                    const value = state.defaultValue()
+                    if (isPromiseLike(value)) {
+                        revalidating = true
+                        if (state.staleWhileRevalidate) {
+                            // SWR: keep stale value visible during revalidation
+                            const t = setTimeout(() => {
+                                pendingTimeouts.delete(t)
+                            }, state.staleWhileRevalidate)
+                            pendingTimeouts.add(t)
+                            value.then(
+                                (resolved: any) => {
+                                    clearTimeout(t)
+                                    pendingTimeouts.delete(t)
+                                    revalidating = false
+                                    lastSuccessTime = Date.now()
+                                    lastGoodValue = resolved
+                                    setAndPropagate(state, resolved)
+                                },
+                                () => {
+                                    clearTimeout(t)
+                                    pendingTimeouts.delete(t)
+                                    revalidating = false
+                                    if (
+                                        state.staleIfError &&
+                                        isPastStaleIfErrorWindow()
+                                    ) {
+                                        setAndPropagate(state, value)
+                                    }
+                                },
+                            )
+                        } else {
+                            // No SWR: show loading state during revalidation
+                            setAndPropagate(state, value)
+                            value.then(
+                                (resolved: any) => {
+                                    revalidating = false
+                                    lastSuccessTime = Date.now()
+                                    lastGoodValue = resolved
+                                    setAndPropagate(state, resolved)
+                                },
+                                () => {
+                                    revalidating = false
+                                    if (
+                                        !isPastStaleIfErrorWindow() &&
+                                        lastGoodValue !== NO_VALUE
+                                    ) {
+                                        setAndPropagate(state, lastGoodValue)
+                                    }
+                                },
+                            )
+                        }
+                    } else {
+                        lastSuccessTime = Date.now()
+                        lastGoodValue = value
+                        setAndPropagate(state, value)
+                    }
+                }, state.maxAge)
+
+                const cleanup = () => {
+                    clearInterval(interval)
+                    for (const t of pendingTimeouts) clearTimeout(t)
+                    pendingTimeouts.clear()
+                }
+
+                if (isGlobal) {
+                    const entry = { cleanup, refCount: 1 }
+                    ;(state as GlobalAtom)._maxAgeInterval = entry
+                    maxAgeCleanup = () => {
+                        entry.refCount--
+                        if (entry.refCount === 0) {
+                            entry.cleanup()
+                            ;(state as GlobalAtom)._maxAgeInterval = undefined
+                        }
                     }
                 } else {
-                    lastSuccessTime = Date.now()
-                    lastGoodValue = value
-                    setValueInData(state, value, data)
-                    propagateUpdatedAtoms([state], data)
+                    maxAgeCleanup = cleanup
                 }
-            }, state.maxAge)
-            maxAgeCleanup = () => {
-                clearInterval(interval)
-                for (const t of pendingTimeouts) clearTimeout(t)
-                pendingTimeouts.clear()
             }
         }
         // Mount this state and all its transitive dependencies

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -105,6 +105,7 @@ export const subscribe = <V>(
                 // Another store already owns the interval — just bump refCount
                 existing.refCount++
                 maxAgeCleanup = () => {
+                    if (existing.refCount <= 0) return
                     existing.refCount--
                     if (existing.refCount === 0) {
                         existing.cleanup()
@@ -147,6 +148,7 @@ export const subscribe = <V>(
                     if (isGlobal) {
                         const stores = (state as any).stores as Set<StoreData>
                         for (const s of stores) return s
+                        // All stores detached — fall back to the original
                     }
                     return data
                 }
@@ -234,6 +236,7 @@ export const subscribe = <V>(
                     const entry = { cleanup, refCount: 1 }
                     ;(state as GlobalAtom).maxAgeInterval = entry
                     maxAgeCleanup = () => {
+                        if (entry.refCount <= 0) return
                         entry.refCount--
                         if (entry.refCount === 0) {
                             entry.cleanup()

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -14,6 +14,7 @@ import { initAtom } from "./initAtom"
 import { initSelector } from "./initSelector"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
+import { setMaxAgeCleanup } from "./maxAgeCleanups"
 import { mountTransitiveDeps } from "./mountAtom"
 import { unsubscribe } from "./unsubscribe"
 
@@ -93,7 +94,6 @@ export const subscribe = <V>(
         }
     }
     subscribers.add(subscription)
-    let maxAgeCleanup: any
     if (subscribers.size === 1) {
         if (isAtom(state) && state.maxAge) {
             const isGlobal = "stores" in state
@@ -104,7 +104,7 @@ export const subscribe = <V>(
             if (existing) {
                 // Another store already owns the interval — just bump refCount
                 existing.refCount++
-                maxAgeCleanup = () => {
+                setMaxAgeCleanup(data, state, () => {
                     if (existing.refCount <= 0) return
                     existing.refCount--
                     if (existing.refCount === 0) {
@@ -113,7 +113,7 @@ export const subscribe = <V>(
                             ;(state as GlobalAtom).maxAgeInterval = undefined
                         }
                     }
-                }
+                })
             } else {
                 const pendingTimeouts = new Set<Timer>()
                 let revalidating = false
@@ -235,7 +235,7 @@ export const subscribe = <V>(
                 if (isGlobal) {
                     const entry = { cleanup, refCount: 1 }
                     ;(state as GlobalAtom).maxAgeInterval = entry
-                    maxAgeCleanup = () => {
+                    setMaxAgeCleanup(data, state, () => {
                         if (entry.refCount <= 0) return
                         entry.refCount--
                         if (entry.refCount === 0) {
@@ -244,9 +244,9 @@ export const subscribe = <V>(
                                 ;(state as GlobalAtom).maxAgeInterval = undefined
                             }
                         }
-                    }
+                    })
                 } else {
-                    maxAgeCleanup = cleanup
+                    setMaxAgeCleanup(data, state, cleanup)
                 }
             }
         }
@@ -268,6 +268,6 @@ export const subscribe = <V>(
             // TODO: Test this scenario
             parentUnsubscribe()
         }
-        unsubscribe(state, subscription, data, maxAgeCleanup)
+        unsubscribe(state, subscription, data)
     }
 }

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -1,12 +1,12 @@
 import type { Atom } from "../types/Atom"
 import type { Family } from "../types/Family"
-import type { GlobalAtom } from "../types/GlobalAtom"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Subscription } from "../types/Subscription"
 import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamily } from "../utils/isFamily"
+import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
 import { isSelectorFamily } from "../utils/isSelectorFamily"
@@ -96,10 +96,8 @@ export const subscribe = <V>(
     subscribers.add(subscription)
     if (subscribers.size === 1) {
         if (isAtom(state) && state.maxAge) {
-            const isGlobal = "stores" in state
-            const existing = isGlobal
-                ? (state as GlobalAtom).maxAgeInterval
-                : undefined
+            const globalState = isGlobalAtom(state) ? state : undefined
+            const existing = globalState?.maxAgeInterval
 
             if (existing) {
                 // Another store already owns the interval — just bump refCount
@@ -109,8 +107,8 @@ export const subscribe = <V>(
                     existing.refCount--
                     if (existing.refCount === 0) {
                         existing.cleanup()
-                        if ((state as GlobalAtom).maxAgeInterval === existing) {
-                            ;(state as GlobalAtom).maxAgeInterval = undefined
+                        if (globalState.maxAgeInterval === existing) {
+                            globalState.maxAgeInterval = undefined
                         }
                     }
                 })
@@ -129,9 +127,8 @@ export const subscribe = <V>(
 
                 // For global atoms, propagate to all stores; for regular atoms, just this store
                 const setAndPropagate = (atom: Atom, val: any) => {
-                    if (isGlobal) {
-                        const globalAtom = state as any
-                        for (const store of globalAtom.stores) {
+                    if (globalState) {
+                        for (const store of globalState.stores) {
                             setValueInData(atom, val, store)
                             propagateUpdatedAtoms([atom], store)
                         }
@@ -145,9 +142,8 @@ export const subscribe = <V>(
                 // store in the set rather than the closed-over `data`
                 // which may become stale if that store is detached.
                 const getValueStore = (): StoreData => {
-                    if (isGlobal) {
-                        const stores = (state as any).stores as Set<StoreData>
-                        for (const s of stores) return s
+                    if (globalState) {
+                        for (const s of globalState.stores) return s
                         // All stores detached — fall back to the original
                     }
                     return data
@@ -232,16 +228,16 @@ export const subscribe = <V>(
                     pendingTimeouts.clear()
                 }
 
-                if (isGlobal) {
+                if (globalState) {
                     const entry = { cleanup, refCount: 1 }
-                    ;(state as GlobalAtom).maxAgeInterval = entry
+                    globalState.maxAgeInterval = entry
                     setMaxAgeCleanup(data, state, () => {
                         if (entry.refCount <= 0) return
                         entry.refCount--
                         if (entry.refCount === 0) {
                             entry.cleanup()
-                            if ((state as GlobalAtom).maxAgeInterval === entry) {
-                                ;(state as GlobalAtom).maxAgeInterval = undefined
+                            if (globalState.maxAgeInterval === entry) {
+                                globalState.maxAgeInterval = undefined
                             }
                         }
                     })

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -108,7 +108,9 @@ export const subscribe = <V>(
                     existing.refCount--
                     if (existing.refCount === 0) {
                         existing.cleanup()
-                        ;(state as GlobalAtom).maxAgeInterval = undefined
+                        if ((state as GlobalAtom).maxAgeInterval === existing) {
+                            ;(state as GlobalAtom).maxAgeInterval = undefined
+                        }
                     }
                 }
             } else {
@@ -229,7 +231,9 @@ export const subscribe = <V>(
                         entry.refCount--
                         if (entry.refCount === 0) {
                             entry.cleanup()
-                            ;(state as GlobalAtom).maxAgeInterval = undefined
+                            if ((state as GlobalAtom).maxAgeInterval === entry) {
+                                ;(state as GlobalAtom).maxAgeInterval = undefined
+                            }
                         }
                     }
                 } else {

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -98,7 +98,7 @@ export const subscribe = <V>(
         if (isAtom(state) && state.maxAge) {
             const isGlobal = "stores" in state
             const existing = isGlobal
-                ? (state as GlobalAtom)._maxAgeInterval
+                ? (state as GlobalAtom).maxAgeInterval
                 : undefined
 
             if (existing) {
@@ -108,7 +108,7 @@ export const subscribe = <V>(
                     existing.refCount--
                     if (existing.refCount === 0) {
                         existing.cleanup()
-                        ;(state as GlobalAtom)._maxAgeInterval = undefined
+                        ;(state as GlobalAtom).maxAgeInterval = undefined
                     }
                 }
             } else {
@@ -224,12 +224,12 @@ export const subscribe = <V>(
 
                 if (isGlobal) {
                     const entry = { cleanup, refCount: 1 }
-                    ;(state as GlobalAtom)._maxAgeInterval = entry
+                    ;(state as GlobalAtom).maxAgeInterval = entry
                     maxAgeCleanup = () => {
                         entry.refCount--
                         if (entry.refCount === 0) {
                             entry.cleanup()
-                            ;(state as GlobalAtom)._maxAgeInterval = undefined
+                            ;(state as GlobalAtom).maxAgeInterval = undefined
                         }
                     }
                 } else {

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -2,13 +2,13 @@ import type { Family } from "../types/Family"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Subscription } from "../types/Subscription"
+import { getMaxAgeCleanup, deleteMaxAgeCleanup } from "./maxAgeCleanups"
 import { isTransitivelySubscribed, unmountOrphanedDeps } from "./mountAtom"
 
 export const unsubscribe = <V>(
     state: State<V> | Family<V>,
     subscription: Subscription,
     data: StoreData,
-    maxAgeCleanup?: any,
 ) => {
     const subscribers = data.subscriptions.get(state)
     if (subscribers) {
@@ -26,7 +26,11 @@ export const unsubscribe = <V>(
             }
         }
         if (subscribers.size === 0) {
-            if (maxAgeCleanup) maxAgeCleanup()
+            const maxAgeCleanup = getMaxAgeCleanup(data, state)
+            if (maxAgeCleanup) {
+                maxAgeCleanup()
+                deleteMaxAgeCleanup(data, state)
+            }
             data.subscriptions.delete(state)
             // Unmount this state and any transitive dependencies that are
             // no longer reachable from any subscriber.

--- a/packages/valdres/src/types/GlobalAtom.ts
+++ b/packages/valdres/src/types/GlobalAtom.ts
@@ -15,5 +15,5 @@ export type GlobalAtom<Value = unknown> = Atom<Value> & {
     getSelf: GlobalAtomGetSelfFunc<Value>
     detach: (storeData: StoreData) => void
     stores: Set<StoreData>
-    _maxAgeInterval: MaxAgeInterval | undefined
+    maxAgeInterval: MaxAgeInterval | undefined
 }

--- a/packages/valdres/src/types/GlobalAtom.ts
+++ b/packages/valdres/src/types/GlobalAtom.ts
@@ -15,5 +15,5 @@ export type GlobalAtom<Value = unknown> = Atom<Value> & {
     getSelf: GlobalAtomGetSelfFunc<Value>
     detach: (storeData: StoreData) => void
     stores: Set<StoreData>
-    maxAgeInterval: MaxAgeInterval | undefined
+    maxAgeInterval?: MaxAgeInterval
 }

--- a/packages/valdres/src/types/GlobalAtom.ts
+++ b/packages/valdres/src/types/GlobalAtom.ts
@@ -4,10 +4,16 @@ import type { GlobalAtomResetSelfFunc } from "./GlobalAtomResetSelfFunc"
 import type { GlobalAtomSetSelfFunc } from "./GlobalAtomSetSelfFunc"
 import type { StoreData } from "./StoreData"
 
+export type MaxAgeInterval = {
+    cleanup: () => void
+    refCount: number
+}
+
 export type GlobalAtom<Value = unknown> = Atom<Value> & {
     setSelf: GlobalAtomSetSelfFunc<Value>
     resetSelf: GlobalAtomResetSelfFunc
     getSelf: GlobalAtomGetSelfFunc<Value>
     detach: (storeData: StoreData) => void
     stores: Set<StoreData>
+    _maxAgeInterval: MaxAgeInterval | undefined
 }

--- a/packages/valdres/src/utils/isGlobalAtom.ts
+++ b/packages/valdres/src/utils/isGlobalAtom.ts
@@ -1,0 +1,4 @@
+import type { GlobalAtom } from "../types/GlobalAtom"
+
+export const isGlobalAtom = <V>(state: any): state is GlobalAtom<V> =>
+    Object.hasOwn(state, "stores")


### PR DESCRIPTION
## Summary
- Global atoms with `maxAge` were creating one `setInterval` per subscribing store, causing `defaultValue()` to fire N times per cycle instead of once
- Hoist the interval onto the atom's `_maxAgeInterval` property with refcounting so only one interval runs regardless of how many stores subscribe
- On tick, propagate the revalidated value to all stores via `setAndPropagate`
- Clear the interval on `resetSelf` to prevent leaked timers
- Read current values from the live `stores` set instead of a closed-over store reference that could go stale on detach

## Test plan
- [x] Added test: global atom with maxAge only calls defaultValue once per interval across two stores
- [x] Added test: resetSelf clears the maxAge interval (no revalidation after reset)
- [x] All 201 existing tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)