### PR TITLE
Fix atom test waitFor to have a real timeout

### DIFF
--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -4,13 +4,18 @@ import { selector } from "./selector"
 import { store } from "./store"
 import { wait } from "../test/utils/wait"
 
-const waitFor = async (callback, count = 0) => {
-    try {
-        callback()
-        return
-    } catch (e) {
-        await wait(1)
-        return waitFor(callback, count++)
+const waitFor = async (callback: () => void, timeoutMs = 2000) => {
+    const deadline = Date.now() + timeoutMs
+    let lastError: unknown
+    while (true) {
+        try {
+            callback()
+            return
+        } catch (e) {
+            lastError = e
+            if (Date.now() >= deadline) throw lastError
+            await wait(5)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
The local `waitFor` in `packages/valdres/src/atom.test.ts` recursed with no retry cap, so any assertion that didn't settle fast enough spun until bun's 5000ms test timeout killed the whole test — with no useful error surfaced. That's what's producing the `atom > atom with maxAge async (no SWR) shows promise during revalidation [5000.07ms]` flake on CI (seen on PR #83).

This replaces it with a deadline-based loop that throws the actual last assertion error after 2s, so flakes become real failures we can debug, and CI doesn't eat a whole 5s per hang.

## Test plan
- [x] `bun test packages/valdres/src/atom.test.ts` — 36/36 pass, ran locally 10x
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)