### PR TITLE
Add isVisibleSelector to @valdres/browser-visibility

### DIFF
--- a/packages/@valdres/browser-visibility/src/index.ts
+++ b/packages/@valdres/browser-visibility/src/index.ts
@@ -1,1 +1,2 @@
 export { visibilityAtom } from "./atoms/visibilityAtom"
+export { isVisibleSelector } from "./selectors/isVisibleSelector"

--- a/packages/@valdres/browser-visibility/src/selectors/isVisibleSelector.ts
+++ b/packages/@valdres/browser-visibility/src/selectors/isVisibleSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { visibilityAtom } from "../atoms/visibilityAtom"
+
+export const isVisibleSelector = selector(
+    get => get(visibilityAtom) === "visible",
+    { name: "@valdres/browser-visibility/isVisible" },
+)


### PR DESCRIPTION
## Summary
- Adds `isVisibleSelector` that derives a boolean from `visibilityAtom` (`true` when `visibilityState === "visible"`).
- Keeps `visibilityAtom` as `DocumentVisibilityState` so the atom stays faithful to the native Page Visibility API (which historically included states like `prerender`/`unloaded`), while giving callers a clean boolean for the common case.

## Test plan
- [ ] `bun test` in `packages/@valdres/browser-visibility`
- [ ] Verify `isVisibleSelector` is exported from the package entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)