### PR TITLE
Add @valdres/browser-screen package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,19 @@
         "valdres": "0.2.0-pre.28",
       },
     },
+    "packages/@valdres/browser-screen": {
+      "name": "@valdres/browser-screen",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/color-mode": {
       "name": "@valdres/color-mode",
       "version": "0.2.0-pre.28",
@@ -961,6 +974,8 @@
     "@valdres/browser-keyboard": ["@valdres/browser-keyboard@workspace:packages/@valdres/browser-keyboard"],
 
     "@valdres/browser-online": ["@valdres/browser-online@workspace:packages/@valdres/browser-online"],
+
+    "@valdres/browser-screen": ["@valdres/browser-screen@workspace:packages/@valdres/browser-screen"],
 
     "@valdres/color-mode": ["@valdres/color-mode@workspace:packages/@valdres/color-mode"],
 
@@ -2817,6 +2832,10 @@
     "@valdres/browser-online/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-online/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-screen/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-screen/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/public-ip/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-screen/bunfig.toml
+++ b/packages/@valdres/browser-screen/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-screen/dev/index.html
+++ b/packages/@valdres/browser-screen/dev/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-screen demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+            }
+            dl {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 0.4rem 1.25rem;
+                margin: 0;
+                font-size: 0.95rem;
+            }
+            dt {
+                color: #888;
+            }
+            dd {
+                margin: 0;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            }
+            .hint {
+                margin-top: 1rem;
+                font-size: 0.85rem;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-screen</h1>
+        <p class="muted">
+            Reactive wrapper for <code>window.screen</code>. Resize the window,
+            rotate the screen, or drag the window to a display with a different
+            pixel density to see updates.
+        </p>
+
+        <div class="card">
+            <dl id="screen"></dl>
+        </div>
+
+        <p class="hint muted">
+            Note: pure arrangement changes (e.g. rearranging monitors in System
+            Settings without moving this window) are not detectable through this
+            API — use
+            <code>@valdres/browser-window-management</code> for that.
+        </p>
+
+        <script>
+            // valdres reads process.env.VALDRES_VERSION at import time
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.ts"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-screen/dev/index.ts
+++ b/packages/@valdres/browser-screen/dev/index.ts
@@ -1,0 +1,26 @@
+import { store } from "valdres"
+import { screenAtom } from "../src"
+
+const s = store()
+const el = document.getElementById("screen")!
+
+const field = (label: string, value: string | number) =>
+    `<dt>${label}</dt><dd>${value}</dd>`
+
+const render = () => {
+    const info = s.get(screenAtom)
+    el.innerHTML = [
+        field("size", `${info.width} × ${info.height}`),
+        field("avail", `${info.availWidth} × ${info.availHeight}`),
+        field("devicePixelRatio", info.devicePixelRatio),
+        field("colorDepth", `${info.colorDepth}-bit`),
+        field("pixelDepth", `${info.pixelDepth}-bit`),
+        field(
+            "orientation",
+            `${info.orientationType} @ ${info.orientationAngle}°`,
+        ),
+    ].join("")
+}
+
+s.sub(screenAtom, render)
+render()

--- a/packages/@valdres/browser-screen/dev/server.ts
+++ b/packages/@valdres/browser-screen/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3016),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-screen demo: ${server.url}`)

--- a/packages/@valdres/browser-screen/package.json
+++ b/packages/@valdres/browser-screen/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@valdres/browser-screen",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
+++ b/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { screenAtom } from "./screenAtom"
+
+describe("screenAtom", () => {
+    test("initial value reflects window.screen", () => {
+        const s = store()
+        const info = s.get(screenAtom)
+        expect(info.width).toBe(window.screen.width)
+        expect(info.height).toBe(window.screen.height)
+        expect(info.devicePixelRatio).toBe(window.devicePixelRatio)
+    })
+
+    test("updates atom when window resize fires", () => {
+        const s = store()
+        // touch atom so subscribe fires
+        s.get(screenAtom)
+
+        Object.defineProperty(window.screen, "width", {
+            value: 3840,
+            configurable: true,
+        })
+        Object.defineProperty(window.screen, "height", {
+            value: 2160,
+            configurable: true,
+        })
+        window.dispatchEvent(new Event("resize"))
+
+        const info = s.get(screenAtom)
+        expect(info.width).toBe(3840)
+        expect(info.height).toBe(2160)
+    })
+})

--- a/packages/@valdres/browser-screen/src/atoms/screenAtom.ts
+++ b/packages/@valdres/browser-screen/src/atoms/screenAtom.ts
@@ -1,0 +1,10 @@
+import { atom } from "valdres"
+import type { ScreenInfo } from "../../types/ScreenInfo"
+import { readScreen } from "../lib/readScreen"
+import { subscribe } from "../lib/subscribe"
+
+export const screenAtom = atom<ScreenInfo>(readScreen, {
+    global: true,
+    name: "@valdres/browser-screen/screen",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-screen/src/index.ts
+++ b/packages/@valdres/browser-screen/src/index.ts
@@ -1,0 +1,3 @@
+export { screenAtom } from "./atoms/screenAtom"
+
+export type { ScreenInfo } from "../types/ScreenInfo"

--- a/packages/@valdres/browser-screen/src/lib/readScreen.test.ts
+++ b/packages/@valdres/browser-screen/src/lib/readScreen.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { readScreen } from "./readScreen"
+
+describe("readScreen", () => {
+    test("returns a plain snapshot of window.screen + devicePixelRatio", () => {
+        const info = readScreen()
+        expect(info.width).toBe(window.screen.width)
+        expect(info.height).toBe(window.screen.height)
+        expect(info.availWidth).toBe(window.screen.availWidth)
+        expect(info.availHeight).toBe(window.screen.availHeight)
+        expect(info.devicePixelRatio).toBe(window.devicePixelRatio)
+        expect(typeof info.orientationType).toBe("string")
+        expect(typeof info.orientationAngle).toBe("number")
+    })
+})

--- a/packages/@valdres/browser-screen/src/lib/readScreen.ts
+++ b/packages/@valdres/browser-screen/src/lib/readScreen.ts
@@ -1,0 +1,29 @@
+import type { ScreenInfo } from "../../types/ScreenInfo"
+
+const EMPTY: ScreenInfo = {
+    width: 0,
+    height: 0,
+    availWidth: 0,
+    availHeight: 0,
+    colorDepth: 24,
+    pixelDepth: 24,
+    devicePixelRatio: 1,
+    orientationType: "landscape-primary",
+    orientationAngle: 0,
+}
+
+export const readScreen = (): ScreenInfo => {
+    if (typeof window === "undefined" || !window.screen) return EMPTY
+    const s = window.screen
+    return {
+        width: s.width,
+        height: s.height,
+        availWidth: s.availWidth,
+        availHeight: s.availHeight,
+        colorDepth: s.colorDepth,
+        pixelDepth: s.pixelDepth,
+        devicePixelRatio: window.devicePixelRatio,
+        orientationType: s.orientation?.type ?? "landscape-primary",
+        orientationAngle: s.orientation?.angle ?? 0,
+    }
+}

--- a/packages/@valdres/browser-screen/src/lib/readScreen.ts
+++ b/packages/@valdres/browser-screen/src/lib/readScreen.ts
@@ -1,6 +1,6 @@
 import type { ScreenInfo } from "../../types/ScreenInfo"
 
-const EMPTY: ScreenInfo = {
+const EMPTY: ScreenInfo = Object.freeze({
     width: 0,
     height: 0,
     availWidth: 0,
@@ -8,9 +8,9 @@ const EMPTY: ScreenInfo = {
     colorDepth: 24,
     pixelDepth: 24,
     devicePixelRatio: 1,
-    orientationType: "landscape-primary",
+    orientationType: "landscape-primary" as OrientationType,
     orientationAngle: 0,
-}
+})
 
 export const readScreen = (): ScreenInfo => {
     if (typeof window === "undefined" || !window.screen) return EMPTY

--- a/packages/@valdres/browser-screen/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-screen/src/lib/subscribe.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { screenAtom } from "../atoms/screenAtom"
+import { subscribe } from "./subscribe"
+
+const setDPR = (value: number) =>
+    Object.defineProperty(window, "devicePixelRatio", {
+        value,
+        configurable: true,
+    })
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        setDPR(1)
+    })
+
+    test("updates screenAtom when matchMedia resolution change fires", () => {
+        let current: (EventTarget & { matches: boolean; media: string }) | null =
+            null
+        window.matchMedia = ((query: string) => {
+            const mq = new EventTarget() as EventTarget & {
+                matches: boolean
+                media: string
+            }
+            mq.matches = true
+            mq.media = query
+            current = mq
+            return mq as unknown as MediaQueryList
+        }) as typeof window.matchMedia
+
+        const s = store()
+        const cleanup = subscribe()
+
+        setDPR(2)
+        current?.dispatchEvent(new Event("change"))
+        expect(s.get(screenAtom).devicePixelRatio).toBe(2)
+
+        // listener should be rebound to the new DPR
+        setDPR(3)
+        current?.dispatchEvent(new Event("change"))
+        expect(s.get(screenAtom).devicePixelRatio).toBe(3)
+        expect(current?.media).toBe("(resolution: 3dppx)")
+
+        cleanup?.()
+    })
+
+    test("cleanup removes the resize listener", () => {
+        const s = store()
+        const cleanup = subscribe()
+
+        setDPR(2)
+        window.dispatchEvent(new Event("resize"))
+        expect(s.get(screenAtom).devicePixelRatio).toBe(2)
+
+        cleanup?.()
+
+        setDPR(4)
+        window.dispatchEvent(new Event("resize"))
+        expect(s.get(screenAtom).devicePixelRatio).toBe(2)
+    })
+})

--- a/packages/@valdres/browser-screen/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-screen/src/lib/subscribe.ts
@@ -17,19 +17,27 @@ export const subscribe = () => {
         update()
         bindDPR()
     }
+    const addMqListener = (mq: MediaQueryList, fn: () => void) => {
+        if (mq.addEventListener) mq.addEventListener("change", fn)
+        else mq.addListener?.(fn)
+    }
+    const removeMqListener = (mq: MediaQueryList, fn: () => void) => {
+        if (mq.removeEventListener) mq.removeEventListener("change", fn)
+        else mq.removeListener?.(fn)
+    }
     const bindDPR = () => {
         if (typeof window.matchMedia !== "function") return
-        dprMq?.removeEventListener("change", onDPRChange)
+        if (dprMq) removeMqListener(dprMq, onDPRChange)
         dprMq = window.matchMedia(
             `(resolution: ${window.devicePixelRatio}dppx)`,
         )
-        dprMq.addEventListener("change", onDPRChange)
+        addMqListener(dprMq, onDPRChange)
     }
     bindDPR()
 
     return () => {
         window.removeEventListener("resize", update)
         orientation?.removeEventListener?.("change", update)
-        dprMq?.removeEventListener("change", onDPRChange)
+        if (dprMq) removeMqListener(dprMq, onDPRChange)
     }
 }

--- a/packages/@valdres/browser-screen/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-screen/src/lib/subscribe.ts
@@ -1,0 +1,35 @@
+import { screenAtom } from "../atoms/screenAtom"
+import { readScreen } from "./readScreen"
+
+const update = () => screenAtom.setSelf(readScreen())
+
+export const subscribe = () => {
+    if (typeof window === "undefined") return
+    update()
+    window.addEventListener("resize", update)
+    const orientation = window.screen?.orientation
+    orientation?.addEventListener?.("change", update)
+
+    // `(resolution: Xdppx)` only fires when crossing the exact threshold,
+    // so rebind to the new DPR after each change.
+    let dprMq: MediaQueryList | null = null
+    const onDPRChange = () => {
+        update()
+        bindDPR()
+    }
+    const bindDPR = () => {
+        if (typeof window.matchMedia !== "function") return
+        dprMq?.removeEventListener("change", onDPRChange)
+        dprMq = window.matchMedia(
+            `(resolution: ${window.devicePixelRatio}dppx)`,
+        )
+        dprMq.addEventListener("change", onDPRChange)
+    }
+    bindDPR()
+
+    return () => {
+        window.removeEventListener("resize", update)
+        orientation?.removeEventListener?.("change", update)
+        dprMq?.removeEventListener("change", onDPRChange)
+    }
+}

--- a/packages/@valdres/browser-screen/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-screen/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-screen/tsconfig.json
+++ b/packages/@valdres/browser-screen/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dev", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-screen/types/ScreenInfo.ts
+++ b/packages/@valdres/browser-screen/types/ScreenInfo.ts
@@ -1,0 +1,11 @@
+export interface ScreenInfo {
+    width: number
+    height: number
+    availWidth: number
+    availHeight: number
+    colorDepth: number
+    pixelDepth: number
+    devicePixelRatio: number
+    orientationType: OrientationType
+    orientationAngle: number
+}


### PR DESCRIPTION
## Summary
- Adds `@valdres/browser-screen`, a reactive wrapper around the legacy `window.screen` + `devicePixelRatio` APIs.
- Exports `screenAtom` with a plain snapshot (width, height, availWidth/Height, colorDepth, DPR, orientation).
- Listens to `resize`, `screen.orientation` change, and a `matchMedia('(resolution: Xdppx)')` query so DPR changes (moving between displays with different scaling) trigger updates.

## Test plan
- [x] Unit tests for snapshot shape, matchMedia-driven DPR updates, and subscribe cleanup (5 tests)
- [ ] Manual check: run `bun run dev` in the package, resize the window and drag between displays with different scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)