### PR TITLE
Deflake atom maxAge async tests

### DIFF
--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -406,28 +406,40 @@ describe("atom", () => {
         }
         const atom1 = atom(atomCallback, { maxAge })
 
-        const callback = mock(() => {})
+        // Capture every value the store transitions through. Asserting against
+        // store1.get() directly is racy: the maxAge interval keeps firing, so a
+        // resolved value can be replaced by a fresh pending promise before the
+        // assertion runs (a subsequent tick would never resolve, and the test
+        // would time out).
+        const observed: any[] = []
+        const callback = mock(() => {
+            observed.push(store1.get(atom1))
+        })
         const unsubscribe = store1.sub(atom1, callback)
 
         // Initially holds a pending promise
         expect(store1.get(atom1)).toBeInstanceOf(Promise)
 
-        // Resolve initial fetch before the maxAge window closes so
-        // revalidation is scheduled off a resolved value, not a still-pending
-        // one — otherwise slow CI runners can flip the ordering.
         resolvers[0](100)
-        await waitFor(() => expect(store1.get(atom1)).toBe(100))
+        await waitFor(() => expect(observed).toContain(100))
 
-        // Give the maxAge interval deterministic time to fire before polling.
-        await wait(maxAge + 20)
+        // The next maxAge tick should trigger a fresh fetch.
         await waitFor(() => expect(fetchCount).toBe(2))
 
-        // Without SWR, the store should show the pending promise (loading state)
-        expect(store1.get(atom1)).toBeInstanceOf(Promise)
+        // Without SWR, that fresh fetch publishes a pending promise as the
+        // loading state. We verify by checking that *some* value observed
+        // after 100 was a Promise (rather than reading store1.get() right
+        // now, which races with later ticks).
+        const indexOf100 = observed.indexOf(100)
+        const promiseAfter100 = observed
+            .slice(indexOf100 + 1)
+            .find(v => v instanceof Promise)
+        expect(promiseAfter100).toBeInstanceOf(Promise)
 
-        // Resolve revalidation
+        // Resolve revalidation. Use observed (not store1.get()) because a
+        // later tick may replace 200 with a new pending promise.
         resolvers[1](200)
-        await waitFor(() => expect(store1.get(atom1)).toBe(200))
+        await waitFor(() => expect(observed).toContain(200))
 
         unsubscribe()
     })
@@ -889,44 +901,61 @@ describe("atom", () => {
                 })
             }
 
-            const atom1 = atom(atomCallback, {
-                maxAge: 15,
-                staleIfError: 40,
-            })
+            // Use generously-sized windows. The production code initializes
+            // lastSuccessTime at subscribe time and only updates it on a
+            // tick-driven revalidation success — not on the initial fetch.
+            // With a tight staleIfError (e.g. 40ms) the first rejection check
+            // races the wall clock on slow CI runners and falls outside the
+            // window, so the stale value isn't restored.
+            const maxAge = 50
+            const staleIfError = 200
+            const atom1 = atom(atomCallback, { maxAge, staleIfError })
 
-            const callback = mock(() => {})
+            // Capture every observed value via the subscription callback so
+            // assertions don't race with the next maxAge tick replacing the
+            // store value with a fresh pending promise.
+            const observed: any[] = []
+            const callback = mock(() => {
+                observed.push(store1.get(atom1))
+            })
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
             resolvers[0].resolve(100)
-            await wait(1)
-            expect(store1.get(atom1)).toBe(100)
+            await waitFor(() => expect(observed).toContain(100))
 
             // First revalidation: reject (within staleIfError window)
             await waitFor(() => expect(fetchCount).toBe(2))
             resolvers[1].reject(new Error("fail 1"))
-            await wait(1)
-            expect(store1.get(atom1)).toBe(100) // stale value kept
+            // Stale value should be restored — wait for it via the callback.
+            await waitFor(() =>
+                expect(observed[observed.length - 1]).toBe(100),
+            )
 
