### PR TITLE
Add @valdres/browser-visibility package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -189,6 +189,24 @@
         "valdres": "0.2.0-pre.28",
       },
     },
+    "packages/@valdres/browser-visibility": {
+      "name": "@valdres/browser-visibility",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-window": {
       "name": "@valdres/browser-window",
       "version": "0.2.0-pre.28",
@@ -1041,6 +1059,8 @@
     "@valdres/browser-screen": ["@valdres/browser-screen@workspace:packages/@valdres/browser-screen"],
 
     "@valdres/browser-screen-details": ["@valdres/browser-screen-details@workspace:packages/@valdres/browser-screen-details"],
+
+    "@valdres/browser-visibility": ["@valdres/browser-visibility@workspace:packages/@valdres/browser-visibility"],
 
     "@valdres/browser-window": ["@valdres/browser-window@workspace:packages/@valdres/browser-window"],
 
@@ -2915,6 +2935,10 @@
     "@valdres/browser-screen-details/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-screen-details/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-visibility/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-visibility/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-window/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-focus/dev/index.tsx
+++ b/packages/@valdres/browser-focus/dev/index.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useState } from "react"
+import { StrictMode, useEffect, useRef, useState } from "react"
 import { createRoot } from "react-dom/client"
 import { Provider, useValue } from "valdres-react"
 import { focusAtom } from "../src"
