### PR TITLE
Fix flaky atom maxAge revalidation test

### DIFF
--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -408,8 +408,7 @@ describe("atom", () => {
 
         // Resolve initial fetch
         resolvers[0](100)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(100)
+        await waitFor(() => expect(store1.get(atom1)).toBe(100))
 
         // Wait for maxAge to expire and trigger revalidation
         await waitFor(() => expect(fetchCount).toBe(2))
@@ -419,8 +418,7 @@ describe("atom", () => {
 
         // Resolve revalidation
         resolvers[1](200)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(200)
+        await waitFor(() => expect(store1.get(atom1)).toBe(200))
 
         unsubscribe()
     })


### PR DESCRIPTION
## Summary
- `atom > atom with maxAge async (no SWR) shows promise during revalidation` intermittently fails in CI with `Expected: 200 / Received: Promise { <pending> }` (e.g. run [24860418784](https://github.com/eigilsagafos/valdres/actions/runs/24860418784/job/72784245126))
- Root cause: `await wait(1)` after resolving the promise isn't always enough for the store to commit the value on loaded CI runners
- Replace the two `wait(1)` + direct-expect pairs with `waitFor(() => expect(...))` so the assertion retries until it passes, matching the pattern already used elsewhere in this test

## Test plan
- [x] `bun test src/atom.test.ts -t "shows promise during revalidation"` passes locally