### PR TITLE
Add @valdres/browser-focus package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,24 @@
         "typescript": "5.9.2",
       },
     },
+    "packages/@valdres/browser-focus": {
+      "name": "@valdres/browser-focus",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-geolocation": {
       "name": "@valdres/browser-geolocation",
       "version": "0.2.0-pre.28",
@@ -971,7 +989,9 @@
 
     "@types/prop-types": ["@types/prop-types@15.7.13", "", {}, "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="],
 
-    "@types/react": ["@types/react@18.3.8", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q=="],
+    "@types/react": ["@types/react@19.1.12", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.1.9", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -996,6 +1016,8 @@
     "@valdres-react/panable": ["@valdres-react/panable@workspace:packages/@valdres-react/panable"],
 
     "@valdres-react/recoil": ["@valdres-react/recoil@workspace:packages/@valdres-react/recoil"],
+
+    "@valdres/browser-focus": ["@valdres/browser-focus@workspace:packages/@valdres/browser-focus"],
 
     "@valdres/browser-geolocation": ["@valdres/browser-geolocation@workspace:packages/@valdres/browser-geolocation"],
 
@@ -2859,6 +2881,10 @@
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.25.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.7", "@babel/helper-validator-identifier": "^7.25.7", "to-fast-properties": "^2.0.0" } }, "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ=="],
 
+    "@valdres/browser-focus/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-focus/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
     "@valdres/browser-geolocation/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-geolocation/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
@@ -2874,6 +2900,8 @@
     "@valdres/browser-window/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-window/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/documentation/@types/react": ["@types/react@18.3.8", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q=="],
 
     "@valdres/public-ip/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-focus/bunfig.toml
+++ b/packages/@valdres/browser-focus/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-focus/dev/index.html
+++ b/packages/@valdres/browser-focus/dev/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-focus demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-focus</h1>
+        <p class="muted">
+            Reactive wrapper for <code>document.hasFocus()</code>. Click
+            another window or tab to blur, click back to focus.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            // valdres reads process.env.VALDRES_VERSION at import time
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-focus/dev/index.tsx
+++ b/packages/@valdres/browser-focus/dev/index.tsx
@@ -1,0 +1,47 @@
+import { StrictMode, useEffect, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { focusAtom } from "../src"
+
+type Entry = { at: string; focused: boolean }
+
+const Demo = () => {
+    const focused = useValue(focusAtom)
+    const [log, setLog] = useState<Entry[]>([])
+
+    useEffect(() => {
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), focused },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [focused])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${focused ? " on" : ""}`} />
+                <span className="label">
+                    {focused ? "focused" : "blurred"}
+                </span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.focused ? "focus" : "blur"}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-focus/dev/server.ts
+++ b/packages/@valdres/browser-focus/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3018),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-focus demo: ${server.url}`)

--- a/packages/@valdres/browser-focus/package.json
+++ b/packages/@valdres/browser-focus/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-focus",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-focus/src/atoms/focusAtom.test.ts
+++ b/packages/@valdres/browser-focus/src/atoms/focusAtom.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import { store } from "valdres"
+import { focusAtom } from "./focusAtom"
+
+const setHasFocus = (value: boolean) => {
+    Object.defineProperty(document, "hasFocus", {
+        value: () => value,
+        configurable: true,
+    })
+}
+
+describe("focusAtom", () => {
+    afterAll(() => setHasFocus(true))
+
+    test("first read evaluates lazily and onInit wires event listeners", () => {
+        setHasFocus(false)
+        const s = store()
+        expect(s.get(focusAtom)).toBe(false)
+
+        window.dispatchEvent(new Event("focus"))
+        expect(s.get(focusAtom)).toBe(true)
+
+        window.dispatchEvent(new Event("blur"))
+        expect(s.get(focusAtom)).toBe(false)
+    })
+})

--- a/packages/@valdres/browser-focus/src/atoms/focusAtom.ts
+++ b/packages/@valdres/browser-focus/src/atoms/focusAtom.ts
@@ -1,0 +1,13 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+const getInitial = () => {
+    if (typeof document === "undefined") return true
+    return document.hasFocus()
+}
+
+export const focusAtom = atom<boolean>(getInitial, {
+    global: true,
+    name: "@valdres/browser-focus/focus",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-focus/src/index.ts
+++ b/packages/@valdres/browser-focus/src/index.ts
@@ -1,0 +1,1 @@
+export { focusAtom } from "./atoms/focusAtom"

--- a/packages/@valdres/browser-focus/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-focus/src/lib/subscribe.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { store } from "valdres"
+import { subscribe } from "./subscribe"
+import { focusAtom } from "../atoms/focusAtom"
+
+const setHasFocus = (value: boolean) => {
+    Object.defineProperty(document, "hasFocus", {
+        value: () => value,
+        configurable: true,
+    })
+}
+
+describe("subscribe", () => {
+    afterEach(() => setHasFocus(true))
+
+    test("syncs initial value from document.hasFocus()", () => {
+        setHasFocus(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(focusAtom)).toBe(false)
+        cleanup?.()
+    })
+
+    test("updates atom when focus/blur events fire", () => {
+        setHasFocus(true)
+        const s = store()
+        const cleanup = subscribe()
+
+        expect(s.get(focusAtom)).toBe(true)
+
+        window.dispatchEvent(new Event("blur"))
+        expect(s.get(focusAtom)).toBe(false)
+
+        window.dispatchEvent(new Event("focus"))
+        expect(s.get(focusAtom)).toBe(true)
+
+        cleanup?.()
+    })
+
+    test("cleanup removes listeners so later events do not update atom", () => {
+        setHasFocus(true)
+        const s = store()
+        const cleanup = subscribe()
+        cleanup?.()
+
+        window.dispatchEvent(new Event("blur"))
+        expect(s.get(focusAtom)).toBe(true)
+    })
+})

--- a/packages/@valdres/browser-focus/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-focus/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import { focusAtom } from "../atoms/focusAtom"
+
+const sync = () => focusAtom.setSelf(document.hasFocus())
+const onFocus = () => focusAtom.setSelf(true)
+const onBlur = () => focusAtom.setSelf(false)
+
+export const subscribe = () => {
+    if (typeof window === "undefined") return
+    sync()
+    window.addEventListener("focus", onFocus)
+    window.addEventListener("blur", onBlur)
+    return () => {
+        window.removeEventListener("focus", onFocus)
+        window.removeEventListener("blur", onBlur)
+    }
+}

--- a/packages/@valdres/browser-focus/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-focus/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-focus/tsconfig.json
+++ b/packages/@valdres/browser-focus/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## Summary
- New `@valdres/browser-focus` package: reactive `focusAtom` tracking `document.hasFocus()`, updated via `focus`/`blur` listeners
- Follows the `browser-online` pattern (global atom, `onInit`-wired subscribe, module-level listeners for dedupe)
- Ships a React-based `bun run dev` demo using `valdres-react`'s `Provider` + `useValue`

## Test plan
- [x] `bun test` in `packages/@valdres/browser-focus` — 4 tests pass (atom + subscribe)
- [x] `bun run build` produces `dist/index.js`
- [x] `bun run dev` serves the HTML and bundles the TSX entry (verified HTTP 200)
- [ ] Manual browser check: click away / back to see the focus/blur indicator and event log update

🤖 Generated with [Claude Code](https://claude.com/claude-code)