@@ -8,8 +8,11 @@ type Entry = { at: string; focused: boolean }
 const Demo = () => {
     const focused = useValue(focusAtom)
     const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<boolean | null>(null)
 
     useEffect(() => {
+        if (lastLogged.current === focused) return
+        lastLogged.current = focused
         setLog(prev =>
             [
                 { at: new Date().toLocaleTimeString(), focused },

--- a/packages/@valdres/browser-visibility/bunfig.toml
+++ b/packages/@valdres/browser-visibility/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-visibility/dev/index.html
+++ b/packages/@valdres/browser-visibility/dev/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-visibility demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-visibility</h1>
+        <p class="muted">
+            Reactive wrapper for <code>document.visibilityState</code>. Switch
+            to another tab or minimize the window to flip to
+            <code>hidden</code>; clicking another app while this tab stays
+            on-screen does <em>not</em> change visibility (use
+            <code>@valdres/browser-focus</code> for that).
+        </p>
+        <div id="root"></div>
+
+        <script>
+            // valdres reads process.env.VALDRES_VERSION at import time
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-visibility/dev/index.tsx
+++ b/packages/@valdres/browser-visibility/dev/index.tsx
@@ -1,0 +1,47 @@
+import { StrictMode, useEffect, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { visibilityAtom } from "../src"
+
+type Entry = { at: string; visibility: DocumentVisibilityState }
+
+const Demo = () => {
+    const visibility = useValue(visibilityAtom)
+    const [log, setLog] = useState<Entry[]>([])
+
+    useEffect(() => {
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), visibility },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [visibility])
+
+    return (
+        <>
+            <div className="card">
+                <span
+                    className={`dot${visibility === "visible" ? " on" : ""}`}
+                />
+                <span className="label">{visibility}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.visibility}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-visibility/dev/index.tsx
+++ b/packages/@valdres/browser-visibility/dev/index.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useState } from "react"
+import { StrictMode, useEffect, useRef, useState } from "react"
 import { createRoot } from "react-dom/client"
 import { Provider, useValue } from "valdres-react"
 import { visibilityAtom } from "../src"
@@ -8,8 +8,11 @@ type Entry = { at: string; visibility: DocumentVisibilityState }
 const Demo = () => {
     const visibility = useValue(visibilityAtom)
     const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<DocumentVisibilityState | null>(null)
 
     useEffect(() => {
+        if (lastLogged.current === visibility) return
+        lastLogged.current = visibility
         setLog(prev =>
             [
                 { at: new Date().toLocaleTimeString(), visibility },

--- a/packages/@valdres/browser-visibility/dev/server.ts
+++ b/packages/@valdres/browser-visibility/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3019),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-visibility demo: ${server.url}`)

--- a/packages/@valdres/browser-visibility/package.json
+++ b/packages/@valdres/browser-visibility/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-visibility",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.test.ts
+++ b/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import { store } from "valdres"
+import { visibilityAtom } from "./visibilityAtom"
+
+const setVisibility = (value: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", {
+        value,
+        configurable: true,
+    })
+}
+
+describe("visibilityAtom", () => {
+    afterAll(() => setVisibility("visible"))
+
+    test("first read evaluates lazily and onInit wires event listeners", () => {
+        setVisibility("hidden")
+        const s = store()
+        expect(s.get(visibilityAtom)).toBe("hidden")
+
+        setVisibility("visible")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(visibilityAtom)).toBe("visible")
+
+        setVisibility("hidden")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(visibilityAtom)).toBe("hidden")
+    })
+})

--- a/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.ts
+++ b/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.ts
@@ -1,0 +1,13 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+const getInitial = (): DocumentVisibilityState => {
+    if (typeof document === "undefined") return "visible"
+    return document.visibilityState
+}
+
+export const visibilityAtom = atom<DocumentVisibilityState>(getInitial, {
+    global: true,
+    name: "@valdres/browser-visibility/visibility",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-visibility/src/index.ts
+++ b/packages/@valdres/browser-visibility/src/index.ts
@@ -1,0 +1,1 @@
+export { visibilityAtom } from "./atoms/visibilityAtom"

--- a/packages/@valdres/browser-visibility/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-visibility/src/lib/subscribe.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect, afterEach } from "bun:test"
+import { store } from "valdres"
+import { subscribe } from "./subscribe"
+import { visibilityAtom } from "../atoms/visibilityAtom"
+
+const setVisibility = (value: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", {
+        value,
+        configurable: true,
+    })
+}
+
+describe("subscribe", () => {
+    afterEach(() => setVisibility("visible"))
+
+    test("syncs initial value from document.visibilityState", () => {
+        setVisibility("hidden")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(visibilityAtom)).toBe("hidden")
+        cleanup?.()
+    })
+
+    test("updates atom when visibilitychange event fires", () => {
+        setVisibility("visible")
+        const s = store()
+        const cleanup = subscribe()
+
+        expect(s.get(visibilityAtom)).toBe("visible")
+
+        setVisibility("hidden")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(visibilityAtom)).toBe("hidden")
+
+        setVisibility("visible")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(visibilityAtom)).toBe("visible")
+
+        cleanup?.()
+    })
+
+    test("cleanup removes listeners so later events do not update atom", () => {
+        setVisibility("visible")
+        const s = store()
+        const cleanup = subscribe()
+        cleanup?.()
+
+        setVisibility("hidden")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(visibilityAtom)).toBe("visible")
+    })
+})

--- a/packages/@valdres/browser-visibility/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-visibility/src/lib/subscribe.ts
@@ -1,0 +1,13 @@
+import { visibilityAtom } from "../atoms/visibilityAtom"
+
+const sync = () => visibilityAtom.setSelf(document.visibilityState)
+const onChange = () => visibilityAtom.setSelf(document.visibilityState)
+
+export const subscribe = () => {
+    if (typeof document === "undefined") return
+    sync()
+    document.addEventListener("visibilitychange", onChange)
+    return () => {
+        document.removeEventListener("visibilitychange", onChange)
+    }
+}

--- a/packages/@valdres/browser-visibility/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-visibility/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-visibility/tsconfig.json
+++ b/packages/@valdres/browser-visibility/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## Summary
- New `@valdres/browser-visibility` package: a reactive `visibilityAtom` wrapping the Page Visibility API (`document.visibilityState` + `visibilitychange` event).
- Mirrors the structure of `@valdres/browser-focus` (#89): same `package.json` shape, `bunfig.toml`, happy-dom test setup, module-level listener functions in `src/lib/subscribe.ts`, and a React demo under `dev/` (port `3019`).
- The atom value uses the native `DocumentVisibilityState` union (`"visible" | "hidden" | "prerender"`).

## Distinction from @valdres/browser-focus
`browser-focus` tracks keyboard focus via `document.hasFocus()` plus `focus`/`blur` events on `window` — it flips to `false` as soon as another app or window gets focus, even if this tab is still visible. `browser-visibility` only flips to `"hidden"` when the tab is actually backgrounded or the window minimized; clicking another app while the tab stays on-screen leaves it `"visible"`.

## Test plan
- [x] `bun install` from repo root
- [x] `bun test` in the package — 4 pass / 0 fail
- [x] `bun run build` succeeds
- [x] `PORT=3099 bun run dev` — `/` returns HTTP 200, bundled JS returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)