-            // Second revalidation: succeed (resets the window)
+            // Second revalidation: succeed (resets the window). Capture the
+            // success time so we can wait deterministically past the window.
             await waitFor(() => expect(fetchCount).toBe(3))
             resolvers[2].resolve(200)
-            await wait(1)
-            expect(store1.get(atom1)).toBe(200) // updated
+            await waitFor(() => expect(observed).toContain(200))
+            const lastSuccessAt = Date.now()
 
-            // Wait past maxAge + staleIfError from last success (15 + 40 = 55ms)
-            await wait(60)
+            // Wait past maxAge + staleIfError from the last success, plus a
+            // buffer to absorb scheduler jitter.
+            const elapsed = Date.now() - lastSuccessAt
+            await wait(maxAge + staleIfError + 50 - elapsed)
+
+            // A revalidation tick should have fired by now.
+            expect(fetchCount).toBeGreaterThanOrEqual(4)
 
             // Reject all pending revalidations (past window now)
-            const pending = resolvers.length
-            expect(fetchCount).toBeGreaterThanOrEqual(4)
             for (let i = 3; i < resolvers.length; i++) {
                 resolvers[i].reject(new Error("fail N"))
             }
-            await wait(1)
 
-            // Past staleIfError window — stale value should NOT be served
-            expect(store1.get(atom1)).not.toBe(200)
+            // Past staleIfError window — stale value (200) should NOT be
+            // restored. Wait for the rejection microtask to settle, then
+            // verify the store is no longer holding 200.
+            await waitFor(() => expect(store1.get(atom1)).not.toBe(200))
 
             unsubscribe()
         },


### PR DESCRIPTION
## Summary

Two tests in `packages/valdres/src/atom.test.ts` were intermittently failing on CI:

- `atom > atom with maxAge async (no SWR) shows promise during revalidation` (timed out at ~2116ms on PR #90)
- `atom > multiple consecutive failures with staleIfError` (failed on commit 964dd90 on main)

Both are race conditions in the *test* setup — production behavior in `subscribe.ts` is unchanged.

## Diagnosis

**Test 1** asserted against `store.get()` directly with `waitFor(() => expect(store.get(atom)).toBe(200))` after resolving the second fetch. But the maxAge interval keeps firing in the background — a subsequent tick can swap the resolved `200` for a fresh pending promise before the polling iteration sees it. With no further resolver call coming, `waitFor` then runs to the 2000ms deadline.

**Test 2** used `maxAge: 15` and `staleIfError: 40` (a 55ms staleIfError window). The production code initializes `lastSuccessTime` at subscribe time and only updates it on a tick-driven revalidation success — *not* on the initial fetch's resolution. On slow CI runners the first rejection callback fired past the 55ms threshold-from-subscribe, so the rejection branch's `isPastStaleIfErrorWindow()` returned true and skipped restoring the stale value. The store stayed as the pending promise from the in-flight revalidation, and the assertion `expect(store.get(atom)).toBe(100)` failed.

## Fix

- Both tests now capture every value the store transitions through via the subscription callback, and assert against the captured sequence (`observed.toContain(...)`) instead of polling the live store value. This is immune to subsequent ticks replacing the value.
- Test 2 widens the windows to `maxAge: 50`, `staleIfError: 200` (250ms window), and times the post-success wait from a captured `lastSuccessAt` so scheduler jitter cannot push us inside the window after we mean to be past it.

Verified by running each test 50× under heavy CPU pressure (8 background `yes > /dev/null` processes): 50/50 green for both. Full `bun test` suite ran 5× clean afterwards.

## Test plan

- [x] `bun test src/atom.test.ts -t "shows promise during revalidation"` × 50 under load → 50/50 pass
- [x] `bun test src/atom.test.ts -t "multiple consecutive failures"` × 50 under load → 50/50 pass
- [x] `cd packages/valdres && bun test` × 5 → all green (264 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)