### PR TITLE
Handle bare promises passed to setAtom

### DIFF
--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -333,6 +333,48 @@ describe("globalAtom", () => {
         expect(cleanupCount - cleanupBefore).toBe(1)
     })
 
+    test("setSelf with bare promise resolves into stored value across stores", async () => {
+        const store1 = store()
+        const store2 = store()
+        const testAtom = atom<string | Promise<string>>("initial", {
+            global: true,
+            name: "bare-promise-resolve",
+        })
+        expect(store1.get(testAtom)).toBe("initial")
+        expect(store2.get(testAtom)).toBe("initial")
+
+        const sub1 = mock(() => {})
+        const sub2 = mock(() => {})
+        store1.sub(testAtom, sub1)
+        store2.sub(testAtom, sub2)
+
+        testAtom.setSelf(Promise.resolve("new"))
+        await wait(0)
+
+        expect(store1.get(testAtom)).toBe("new")
+        expect(store2.get(testAtom)).toBe("new")
+        expect(sub1).toHaveBeenCalled()
+        expect(sub2).toHaveBeenCalled()
+    })
+
+    test("setSelf with bare rejected promise reverts to previous value", async () => {
+        const store1 = store()
+        const store2 = store()
+        const testAtom = atom<string | Promise<string>>("previous", {
+            global: true,
+            name: "bare-promise-reject",
+        })
+        expect(store1.get(testAtom)).toBe("previous")
+        expect(store2.get(testAtom)).toBe("previous")
+
+        testAtom.setSelf(Promise.reject(new Error("boom")))
+        await wait(0)
+        await Promise.resolve()
+
+        expect(store1.get(testAtom)).toBe("previous")
+        expect(store2.get(testAtom)).toBe("previous")
+    })
+
     test("resetSelf clears maxAge interval for global atom", async () => {
         let callCount = 0
         const testAtom = atom(

--- a/packages/valdres/src/lib/setAtom.test.ts
+++ b/packages/valdres/src/lib/setAtom.test.ts
@@ -82,6 +82,24 @@ describe("setAtom", () => {
         expect(store1.get(stringAtom)).toBe("initial")
     })
 
+    test("set with a bare thenable normalizes to a real Promise", async () => {
+        const store1 = store()
+        const stringAtom = atom("initial")
+        store1.get(stringAtom)
+        // Minimal thenable: .then is a function but no .catch/.finally
+        const thenable: PromiseLike<string> = {
+            then(onFulfilled) {
+                return Promise.resolve(
+                    onFulfilled ? onFulfilled("adopted") : ("adopted" as any),
+                ) as any
+            },
+        }
+        const result = setAtom(stringAtom, thenable, store1.data)
+        expect(result instanceof Promise).toBe(true)
+        await result
+        expect(store1.get(stringAtom)).toBe("adopted")
+    })
+
     test("set with async updater stores promise then resolves", async () => {
         const store1 = store()
         const stringAtom = atom("initial")

--- a/packages/valdres/src/lib/setAtom.test.ts
+++ b/packages/valdres/src/lib/setAtom.test.ts
@@ -256,6 +256,33 @@ describe("setAtom", () => {
         expect(store1.get(emptyAtom)).toBe("second")
     })
 
+    test("async updater onSet throwing does not escape as unhandled rejection", async () => {
+        const rejections: unknown[] = []
+        const handler = (err: unknown) => rejections.push(err)
+        process.on("unhandledRejection", handler)
+        try {
+            const onSetMock = mock(() => {
+                throw new Error("onSet boom")
+            })
+            const store1 = store()
+            const stringAtom = atom<string>("initial", { onSet: onSetMock })
+            store1.get(stringAtom)
+
+            const result = setAtom(
+                stringAtom,
+                () => Promise.resolve("updated"),
+                store1.data,
+            )
+            await result
+            // Allow unhandled rejection tracking to flush
+            await new Promise(r => setTimeout(r, 10))
+
+            expect(rejections).toHaveLength(0)
+        } finally {
+            process.off("unhandledRejection", handler)
+        }
+    })
+
     test("deep freeze applies to function values with properties", () => {
         const defaultStore = store()
         const fn = () => "hello"

--- a/packages/valdres/src/lib/setAtom.test.ts
+++ b/packages/valdres/src/lib/setAtom.test.ts
@@ -56,6 +56,32 @@ describe("setAtom", () => {
         )
     })
 
+    test("set with bare promise stores it then resolves", async () => {
+        const store1 = store()
+        const stringAtom = atom("initial")
+        store1.get(stringAtom)
+        const promise = Promise.resolve("updated")
+        const result = setAtom(stringAtom, promise, store1.data)
+        expect(isPromiseLike(result)).toBe(true)
+        expect(store1.data.values.get(stringAtom)).toBe(promise)
+        await result
+        expect(store1.data.values.get(stringAtom)).toBe("updated")
+    })
+
+    test("set with bare rejected promise reverts to previous value", async () => {
+        const store1 = store()
+        const stringAtom = atom("initial")
+        store1.get(stringAtom)
+        const result = setAtom(
+            stringAtom,
+            Promise.reject(new Error("boom")),
+            store1.data,
+        )
+        try { await result } catch {}
+        await Promise.resolve()
+        expect(store1.get(stringAtom)).toBe("initial")
+    })
+
     test("set with async updater stores promise then resolves", async () => {
         const store1 = store()
         const stringAtom = atom("initial")

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -1,4 +1,5 @@
 import type { Atom } from "../types/Atom"
+import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { getState } from "./getState"
@@ -8,10 +9,7 @@ import { setValueInData } from "./setValueInData"
 
 export const setAtom = <Value = any>(
     atom: Atom<Value>,
-    newValue:
-        | Value
-        | Promise<Value>
-        | ((currentValue: Value) => Value | Promise<Value>),
+    newValue: SetAtomValue<Value>,
     data: StoreData,
     skipOnSet = false,
 ) => {
@@ -42,22 +40,25 @@ export const setAtom = <Value = any>(
             promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
         }
         setValueInData(atom, promise as Value, data)
-        promise.then(resolvedValue => {
-            // Stale promise guard: if another set() overwrote us, bail
-            if (data.values.get(atom) !== promise) return
-            setValueInData(atom, resolvedValue, data)
-            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
-            if (emptyAtomPromise) {
-                // @ts-ignore
-                emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
-            }
-            propagateUpdatedAtoms([atom], data)
-        }).catch(() => {
-            // On rejection, revert to previous value if promise is still current
-            if (data.values.get(atom) !== promise) return
-            setValueInData(atom, currentValue, data)
-            propagateUpdatedAtoms([atom], data)
-        })
+        promise.then(
+            resolvedValue => {
+                // Stale promise guard: if another set() overwrote us, bail
+                if (data.values.get(atom) !== promise) return
+                setValueInData(atom, resolvedValue, data)
+                if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
+                if (emptyAtomPromise) {
+                    // @ts-ignore
+                    emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
+                }
+                propagateUpdatedAtoms([atom], data)
+            },
+            () => {
+                // On rejection, revert to previous value if promise is still current
+                if (data.values.get(atom) !== promise) return
+                setValueInData(atom, currentValue, data)
+                propagateUpdatedAtoms([atom], data)
+            },
+        )
         if (initializedAtomsSet && initializedAtomsSet.size > 0) {
             initializedAtomsSet.add(atom)
             propagateUpdatedAtoms([...initializedAtomsSet], data)

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -25,7 +25,11 @@ export const setAtom = <Value = any>(
         newValue = newValue(currentValue)
     }
     if (isPromiseLike(newValue)) {
-        const promise = newValue as Promise<Value>
+        // Normalize thenables to real Promises so internal code (including
+        // downstream .catch/.finally handlers) always works on a Promise.
+        // Promise.resolve(realPromise) returns the same reference, so this
+        // is a no-op allocation for the common case.
+        const promise = Promise.resolve(newValue) as Promise<Value>
         // Same promise reference — no-op (matches equality check below)
         if (currentValue === promise) return promise as Value
         // @ts-ignore
@@ -67,16 +71,19 @@ export const setAtom = <Value = any>(
         }
         return promise as Value
     }
+    // Past the isPromiseLike branch newValue is guaranteed to be a plain
+    // Value (TypeScript can't narrow out PromiseLike fully, so we restate it).
+    let syncValue = newValue as Value
     const areEqual = isPromiseLike(currentValue)
-        ? currentValue === newValue
-        : atom.equal(currentValue, newValue)
-    if (areEqual) return newValue
-    newValue = setValueInData(atom, newValue, data)
-    if (atom.onSet && !skipOnSet) atom.onSet(newValue, data)
+        ? currentValue === syncValue
+        : atom.equal(currentValue, syncValue)
+    if (areEqual) return syncValue
+    syncValue = setValueInData(atom, syncValue, data)
+    if (atom.onSet && !skipOnSet) atom.onSet(syncValue, data)
     // @ts-ignore
     if (currentValue?.__isEmptyAtomPromise__) {
         // @ts-ignore
-        currentValue.__resolveEmptyAtomPromise__(newValue)
+        currentValue.__resolveEmptyAtomPromise__(syncValue)
     }
     if (initializedAtomsSet && initializedAtomsSet.size > 0) {
         initializedAtomsSet.add(atom)
@@ -84,5 +91,5 @@ export const setAtom = <Value = any>(
     } else {
         propagateUpdatedAtoms([atom], data)
     }
-    return newValue
+    return syncValue
 }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -24,8 +24,8 @@ const handlePromise = <Value>(
         promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
     }
     setValueInData(atom, promise as Value, data)
-    promise.then(
-        resolvedValue => {
+    promise
+        .then(resolvedValue => {
             // Stale promise guard: if another set() overwrote us, bail
             if (data.values.get(atom) !== promise) return
             setValueInData(atom, resolvedValue, data)
@@ -35,14 +35,17 @@ const handlePromise = <Value>(
                 emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
             }
             propagateUpdatedAtoms([atom], data)
-        },
-        () => {
-            // On rejection, revert to previous value if promise is still current
+        })
+        // Chained .catch so errors thrown inside the fulfilled handler
+        // (e.g. from atom.onSet) don't surface as unhandled rejections.
+        .catch(() => {
+            // Only revert if the promise is still the current in-flight value;
+            // if a fulfilled handler partially updated state, the guard below
+            // lets us avoid clobbering it.
             if (data.values.get(atom) !== promise) return
             setValueInData(atom, currentValue, data)
             propagateUpdatedAtoms([atom], data)
-        },
-    )
+        })
 }
 
 export const setAtom = <Value = any>(

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -8,7 +8,10 @@ import { setValueInData } from "./setValueInData"
 
 export const setAtom = <Value = any>(
     atom: Atom<Value>,
-    newValue: Value | ((currentValue: Value) => Value),
+    newValue:
+        | Value
+        | Promise<Value>
+        | ((currentValue: Value) => Value | Promise<Value>),
     data: StoreData,
     skipOnSet = false,
 ) => {
@@ -22,46 +25,46 @@ export const setAtom = <Value = any>(
     }
     if (isFunction(newValue)) {
         newValue = newValue(currentValue)
-        if (isPromiseLike(newValue)) {
-            const promise = newValue as Promise<Value>
-            // Same promise reference — no-op (matches equality check below)
-            if (currentValue === promise) return promise as Value
+    }
+    if (isPromiseLike(newValue)) {
+        const promise = newValue as Promise<Value>
+        // Same promise reference — no-op (matches equality check below)
+        if (currentValue === promise) return promise as Value
+        // @ts-ignore
+        // Preserve the empty-atom resolver so racing async sets can
+        // forward it even when the first set becomes stale.
+        const emptyAtomPromise = currentValue?.__isEmptyAtomPromise__
+            ? currentValue
             // @ts-ignore
-            // Preserve the empty-atom resolver so racing async sets can
-            // forward it even when the first set becomes stale.
-            const emptyAtomPromise = currentValue?.__isEmptyAtomPromise__
-                ? currentValue
-                // @ts-ignore
-                : currentValue?.__emptyAtomPromiseOrigin__ ?? null
+            : currentValue?.__emptyAtomPromiseOrigin__ ?? null
+        if (emptyAtomPromise) {
+            // @ts-ignore
+            promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
+        }
+        setValueInData(atom, promise as Value, data)
+        promise.then(resolvedValue => {
+            // Stale promise guard: if another set() overwrote us, bail
+            if (data.values.get(atom) !== promise) return
+            setValueInData(atom, resolvedValue, data)
+            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
             if (emptyAtomPromise) {
                 // @ts-ignore
-                promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
+                emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
             }
-            setValueInData(atom, promise as Value, data)
-            promise.then(resolvedValue => {
-                // Stale promise guard: if another set() overwrote us, bail
-                if (data.values.get(atom) !== promise) return
-                setValueInData(atom, resolvedValue, data)
-                if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
-                if (emptyAtomPromise) {
-                    // @ts-ignore
-                    emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
-                }
-                propagateUpdatedAtoms([atom], data)
-            }).catch(() => {
-                // On rejection, revert to previous value if promise is still current
-                if (data.values.get(atom) !== promise) return
-                setValueInData(atom, currentValue, data)
-                propagateUpdatedAtoms([atom], data)
-            })
-            if (initializedAtomsSet && initializedAtomsSet.size > 0) {
-                initializedAtomsSet.add(atom)
-                propagateUpdatedAtoms([...initializedAtomsSet], data)
-            } else {
-                propagateUpdatedAtoms([atom], data)
-            }
-            return promise as Value
+            propagateUpdatedAtoms([atom], data)
+        }).catch(() => {
+            // On rejection, revert to previous value if promise is still current
+            if (data.values.get(atom) !== promise) return
+            setValueInData(atom, currentValue, data)
+            propagateUpdatedAtoms([atom], data)
+        })
+        if (initializedAtomsSet && initializedAtomsSet.size > 0) {
+            initializedAtomsSet.add(atom)
+            propagateUpdatedAtoms([...initializedAtomsSet], data)
+        } else {
+            propagateUpdatedAtoms([atom], data)
         }
+        return promise as Value
     }
     const areEqual = isPromiseLike(currentValue) || isPromiseLike(newValue)
         ? currentValue === newValue

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -7,6 +7,44 @@ import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { setValueInData } from "./setValueInData"
 
+const handlePromise = <Value>(
+    atom: Atom<Value>,
+    promise: Promise<Value>,
+    currentValue: Value,
+    data: StoreData,
+    skipOnSet: boolean,
+) => {
+    // @ts-ignore
+    const emptyAtomPromise = currentValue?.__isEmptyAtomPromise__
+        ? currentValue
+        // @ts-ignore
+        : currentValue?.__emptyAtomPromiseOrigin__ ?? null
+    if (emptyAtomPromise) {
+        // @ts-ignore
+        promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
+    }
+    setValueInData(atom, promise as Value, data)
+    promise.then(
+        resolvedValue => {
+            // Stale promise guard: if another set() overwrote us, bail
+            if (data.values.get(atom) !== promise) return
+            setValueInData(atom, resolvedValue, data)
+            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
+            if (emptyAtomPromise) {
+                // @ts-ignore
+                emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
+            }
+            propagateUpdatedAtoms([atom], data)
+        },
+        () => {
+            // On rejection, revert to previous value if promise is still current
+            if (data.values.get(atom) !== promise) return
+            setValueInData(atom, currentValue, data)
+            propagateUpdatedAtoms([atom], data)
+        },
+    )
+}
+
 export const setAtom = <Value = any>(
     atom: Atom<Value>,
     newValue: SetAtomValue<Value>,
@@ -32,37 +70,7 @@ export const setAtom = <Value = any>(
         const promise = Promise.resolve(newValue) as Promise<Value>
         // Same promise reference — no-op (matches equality check below)
         if (currentValue === promise) return promise as Value
-        // @ts-ignore
-        // Preserve the empty-atom resolver so racing async sets can
-        // forward it even when the first set becomes stale.
-        const emptyAtomPromise = currentValue?.__isEmptyAtomPromise__
-            ? currentValue
-            // @ts-ignore
-            : currentValue?.__emptyAtomPromiseOrigin__ ?? null
-        if (emptyAtomPromise) {
-            // @ts-ignore
-            promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
-        }
-        setValueInData(atom, promise as Value, data)
-        promise.then(
-            resolvedValue => {
-                // Stale promise guard: if another set() overwrote us, bail
-                if (data.values.get(atom) !== promise) return
-                setValueInData(atom, resolvedValue, data)
-                if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
-                if (emptyAtomPromise) {
-                    // @ts-ignore
-                    emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
-                }
-                propagateUpdatedAtoms([atom], data)
-            },
-            () => {
-                // On rejection, revert to previous value if promise is still current
-                if (data.values.get(atom) !== promise) return
-                setValueInData(atom, currentValue, data)
-                propagateUpdatedAtoms([atom], data)
-            },
-        )
+        handlePromise(atom, promise, currentValue, data, skipOnSet)
         if (initializedAtomsSet && initializedAtomsSet.size > 0) {
             initializedAtomsSet.add(atom)
             propagateUpdatedAtoms([...initializedAtomsSet], data)

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -66,7 +66,7 @@ export const setAtom = <Value = any>(
         }
         return promise as Value
     }
-    const areEqual = isPromiseLike(currentValue) || isPromiseLike(newValue)
+    const areEqual = isPromiseLike(currentValue)
         ? currentValue === newValue
         : atom.equal(currentValue, newValue)
     if (areEqual) return newValue

--- a/packages/valdres/src/types/GlobalAtomSetSelfFunc.ts
+++ b/packages/valdres/src/types/GlobalAtomSetSelfFunc.ts
@@ -1,3 +1,5 @@
+import type { SetAtomValue } from "./SetAtomValue"
+
 export type GlobalAtomSetSelfFunc<Value = unknown> = (
-    value: Value | Promise<Value> | ((current: Value) => Value | Promise<Value>),
+    value: SetAtomValue<Value>,
 ) => void

--- a/packages/valdres/src/types/GlobalAtomSetSelfFunc.ts
+++ b/packages/valdres/src/types/GlobalAtomSetSelfFunc.ts
@@ -1,1 +1,3 @@
-export type GlobalAtomSetSelfFunc<Value = unknown> = (value: Value) => void
+export type GlobalAtomSetSelfFunc<Value = unknown> = (
+    value: Value | Promise<Value> | ((current: Value) => Value | Promise<Value>),
+) => void

--- a/packages/valdres/src/types/SetAtomValue.ts
+++ b/packages/valdres/src/types/SetAtomValue.ts
@@ -1,1 +1,4 @@
-export type SetAtomValue<Value> = Value | ((current: Value) => Value)
+export type SetAtomValue<Value> =
+    | Value
+    | Promise<Value>
+    | ((current: Value) => Value | Promise<Value>)

--- a/packages/valdres/src/types/SetAtomValue.ts
+++ b/packages/valdres/src/types/SetAtomValue.ts
@@ -1,4 +1,4 @@
 export type SetAtomValue<Value> =
     | Value
-    | Promise<Value>
-    | ((current: Value) => Value | Promise<Value>)
+    | PromiseLike<Value>
+    | ((current: Value) => Value | PromiseLike<Value>)

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -3,15 +3,16 @@ import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { GetValue } from "./GetValue"
 import type { ResetAtom } from "./ResetAtom"
 import type { ScopedStoreData, StoreData } from "./StoreData"
+import type { SetAtomValue } from "./SetAtomValue"
 import type { SubscribeFn } from "./SubscribeFn"
 import type { TransactionFn } from "./TransactionFn"
 
 type SetAtom = {
     <Value extends any, Args extends [any, ...any[]] = [any, ...any[]]>(
         atom: AtomFamilyAtom<Value, Args>,
-        value: Value,
+        value: SetAtomValue<Value>,
     ): void
-    <Value extends any>(atom: Atom<Value>, value: Value): void
+    <Value extends any>(atom: Atom<Value>, value: SetAtomValue<Value>): void
 }
 
 type DeleteAtom = <


### PR DESCRIPTION
## Summary
- `setAtom` only attached `.then/.catch` resolution handling when the caller passed a thunk that returned a promise. A bare `Promise` bypassed that branch and subscribers kept seeing the unresolved promise — e.g. `ipAtom.setSelf(fetchPublicIp(...))` in `@valdres/public-ip` left the UI on stale values.
- Hoist the `isPromiseLike(newValue)` branch above the `isFunction(newValue)` check so both call shapes share the stale-promise guard, rejection revert, and empty-atom-promise forwarding.
- Widen `SetAtomValue`, `GlobalAtomSetSelfFunc`, and the `Store` `SetAtom` overloads so the types reflect what the runtime accepts. Matches the jotai `setAtom(bare promise)` ergonomic.

## Test plan
- [x] `packages/valdres` — 272 pass / 0 fail (new red tests for bare-promise setSelf + rejected-promise revert)
- [x] `packages/@valdres-react/jotai` — 118 pass / 0 fail
- [x] `packages/@valdres/public-ip` — 23 pass / 0 fail
- [x] `bun run tsc` — no net-new errors vs. baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)