### PR TITLE
Add @valdres/browser-presence package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -163,6 +163,28 @@
         "valdres": "0.2.0-pre.28",
       },
     },
+    "packages/@valdres/browser-presence": {
+      "name": "@valdres/browser-presence",
+      "version": "0.2.0-pre.28",
+      "dependencies": {
+        "@valdres/browser-focus": "0.2.0-pre.28",
+        "@valdres/browser-visibility": "0.2.0-pre.28",
+      },
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-screen": {
       "name": "@valdres/browser-screen",
       "version": "0.2.0-pre.28",
@@ -1055,6 +1077,8 @@
     "@valdres/browser-keyboard": ["@valdres/browser-keyboard@workspace:packages/@valdres/browser-keyboard"],
 
     "@valdres/browser-online": ["@valdres/browser-online@workspace:packages/@valdres/browser-online"],
+
+    "@valdres/browser-presence": ["@valdres/browser-presence@workspace:packages/@valdres/browser-presence"],
 
     "@valdres/browser-screen": ["@valdres/browser-screen@workspace:packages/@valdres/browser-screen"],
 
@@ -2927,6 +2951,10 @@
     "@valdres/browser-online/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-online/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-presence/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-presence/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-screen/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-presence/bunfig.toml
+++ b/packages/@valdres/browser-presence/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-presence/dev/index.html
+++ b/packages/@valdres/browser-presence/dev/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-presence demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .inputs {
+                margin-top: 1rem;
+                display: flex;
+                gap: 1rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.9rem;
+                color: #888;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-presence</h1>
+        <p class="muted">
+            <code>presenceSelector</code> is <code>true</code> when the tab is
+            visible <em>and</em> the window has focus. Switch tabs or click
+            another window to flip it.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            // valdres reads process.env.VALDRES_VERSION at import time
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-presence/dev/index.tsx
+++ b/packages/@valdres/browser-presence/dev/index.tsx
@@ -1,0 +1,56 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { focusAtom } from "@valdres/browser-focus"
+import { visibilityAtom } from "@valdres/browser-visibility"
+import { presenceSelector } from "../src"
+
+type Entry = { at: string; present: boolean }
+
+const Demo = () => {
+    const present = useValue(presenceSelector)
+    const focused = useValue(focusAtom)
+    const visibility = useValue(visibilityAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<boolean | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === present) return
+        lastLogged.current = present
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), present },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [present])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${present ? " on" : ""}`} />
+                <span className="label">{present ? "present" : "away"}</span>
+            </div>
+            <div className="inputs">
+                <span>visibility: {visibility}</span>
+                <span>focus: {focused ? "focused" : "blurred"}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.present ? "present" : "away"}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-presence/dev/server.ts
+++ b/packages/@valdres/browser-presence/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3020),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-presence demo: ${server.url}`)

--- a/packages/@valdres/browser-presence/package.json
+++ b/packages/@valdres/browser-presence/package.json
@@ -1,0 +1,49 @@
+{
+    "name": "@valdres/browser-presence",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "dependencies": {
+        "@valdres/browser-focus": "0.2.0-pre.28",
+        "@valdres/browser-visibility": "0.2.0-pre.28"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-presence/src/index.ts
+++ b/packages/@valdres/browser-presence/src/index.ts
@@ -1,0 +1,1 @@
+export { presenceSelector } from "./selectors/presenceSelector"

--- a/packages/@valdres/browser-presence/src/selectors/presenceSelector.test.ts
+++ b/packages/@valdres/browser-presence/src/selectors/presenceSelector.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import { store } from "valdres"
+import { presenceSelector } from "./presenceSelector"
+
+const setHasFocus = (value: boolean) => {
+    Object.defineProperty(document, "hasFocus", {
+        value: () => value,
+        configurable: true,
+    })
+}
+
+const setVisibility = (value: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", {
+        value,
+        configurable: true,
+    })
+}
+
+describe("presenceSelector", () => {
+    afterAll(() => {
+        setHasFocus(true)
+        setVisibility("visible")
+    })
+
+    test("is true when tab is visible and window is focused", () => {
+        setHasFocus(true)
+        setVisibility("visible")
+        const s = store()
+        expect(s.get(presenceSelector)).toBe(true)
+    })
+
+    test("is false when window loses focus", () => {
+        setHasFocus(true)
+        setVisibility("visible")
+        const s = store()
+        expect(s.get(presenceSelector)).toBe(true)
+
+        window.dispatchEvent(new Event("blur"))
+        expect(s.get(presenceSelector)).toBe(false)
+
+        window.dispatchEvent(new Event("focus"))
+        expect(s.get(presenceSelector)).toBe(true)
+    })
+
+    test("is false when tab becomes hidden", () => {
+        setHasFocus(true)
+        setVisibility("visible")
+        const s = store()
+        expect(s.get(presenceSelector)).toBe(true)
+
+        setVisibility("hidden")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(presenceSelector)).toBe(false)
+
+        setVisibility("visible")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(presenceSelector)).toBe(true)
+    })
+
+    test("is false when both visibility and focus are lost", () => {
+        setHasFocus(true)
+        setVisibility("visible")
+        const s = store()
+        expect(s.get(presenceSelector)).toBe(true)
+
+        window.dispatchEvent(new Event("blur"))
+        setVisibility("hidden")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(presenceSelector)).toBe(false)
+
+        window.dispatchEvent(new Event("focus"))
+        expect(s.get(presenceSelector)).toBe(false)
+
+        setVisibility("visible")
+        document.dispatchEvent(new Event("visibilitychange"))
+        expect(s.get(presenceSelector)).toBe(true)
+    })
+})

--- a/packages/@valdres/browser-presence/src/selectors/presenceSelector.ts
+++ b/packages/@valdres/browser-presence/src/selectors/presenceSelector.ts
@@ -1,0 +1,8 @@
+import { selector } from "valdres"
+import { focusAtom } from "@valdres/browser-focus"
+import { visibilityAtom } from "@valdres/browser-visibility"
+
+export const presenceSelector = selector(
+    get => get(visibilityAtom) === "visible" && get(focusAtom),
+    { name: "@valdres/browser-presence/presence" },
+)

--- a/packages/@valdres/browser-presence/src/selectors/presenceSelector.ts
+++ b/packages/@valdres/browser-presence/src/selectors/presenceSelector.ts
@@ -1,8 +1,8 @@
 import { selector } from "valdres"
 import { focusAtom } from "@valdres/browser-focus"
-import { visibilityAtom } from "@valdres/browser-visibility"
+import { isVisibleSelector } from "@valdres/browser-visibility"
 
 export const presenceSelector = selector(
-    get => get(visibilityAtom) === "visible" && get(focusAtom),
+    get => get(isVisibleSelector) && get(focusAtom),
     { name: "@valdres/browser-presence/presence" },
 )

--- a/packages/@valdres/browser-presence/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-presence/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-presence/tsconfig.json
+++ b/packages/@valdres/browser-presence/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## Summary
- New `@valdres/browser-presence` package that combines `@valdres/browser-visibility` and `@valdres/browser-focus`
- Exposes a single derived `presenceSelector` that is `true` when the tab is visible **and** the window has focus
- Includes unit tests and a `bun run dev` demo (port 3020) showing live present/away status with the underlying visibility + focus values

## Test plan
- [x] `bun test` passes (4 tests)
- [x] `bun run dev` serves and the bundled TSX compiles
- [ ] Manual: switch tabs / click another window in the demo and confirm the dot flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)