### PR TITLE
Fix setAtom bare-promise handling: require thunk for async writes

### DIFF
--- a/packages/@valdres-react/jotai/src/createStore.ts
+++ b/packages/@valdres-react/jotai/src/createStore.ts
@@ -122,6 +122,14 @@ export const createStore = (id?: string) => {
     // so nested sets from unmount cleanups are deferred.
     const originalSet = store.set
     store.set = (state: any, ...args: any[]) => {
+        // Jotai API permits bare-promise writes (atom values of type
+        // Promise<T>). Valdres core requires a thunk so async resolution
+        // is explicit — wrap the bare promise here to preserve jotai
+        // semantics.
+        if (args.length === 1 && isPromiseLike(args[0])) {
+            const bare = args[0]
+            args = [() => bare]
+        }
         if (isSelector(state)) {
             if (activeTxn) {
                 // Already inside a transaction — reuse it

--- a/packages/@valdres/public-ip/src/lib/publicIpOnInit.ts
+++ b/packages/@valdres/public-ip/src/lib/publicIpOnInit.ts
@@ -53,7 +53,7 @@ export const publicIpOnInit = (
     const handler = () => {
         const nav = typeof navigator === "undefined" ? undefined : navigator
         if (nav && nav.onLine === false) return
-        ipAtom.setSelf(fetchPublicIp(endpointsAtom.getSelf(), validate))
+        ipAtom.setSelf(() => fetchPublicIp(endpointsAtom.getSelf(), validate))
     }
     refetchHandlers.add(handler)
     registerSharedListeners()

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1021,7 +1021,7 @@ describe("atom with promise values", () => {
         const store1 = store()
         const countAtom = atom(Promise.resolve(0))
         const infinitePending = new Promise<never>(() => {})
-        store1.set(countAtom, infinitePending)
+        store1.set(countAtom, () => infinitePending)
         expect(store1.get(countAtom)).toBe(infinitePending)
     })
 
@@ -1031,8 +1031,16 @@ describe("atom with promise values", () => {
         const countAtom = atom(p)
         const callback = mock(() => {})
         store1.sub(countAtom, callback)
-        store1.set(countAtom, p)
+        store1.set(countAtom, () => p)
         expect(callback).not.toHaveBeenCalled()
+    })
+
+    test("set with bare promise throws", () => {
+        const store1 = store()
+        const countAtom = atom<Promise<number>>(Promise.resolve(0))
+        expect(() =>
+            store1.set(countAtom, Promise.resolve(1)),
+        ).toThrowError(/promise/i)
     })
 })
 

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -333,6 +333,58 @@ describe("globalAtom", () => {
         expect(cleanupCount - cleanupBefore).toBe(1)
     })
 
+    test("setSelf with bare promise throws", () => {
+        const testAtom = atom<string>("initial", {
+            global: true,
+            name: "bare-promise-throws",
+        })
+        expect(() =>
+            testAtom.setSelf(Promise.resolve("new") as unknown as string),
+        ).toThrowError(/promise/i)
+    })
+
+    test("setSelf with () => promise resolves into stored value across stores", async () => {
+        const store1 = store()
+        const store2 = store()
+        const testAtom = atom<string>("initial", {
+            global: true,
+            name: "thunk-promise-resolve",
+        })
+        expect(store1.get(testAtom)).toBe("initial")
+        expect(store2.get(testAtom)).toBe("initial")
+
+        const sub1 = mock(() => {})
+        const sub2 = mock(() => {})
+        store1.sub(testAtom, sub1)
+        store2.sub(testAtom, sub2)
+
+        testAtom.setSelf(() => Promise.resolve("new"))
+        await wait(0)
+
+        expect(store1.get(testAtom)).toBe("new")
+        expect(store2.get(testAtom)).toBe("new")
+        expect(sub1).toHaveBeenCalled()
+        expect(sub2).toHaveBeenCalled()
+    })
+
+    test("setSelf with () => rejected promise reverts to previous value", async () => {
+        const store1 = store()
+        const store2 = store()
+        const testAtom = atom<string>("previous", {
+            global: true,
+            name: "thunk-promise-reject",
+        })
+        expect(store1.get(testAtom)).toBe("previous")
+        expect(store2.get(testAtom)).toBe("previous")
+
+        testAtom.setSelf(() => Promise.reject(new Error("boom")))
+        await wait(0)
+        await Promise.resolve()
+
+        expect(store1.get(testAtom)).toBe("previous")
+        expect(store2.get(testAtom)).toBe("previous")
+    })
+
     test("resetSelf clears maxAge interval for global atom", async () => {
         let callCount = 0
         const testAtom = atom(

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -7,6 +7,7 @@ import type { AtomOnSet } from "./../types/AtomOnSet"
 import type { AtomOptions } from "./../types/AtomOptions"
 import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
+import { isPromiseLike } from "../utils/isPromiseLike"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { globalStore } from "../globalStore"
@@ -23,7 +24,14 @@ export const globalAtom = <Value = unknown>(
         throw new Error("onSet on globalAtom is currently not supported")
 
     const onInit: AtomOnInit<Value> = (setSelf, data) => {
-        setSelf(globalStore.get(atom))
+        const current = globalStore.get(atom)
+        // `current` may be a pending promise from an async defaultValue;
+        // setAtom requires a thunk for promise writes, so wrap when needed.
+        setSelf(
+            isPromiseLike(current)
+                ? ((() => current) as unknown as Value)
+                : current,
+        )
         if (!initialized && options.onInit) {
             onReset = options.onInit(newVal => {
                 setSelf(newVal)
@@ -39,6 +47,9 @@ export const globalAtom = <Value = unknown>(
         if (stores.size > 1) {
             for (const store of stores) {
                 if (store.id !== currentStore.id) {
+                    // onSet is only called with resolved values from setAtom's
+                    // .then handler — never a pending promise — so a direct
+                    // setAtom here is safe under the thunk-required contract.
                     setAtom(atom, value, store, true)
                 }
             }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -63,7 +63,15 @@ export const setAtom = <Value = any>(
             return promise as Value
         }
     }
-    const areEqual = isPromiseLike(currentValue) || isPromiseLike(newValue)
+    if (isPromiseLike(newValue)) {
+        throw new Error(
+            "setAtom received a bare Promise. Pass a thunk instead: " +
+                "set(atom, () => promise). A bare promise would be stored " +
+                "without awaiting resolution, silently leaving subscribers " +
+                "on the unresolved reference.",
+        )
+    }
+    const areEqual = isPromiseLike(currentValue)
         ? currentValue === newValue
         : atom.equal(currentValue, newValue)
     if (areEqual) return newValue


### PR DESCRIPTION
## Summary

`setAtom` silently fell through to the literal-value path when called with a bare `Promise`, storing the unresolved promise reference as the atom value. Subscribers never fired again after resolution, and for global atoms the bug fanned out: `onSet` broadcast the bare promise to every peer store.

This shipped as a user-visible bug in `@valdres/public-ip`: a Wi-Fi switch triggered `ipAtom.setSelf(fetchPublicIp(...))`, the fetch succeeded, but the UI stayed on the stale placeholder because the resolved value never replaced the promise reference.

## Fix (option c: require a thunk)

`setAtom` now throws when it receives a bare `Promise`, directing callers to the thunk form:

```ts
// before (silent bug)
atom.setSelf(fetchThing())

// after (explicit async)
atom.setSelf(() => fetchThing())
```

The thunk path already has correct `.then`/`.catch` + stale-promise guard + rejection-revert — this change just closes the silent fall-through for callers who forgot to wrap.

### Why option (c) over a runtime sniff

Three options were considered:
- **(a)** Detect `isPromiseLike(newValue)` regardless of thunk form and attach resolution handlers.
- **(b)** Narrow the fix to `globalAtom.setSelf`.
- **(c)** Reject bare promises, require `() => promise`.

(a) was prototyped first and worked, but leaves a type-safety hole: `setAtom<string>(atom, somePromise)` is a runtime-only type narrowing that doesn't match the declared signature, and it collides semantically with the valid `atom<Promise<T>>` pattern (store a promise literal for suspense). (b) leaves the same bug for non-global atoms. (c) makes the contract explicit and fails loudly for the bug class.

## Internal callers updated

- `@valdres/public-ip/publicIpOnInit.ts` — the motivating bug site — switched to `() => fetchPublicIp(...)`.
- `globalAtom.onInit` — when a new store subscribes, it receives the global store's current value. If that value is a pending promise (async `defaultValue`), wrap it in a thunk before forwarding.
- `@valdres-react/jotai/createStore.ts` — jotai's API permits bare-promise writes (`atom<Promise<T>>` for suspense). Wrapping happens at the compat boundary so valdres core keeps the stricter contract and jotai parity is preserved.

## Test plan

- [x] `packages/valdres` — 268/268 pass (adds: bare-promise throws on `store.set` and `setSelf`; thunk form resolves and reverts on rejection across multiple stores).
- [x] `@valdres-react/jotai` — 118/118 pass (jotai suspense tests unaffected by compat wrapper).
- [x] `@valdres/public-ip` — 23/23 pass.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)