### PR TITLE
Default cache stale windows to Infinity and enforce SWR timeout

### DIFF
--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -393,7 +393,7 @@ describe("atom", () => {
         unsubscribe()
     })
 
-    test("atom with maxAge async (no SWR) shows promise during revalidation", async () => {
+    test("atom with maxAge async and staleWhileRevalidate: 0 shows promise during revalidation", async () => {
         const store1 = store()
         const maxAge = 50
         let fetchCount = 0
@@ -404,7 +404,7 @@ describe("atom", () => {
                 resolvers.push(resolve)
             })
         }
-        const atom1 = atom(atomCallback, { maxAge })
+        const atom1 = atom(atomCallback, { maxAge, staleWhileRevalidate: 0 })
 
         // Capture every value the store transitions through. Asserting against
         // store1.get() directly is racy: the maxAge interval keeps firing, so a
@@ -426,10 +426,10 @@ describe("atom", () => {
         // The next maxAge tick should trigger a fresh fetch.
         await waitFor(() => expect(fetchCount).toBe(2))
 
-        // Without SWR, that fresh fetch publishes a pending promise as the
-        // loading state. We verify by checking that *some* value observed
-        // after 100 was a Promise (rather than reading store1.get() right
-        // now, which races with later ticks).
+        // With staleWhileRevalidate: 0, that fresh fetch publishes a pending
+        // promise as the loading state. We verify by checking that *some*
+        // value observed after 100 was a Promise (rather than reading
+        // store1.get() right now, which races with later ticks).
         const indexOf100 = observed.indexOf(100)
         const promiseAfter100 = observed
             .slice(indexOf100 + 1)
@@ -499,6 +499,52 @@ describe("atom", () => {
 
         unsubscribe()
     })
+
+    test(
+        "staleWhileRevalidate window expiration flips to pending promise",
+        async () => {
+            const store1 = store()
+            let fetchCount = 0
+            const resolvers: Array<(v: number) => void> = []
+            const atomCallback = () => {
+                fetchCount++
+                return new Promise<number>(resolve => {
+                    resolvers.push(resolve)
+                })
+            }
+
+            const atom1 = atom(atomCallback, {
+                maxAge: 20,
+                staleWhileRevalidate: 50,
+            })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            // Resolve initial fetch
+            resolvers[0](100)
+            await wait(1)
+            expect(store1.get(atom1)).toBe(100)
+
+            // Wait for revalidation to start (do NOT resolve)
+            await waitFor(() => expect(fetchCount).toBe(2))
+
+            // Within SWR window — stale value still visible
+            expect(store1.get(atom1)).toBe(100)
+
+            // Wait past the SWR window (50ms) with revalidation still in flight
+            await wait(80)
+
+            // SWR window expired — store should flip to the pending promise
+            expect(store1.get(atom1)).toBeInstanceOf(Promise)
+
+            // Resolving the in-flight request still updates the value
+            resolvers[1](200)
+            await waitFor(() => expect(store1.get(atom1)).toBe(200))
+
+            unsubscribe()
+        },
+    )
 
     test(
         "staleWhileRevalidate timeout is cleared on revalidation resolve",
@@ -956,6 +1002,193 @@ describe("atom", () => {
             // restored. Wait for the rejection microtask to settle, then
             // verify the store is no longer holding 200.
             await waitFor(() => expect(store1.get(atom1)).not.toBe(200))
+
+            unsubscribe()
+        },
+    )
+
+    test(
+        "swr finite: window expires then reject within staleIfError restores stale",
+        async () => {
+            // After the SWR timeout flips the store to the pending promise,
+            // a subsequent rejection within the staleIfError window must
+            // bring the stale value back — not leave the rejected promise.
+            const store1 = store()
+            let fetchCount = 0
+            const resolvers: Array<{
+                resolve: (v: number) => void
+                reject: (e: Error) => void
+            }> = []
+            const atomCallback = () => {
+                fetchCount++
+                return new Promise<number>((resolve, reject) => {
+                    resolvers.push({ resolve, reject })
+                })
+            }
+
+            const atom1 = atom(atomCallback, {
+                maxAge: 20,
+                staleWhileRevalidate: 30,
+                staleIfError: 500,
+            })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            resolvers[0].resolve(100)
+            await wait(1)
+            expect(store1.get(atom1)).toBe(100)
+
+            // Wait for revalidation to start (don't resolve)
+            await waitFor(() => expect(fetchCount).toBe(2))
+            // Within SWR window — stale visible
+            expect(store1.get(atom1)).toBe(100)
+
+            // Wait past SWR window (30ms) — should flip to pending promise
+            await wait(50)
+            expect(store1.get(atom1)).toBeInstanceOf(Promise)
+
+            // Reject — within staleIfError window, stale should be restored
+            resolvers[1].reject(new Error("network error"))
+            await wait(1)
+            expect(store1.get(atom1)).toBe(100)
+
+            unsubscribe()
+        },
+    )
+
+    test(
+        "swr=0: reject within staleIfError window restores stale",
+        async () => {
+            const store1 = store()
+            let fetchCount = 0
+            const resolvers: Array<{
+                resolve: (v: number) => void
+                reject: (e: Error) => void
+            }> = []
+            const atomCallback = () => {
+                fetchCount++
+                return new Promise<number>((resolve, reject) => {
+                    resolvers.push({ resolve, reject })
+                })
+            }
+
+            const atom1 = atom(atomCallback, {
+                maxAge: 20,
+                staleWhileRevalidate: 0,
+                staleIfError: 500,
+            })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            resolvers[0].resolve(100)
+            await wait(1)
+            expect(store1.get(atom1)).toBe(100)
+
+            await waitFor(() => expect(fetchCount).toBe(2))
+            // swr=0: pending promise is visible during revalidation
+            expect(store1.get(atom1)).toBeInstanceOf(Promise)
+
+            resolvers[1].reject(new Error("network error"))
+            await wait(1)
+            // Within staleIfError window — stale should be restored
+            expect(store1.get(atom1)).toBe(100)
+
+            unsubscribe()
+        },
+    )
+
+    test(
+        "swr=0: reject past staleIfError window leaves rejected promise",
+        async () => {
+            const store1 = store()
+            let fetchCount = 0
+            const resolvers: Array<{
+                resolve: (v: number) => void
+                reject: (e: Error) => void
+            }> = []
+            const atomCallback = () => {
+                fetchCount++
+                return new Promise<number>((resolve, reject) => {
+                    resolvers.push({ resolve, reject })
+                })
+            }
+
+            const atom1 = atom(atomCallback, {
+                maxAge: 20,
+                staleWhileRevalidate: 0,
+                staleIfError: 30,
+            })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            resolvers[0].resolve(100)
+            await wait(1)
+            expect(store1.get(atom1)).toBe(100)
+
+            // Wait past maxAge + staleIfError (50ms)
+            await wait(60)
+            expect(fetchCount).toBeGreaterThanOrEqual(2)
+
+            for (let i = 1; i < resolvers.length; i++) {
+                resolvers[i].reject(new Error("network error"))
+            }
+            await wait(1)
+
+            // Past staleIfError window — stale value should NOT be served
+            const val = store1.get(atom1)
+            expect(val).not.toBe(100)
+            expect(val).toBeInstanceOf(Promise)
+
+            unsubscribe()
+        },
+    )
+
+    test(
+        "reject when no good value exists yet shows the rejected promise",
+        async () => {
+            // Init never resolves → lastGoodValue stays NO_VALUE.
+            // When the first revalidation rejects, there is nothing to
+            // restore — the store should hold the rejected promise so
+            // consumers see the error rather than a forever-pending one.
+            const store1 = store()
+            let fetchCount = 0
+            const resolvers: Array<{
+                resolve: (v: number) => void
+                reject: (e: Error) => void
+            }> = []
+            const atomCallback = () => {
+                fetchCount++
+                return new Promise<number>((resolve, reject) => {
+                    resolvers.push({ resolve, reject })
+                })
+            }
+
+            const atom1 = atom(atomCallback, { maxAge: 20 })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            // Don't resolve init — wait for revalidation tick
+            await waitFor(() => expect(fetchCount).toBe(2))
+
+            // Reject the revalidation
+            resolvers[1].reject(new Error("network error"))
+            await wait(1)
+
+            // No stale exists — store must hold a rejected promise
+            const val = store1.get(atom1)
+            expect(val).toBeInstanceOf(Promise)
+            const settled = await Promise.race([
+                (val as Promise<number>).then(
+                    () => "resolved" as const,
+                    () => "rejected" as const,
+                ),
+                wait(50).then(() => "pending" as const),
+            ])
+            expect(settled).toBe("rejected")
 
             unsubscribe()
         },

--- a/packages/valdres/src/cacheMeta.test.ts
+++ b/packages/valdres/src/cacheMeta.test.ts
@@ -130,6 +130,17 @@ describe("cacheMeta", () => {
         expect(meta!.staleWhileRevalidate).toBe(500)
         expect(meta!.staleIfError).toBe(1000)
     })
+
+    test("cacheMeta defaults staleWhileRevalidate and staleIfError to Infinity", () => {
+        const store1 = store()
+        const atom1 = atom(() => 42, { maxAge: 100 })
+
+        store1.sub(atom1, () => {})
+
+        const meta = store1.get(cacheMeta(atom1))
+        expect(meta!.staleWhileRevalidate).toBe(Infinity)
+        expect(meta!.staleIfError).toBe(Infinity)
+    })
 })
 
 describe("reactive maxAge", () => {

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -248,14 +248,14 @@ export const subscribe = <V>(
                             }
                             value.then(
                                 (resolved: any) => {
-                                    if (timeoutRef) {
+                                    if (timeoutRef !== undefined) {
                                         clearTimeout(timeoutRef)
                                         pendingTimeouts.delete(timeoutRef)
                                     }
                                     handleResolve(resolved)
                                 },
                                 () => {
-                                    if (timeoutRef) {
+                                    if (timeoutRef !== undefined) {
                                         clearTimeout(timeoutRef)
                                         pendingTimeouts.delete(timeoutRef)
                                     }

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -135,14 +135,14 @@ export const subscribe = <V>(
 
                 const getMaxAge = (): number =>
                     resolveReactive(state.maxAge!, data)
-                const getSWR = (): number | undefined =>
-                    state.staleWhileRevalidate
+                const getSWR = (): number =>
+                    state.staleWhileRevalidate !== undefined
                         ? resolveReactive(state.staleWhileRevalidate, data)
-                        : undefined
-                const getStaleIfError = (): number | undefined =>
-                    state.staleIfError
+                        : Infinity
+                const getStaleIfError = (): number =>
+                    state.staleIfError !== undefined
                         ? resolveReactive(state.staleIfError, data)
-                        : undefined
+                        : Infinity
 
                 const metaAtom = state.__cacheMeta ??= { equal, defaultValue: null }
                 const updateMeta = () => {
@@ -165,10 +165,8 @@ export const subscribe = <V>(
                 }
 
                 const isPastStaleIfErrorWindow = () => {
-                    const staleIfError = getStaleIfError()
-                    if (!staleIfError) return true
                     const elapsed = Date.now() - lastSuccessTime
-                    return elapsed >= getMaxAge() + staleIfError
+                    return elapsed >= getMaxAge() + getStaleIfError()
                 }
 
                 // For global atoms, propagate to all stores; for regular atoms, just this store
@@ -210,61 +208,65 @@ export const subscribe = <V>(
                         revalidating = true
                         updateMeta()
                         const swr = getSWR()
-                        if (swr) {
-                            // SWR: keep stale value visible during revalidation
-                            const t = setTimeout(() => {
-                                pendingTimeouts.delete(t)
-                            }, swr)
-                            pendingTimeouts.add(t)
+
+                        const handleResolve = (resolved: any) => {
+                            if (cancelled) return
+                            revalidating = false
+                            lastSuccessTime = Date.now()
+                            lastGoodValue = resolved
+                            setAndPropagate(state, resolved)
+                            updateMeta()
+                        }
+
+                        const handleReject = () => {
+                            if (cancelled) return
+                            revalidating = false
+                            if (
+                                !isPastStaleIfErrorWindow() &&
+                                lastGoodValue !== NO_VALUE
+                            ) {
+                                setAndPropagate(state, lastGoodValue)
+                            } else {
+                                setAndPropagate(state, value)
+                            }
+                            updateMeta()
+                        }
+
+                        if (swr > 0) {
+                            // SWR: keep stale value visible during revalidation.
+                            // Finite swr enforces a window: if the request is
+                            // still in flight when it expires, flip to the
+                            // pending promise (loading state).
+                            let timeoutRef: Timer | undefined
+                            if (Number.isFinite(swr)) {
+                                timeoutRef = setTimeout(() => {
+                                    pendingTimeouts.delete(timeoutRef!)
+                                    if (cancelled || !revalidating) return
+                                    setAndPropagate(state, value)
+                                }, swr)
+                                pendingTimeouts.add(timeoutRef)
+                            }
                             value.then(
                                 (resolved: any) => {
-                                    clearTimeout(t)
-                                    pendingTimeouts.delete(t)
-                                    if (cancelled) return
-                                    revalidating = false
-                                    lastSuccessTime = Date.now()
-                                    lastGoodValue = resolved
-                                    setAndPropagate(state, resolved)
-                                    updateMeta()
+                                    if (timeoutRef) {
+                                        clearTimeout(timeoutRef)
+                                        pendingTimeouts.delete(timeoutRef)
+                                    }
+                                    handleResolve(resolved)
                                 },
                                 () => {
-                                    clearTimeout(t)
-                                    pendingTimeouts.delete(t)
-                                    if (cancelled) return
-                                    revalidating = false
-                                    if (
-                                        getStaleIfError() &&
-                                        isPastStaleIfErrorWindow()
-                                    ) {
-                                        setAndPropagate(state, value)
+                                    if (timeoutRef) {
+                                        clearTimeout(timeoutRef)
+                                        pendingTimeouts.delete(timeoutRef)
                                     }
-                                    updateMeta()
+                                    handleReject()
                                 },
                             )
                         } else {
-                            // No SWR: show loading state during revalidation
+                            // swr === 0: opt out of stale-while-revalidate;
+                            // show pending promise immediately on revalidate.
                             setAndPropagate(state, value)
-                            value.then(
-                                (resolved: any) => {
-                                    if (cancelled) return
-                                    revalidating = false
-                                    lastSuccessTime = Date.now()
-                                    lastGoodValue = resolved
-                                    setAndPropagate(state, resolved)
-                                    updateMeta()
-                                },
-                                () => {
-                                    if (cancelled) return
-                                    revalidating = false
-                                    if (
-                                        !isPastStaleIfErrorWindow() &&
-                                        lastGoodValue !== NO_VALUE
-                                    ) {
-                                        setAndPropagate(state, lastGoodValue)
-                                    }
-                                    updateMeta()
-                                },
-                            )
+                            value.then(handleResolve, handleReject)
                         }
                     } else {
                         lastSuccessTime = Date.now()

--- a/packages/valdres/src/types/Atom.ts
+++ b/packages/valdres/src/types/Atom.ts
@@ -9,8 +9,8 @@ export type CacheMeta = {
     isRevalidating: boolean
     lastSuccessAt: number
     maxAge: number
-    staleWhileRevalidate?: number
-    staleIfError?: number
+    staleWhileRevalidate: number
+    staleIfError: number
 }
 
 export type Atom<Value = unknown> = {


### PR DESCRIPTION
## Summary

Three semantics fixes to the `maxAge` / `staleWhileRevalidate` / `staleIfError` caching layer in `packages/valdres/src/lib/subscribe.ts`:

- **Default `staleWhileRevalidate` and `staleIfError` to `Infinity`** when unset. Matches the intuition from Vercel SWR and React Query: keep showing stale data while revalidating in the background, keep last-good on network errors. Pass `staleWhileRevalidate: 0` to opt back into loading-state-on-revalidate.

- **The SWR timeout actually enforces its window.** Previously the `setTimeout` only removed itself from a `Set` — `swr: 5000` and `swr: 60000` behaved identically. Now if the request is still in flight when the window expires, the atom flips to the pending promise so consumers can render a loading state.

- **`if (swr)` tightened to `if (swr > 0)`.** Previously `swr: 0` fell through to the loading-state branch by truthy coincidence; now it does so by intent.

The error path is also unified: both branches funnel through a single `handleReject` that restores `lastGoodValue` within the `staleIfError` window, otherwise surfaces the rejected promise. The old SWR/non-SWR branches had subtly divergent reject behavior.

`CacheMeta.staleWhileRevalidate` and `staleIfError` are now required fields (always populated, possibly `Infinity`).

## Behavioral change

⚠️ Callers that omitted `staleWhileRevalidate` previously saw a pending promise during revalidation. They will now see the stale value. Pass `staleWhileRevalidate: 0` to restore the old behavior.

## Test coverage

5 new tests added, covering the full branch matrix:

- swr=∞ (default) shows up in `cacheMeta` as Infinity
- swr=finite, window expires → flips to pending promise
- swr=finite, window expires then reject → restores stale (verifies the reject-after-flip interaction)
- swr=0 + reject within `staleIfError` window → restores stale
- swr=0 + reject past `staleIfError` window → leaves rejected promise
- reject when no good value exists yet → shows the rejected promise (no forever-pending)

The two genuinely-new behaviors were verified red-first by temporarily reverting the relevant code change and confirming the test fails.

## Test plan

- [x] `bun test src/atom.test.ts src/cacheMeta.test.ts` → 57/57 pass
- [x] `bun test` (full suite) → 268/269 pass (1 pre-existing todo, no failures)
- [x] Red-first verification on the two new-behavior tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)