### PR TITLE
Rebuild maxAge interval after globalAtom resetSelf

### DIFF
--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -370,6 +370,35 @@ describe("globalAtom", () => {
         unsub1()
     })
 
+    test("resetSelf revives maxAge for passive subscribers that don't re-read", async () => {
+        let defaultValueCalls = 0
+        const testAtom = atom(
+            () => {
+                defaultValueCalls++
+                return defaultValueCalls
+            },
+            { global: true, maxAge: 50 },
+        )
+
+        const store1 = store()
+        let callbackCalls = 0
+        const unsub = store1.sub(testAtom, () => {
+            callbackCalls++
+        })
+        store1.get(testAtom)
+
+        testAtom.resetSelf()
+
+        const callbackCallsAfterReset = callbackCalls
+        await wait(75)
+
+        // Timer should fire and notify the subscriber even though its
+        // callback never re-reads (so onInit isn't re-run via sync read).
+        expect(callbackCalls).toBeGreaterThan(callbackCallsAfterReset)
+
+        unsub()
+    })
+
     test("resetSelf stops maxAge interval when no subscribers remain", async () => {
         let callCount = 0
         const testAtom = atom(

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -333,7 +333,7 @@ describe("globalAtom", () => {
         expect(cleanupCount - cleanupBefore).toBe(1)
     })
 
-    test("resetSelf clears maxAge interval for global atom", async () => {
+    test("resetSelf rebuilds maxAge interval while subscribers remain", async () => {
         let callCount = 0
         const testAtom = atom(
             () => {
@@ -344,23 +344,50 @@ describe("globalAtom", () => {
         )
 
         const store1 = store()
-        const store2 = store()
 
-        const unsub1 = store1.sub(testAtom, () => {})
-        const unsub2 = store2.sub(testAtom, () => {})
+        const unsub1 = store1.sub(testAtom, () => {
+            store1.get(testAtom)
+        })
 
-        const countAfterInit = callCount
+        // Force initialization so the first defaultValue() call is counted.
+        store1.get(testAtom)
 
-        // Reset should clear the interval
+        // Baseline: the interval fires once before reset.
+        await wait(75)
+        const countBeforeReset = callCount
+        expect(countBeforeReset).toBeGreaterThanOrEqual(2)
+
         testAtom.resetSelf()
 
-        // Wait past when the interval would have fired
+        const countAfterReset = callCount
+
+        // After reset, the timer should be rebuilt for the still-subscribed
+        // store so revalidation continues.
         await wait(75)
 
-        // No revalidation calls should have happened after reset
-        expect(callCount - countAfterInit).toBe(0)
+        expect(callCount).toBeGreaterThan(countAfterReset)
 
         unsub1()
-        unsub2()
+    })
+
+    test("resetSelf stops maxAge interval when no subscribers remain", async () => {
+        let callCount = 0
+        const testAtom = atom(
+            () => {
+                callCount++
+                return callCount
+            },
+            { global: true, maxAge: 50 },
+        )
+
+        const store1 = store()
+        store1.get(testAtom)
+
+        testAtom.resetSelf()
+
+        const countAfterReset = callCount
+        await wait(75)
+
+        expect(callCount).toBe(countAfterReset)
     })
 })

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -80,6 +80,10 @@ export const globalAtom = <Value = unknown>(
             for (const store of snapshot) {
                 const subs = store.subscriptions.get(atom)
                 if (subs && subs.size > 0) {
+                    // Re-add the store so the timer's setAndPropagate can
+                    // reach subscribers whose callbacks don't sync re-read
+                    // (and therefore never re-ran onInit to rejoin `stores`).
+                    stores.add(store)
                     installMaxAgeTimer(atom, store)
                 }
             }

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -9,6 +9,7 @@ import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
+import { installMaxAgeTimer } from "./subscribe"
 import { globalStore } from "../globalStore"
 
 export const globalAtom = <Value = unknown>(
@@ -74,6 +75,14 @@ export const globalAtom = <Value = unknown>(
             }
         } finally {
             previousOnReset?.()
+        }
+        if (atom.maxAge) {
+            for (const store of snapshot) {
+                const subs = store.subscriptions.get(atom)
+                if (subs && subs.size > 0) {
+                    installMaxAgeTimer(atom, store)
+                }
+            }
         }
         if (firstError) throw firstError
     }

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -27,6 +27,244 @@ const initSubscribers = <V>(state: State<V> | Family<V>, data: StoreData) => {
     return set
 }
 
+export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
+    if (!state.maxAge) return
+    const globalState = isGlobalAtom(state) ? state : undefined
+    const existing = globalState?.maxAgeInterval
+
+    if (existing) {
+        // Another store already owns the interval — just bump refCount
+        existing.refCount++
+        // Seed the cache meta in this store from an existing store
+        const metaAtom = (state.__cacheMeta ??= { equal, defaultValue: null })
+        for (const s of globalState!.stores) {
+            if (s !== data && s.values.has(metaAtom)) {
+                setValueInData(metaAtom, s.values.get(metaAtom), data)
+                propagateUpdatedAtoms([metaAtom], data)
+                break
+            }
+        }
+        setMaxAgeCleanup(data, state, () => {
+            if (existing.refCount <= 0) return
+            existing.refCount--
+            if (existing.refCount === 0) {
+                existing.cleanup()
+                if (globalState!.maxAgeInterval === existing) {
+                    globalState!.maxAgeInterval = undefined
+                }
+            }
+        })
+        return
+    }
+
+    const pendingTimeouts = new Set<Timer>()
+    let revalidating = false
+    let cancelled = false
+    let lastSuccessTime = Date.now()
+    const NO_VALUE = Symbol()
+    let lastGoodValue: any = NO_VALUE
+    let currentInterval: Timer
+
+    const getMaxAge = (): number => resolveReactive(state.maxAge!, data)
+    const getSWR = (): number =>
+        state.staleWhileRevalidate !== undefined
+            ? resolveReactive(state.staleWhileRevalidate, data)
+            : Infinity
+    const getStaleIfError = (): number =>
+        state.staleIfError !== undefined
+            ? resolveReactive(state.staleIfError, data)
+            : Infinity
+
+    const metaAtom = (state.__cacheMeta ??= { equal, defaultValue: null })
+    const updateMeta = () => {
+        const meta: CacheMeta = {
+            isRevalidating: revalidating,
+            lastSuccessAt: lastSuccessTime,
+            maxAge: getMaxAge(),
+            staleWhileRevalidate: getSWR(),
+            staleIfError: getStaleIfError(),
+        }
+        if (globalState) {
+            for (const store of globalState.stores) {
+                setValueInData(metaAtom, meta, store)
+                propagateUpdatedAtoms([metaAtom], store)
+            }
+        } else {
+            setValueInData(metaAtom, meta, data)
+            propagateUpdatedAtoms([metaAtom], data)
+        }
+    }
+
+    const isPastStaleIfErrorWindow = () => {
+        const elapsed = Date.now() - lastSuccessTime
+        return elapsed >= getMaxAge() + getStaleIfError()
+    }
+
+    const setAndPropagate = (atom: Atom, val: any) => {
+        if (globalState) {
+            for (const store of globalState.stores) {
+                setValueInData(atom, val, store)
+                propagateUpdatedAtoms([atom], store)
+            }
+        } else {
+            setValueInData(atom, val, data)
+            propagateUpdatedAtoms([atom], data)
+        }
+    }
+
+    // For global atoms, read the current value from any store in the set
+    // rather than the closed-over `data` which may become stale if that
+    // store is detached.
+    const getValueStore = (): StoreData => {
+        if (globalState) {
+            for (const s of globalState.stores) return s
+            // All stores detached — fall back to the original
+        }
+        return data
+    }
+
+    const tick = () => {
+        if (revalidating) return
+        if (typeof state.defaultValue !== "function") return
+        const valueStore = getValueStore()
+        if (valueStore.values.has(state)) {
+            const currentValue = valueStore.values.get(state)
+            if (!isPromiseLike(currentValue)) {
+                lastGoodValue = currentValue
+            }
+        }
+        const value = (state.defaultValue as () => any)()
+        if (isPromiseLike(value)) {
+            revalidating = true
+            updateMeta()
+            const swr = getSWR()
+
+            const handleResolve = (resolved: any) => {
+                if (cancelled) return
+                revalidating = false
+                lastSuccessTime = Date.now()
+                lastGoodValue = resolved
+                setAndPropagate(state, resolved)
+                updateMeta()
+            }
+
+            const handleReject = () => {
+                if (cancelled) return
+                revalidating = false
+                if (
+                    !isPastStaleIfErrorWindow() &&
+                    lastGoodValue !== NO_VALUE
+                ) {
+                    setAndPropagate(state, lastGoodValue)
+                } else {
+                    setAndPropagate(state, value)
+                }
+                updateMeta()
+            }
+
+            if (swr > 0) {
+                // SWR: keep stale value visible during revalidation.
+                // Finite swr enforces a window: if the request is still
+                // in flight when it expires, flip to the pending promise
+                // (loading state).
+                let timeoutRef: Timer | undefined
+                if (Number.isFinite(swr)) {
+                    timeoutRef = setTimeout(() => {
+                        pendingTimeouts.delete(timeoutRef!)
+                        if (cancelled || !revalidating) return
+                        setAndPropagate(state, value)
+                    }, swr)
+                    pendingTimeouts.add(timeoutRef)
+                }
+                value.then(
+                    (resolved: any) => {
+                        if (timeoutRef !== undefined) {
+                            clearTimeout(timeoutRef)
+                            pendingTimeouts.delete(timeoutRef)
+                        }
+                        handleResolve(resolved)
+                    },
+                    () => {
+                        if (timeoutRef !== undefined) {
+                            clearTimeout(timeoutRef)
+                            pendingTimeouts.delete(timeoutRef)
+                        }
+                        handleReject()
+                    },
+                )
+            } else {
+                // swr === 0: opt out of stale-while-revalidate; show
+                // pending promise immediately on revalidate.
+                setAndPropagate(state, value)
+                value.then(handleResolve, handleReject)
+            }
+        } else {
+            lastSuccessTime = Date.now()
+            lastGoodValue = value
+            setAndPropagate(state, value)
+            updateMeta()
+        }
+    }
+
+    const startInterval = () => {
+        currentInterval = setInterval(tick, getMaxAge())
+    }
+
+    startInterval()
+    updateMeta()
+
+    const configUnsubs: (() => void)[] = []
+    if (isReactive(state.maxAge)) {
+        configUnsubs.push(
+            subscribe(
+                state.maxAge as any,
+                () => {
+                    clearInterval(currentInterval)
+                    startInterval()
+                    updateMeta()
+                },
+                false,
+                data,
+            ),
+        )
+    }
+    if (state.staleWhileRevalidate && isReactive(state.staleWhileRevalidate)) {
+        configUnsubs.push(
+            subscribe(state.staleWhileRevalidate as any, () => updateMeta(), false, data),
+        )
+    }
+    if (state.staleIfError && isReactive(state.staleIfError)) {
+        configUnsubs.push(
+            subscribe(state.staleIfError as any, () => updateMeta(), false, data),
+        )
+    }
+
+    const cleanup = () => {
+        cancelled = true
+        clearInterval(currentInterval)
+        for (const t of pendingTimeouts) clearTimeout(t)
+        pendingTimeouts.clear()
+        for (const unsub of configUnsubs) unsub()
+    }
+
+    if (globalState) {
+        const entry = { cleanup, refCount: 1 }
+        globalState.maxAgeInterval = entry
+        setMaxAgeCleanup(data, state, () => {
+            if (entry.refCount <= 0) return
+            entry.refCount--
+            if (entry.refCount === 0) {
+                entry.cleanup()
+                if (globalState.maxAgeInterval === entry) {
+                    globalState.maxAgeInterval = undefined
+                }
+            }
+        })
+    } else {
+        setMaxAgeCleanup(data, state, cleanup)
+    }
+}
+
 export const subscribe = <V>(
     state: State<V> | Family<V>,
     callback: (arg?: any) => void,
@@ -99,242 +337,7 @@ export const subscribe = <V>(
     subscribers.add(subscription)
     if (subscribers.size === 1) {
         if (isAtom(state) && state.maxAge) {
-            const globalState = isGlobalAtom(state) ? state : undefined
-            const existing = globalState?.maxAgeInterval
-
-            if (existing) {
-                // Another store already owns the interval — just bump refCount
-                existing.refCount++
-                // Seed the cache meta in this store from an existing store
-                const metaAtom = state.__cacheMeta ??= { equal, defaultValue: null }
-                for (const s of globalState!.stores) {
-                    if (s !== data && s.values.has(metaAtom)) {
-                        setValueInData(metaAtom, s.values.get(metaAtom), data)
-                        propagateUpdatedAtoms([metaAtom], data)
-                        break
-                    }
-                }
-                setMaxAgeCleanup(data, state, () => {
-                    if (existing.refCount <= 0) return
-                    existing.refCount--
-                    if (existing.refCount === 0) {
-                        existing.cleanup()
-                        if (globalState.maxAgeInterval === existing) {
-                            globalState.maxAgeInterval = undefined
-                        }
-                    }
-                })
-            } else {
-                const pendingTimeouts = new Set<Timer>()
-                let revalidating = false
-                let cancelled = false
-                let lastSuccessTime = Date.now()
-                const NO_VALUE = Symbol()
-                let lastGoodValue: any = NO_VALUE
-                let currentInterval: Timer
-
-                const getMaxAge = (): number =>
-                    resolveReactive(state.maxAge!, data)
-                const getSWR = (): number =>
-                    state.staleWhileRevalidate !== undefined
-                        ? resolveReactive(state.staleWhileRevalidate, data)
-                        : Infinity
-                const getStaleIfError = (): number =>
-                    state.staleIfError !== undefined
-                        ? resolveReactive(state.staleIfError, data)
-                        : Infinity
-
-                const metaAtom = state.__cacheMeta ??= { equal, defaultValue: null }
-                const updateMeta = () => {
-                    const meta: CacheMeta = {
-                        isRevalidating: revalidating,
-                        lastSuccessAt: lastSuccessTime,
-                        maxAge: getMaxAge(),
-                        staleWhileRevalidate: getSWR(),
-                        staleIfError: getStaleIfError(),
-                    }
-                    if (globalState) {
-                        for (const store of globalState.stores) {
-                            setValueInData(metaAtom, meta, store)
-                            propagateUpdatedAtoms([metaAtom], store)
-                        }
-                    } else {
-                        setValueInData(metaAtom, meta, data)
-                        propagateUpdatedAtoms([metaAtom], data)
-                    }
-                }
-
-                const isPastStaleIfErrorWindow = () => {
-                    const elapsed = Date.now() - lastSuccessTime
-                    return elapsed >= getMaxAge() + getStaleIfError()
-                }
-
-                // For global atoms, propagate to all stores; for regular atoms, just this store
-                const setAndPropagate = (atom: Atom, val: any) => {
-                    if (globalState) {
-                        for (const store of globalState.stores) {
-                            setValueInData(atom, val, store)
-                            propagateUpdatedAtoms([atom], store)
-                        }
-                    } else {
-                        setValueInData(atom, val, data)
-                        propagateUpdatedAtoms([atom], data)
-                    }
-                }
-
-                // For global atoms, read the current value from any
-                // store in the set rather than the closed-over `data`
-                // which may become stale if that store is detached.
-                const getValueStore = (): StoreData => {
-                    if (globalState) {
-                        for (const s of globalState.stores) return s
-                        // All stores detached — fall back to the original
-                    }
-                    return data
-                }
-
-                const tick = () => {
-                    if (revalidating) return
-                    if (typeof state.defaultValue !== "function") return
-                    const valueStore = getValueStore()
-                    if (valueStore.values.has(state)) {
-                        const currentValue = valueStore.values.get(state)
-                        if (!isPromiseLike(currentValue)) {
-                            lastGoodValue = currentValue
-                        }
-                    }
-                    const value = state.defaultValue()
-                    if (isPromiseLike(value)) {
-                        revalidating = true
-                        updateMeta()
-                        const swr = getSWR()
-
-                        const handleResolve = (resolved: any) => {
-                            if (cancelled) return
-                            revalidating = false
-                            lastSuccessTime = Date.now()
-                            lastGoodValue = resolved
-                            setAndPropagate(state, resolved)
-                            updateMeta()
-                        }
-
-                        const handleReject = () => {
-                            if (cancelled) return
-                            revalidating = false
-                            if (
-                                !isPastStaleIfErrorWindow() &&
-                                lastGoodValue !== NO_VALUE
-                            ) {
-                                setAndPropagate(state, lastGoodValue)
-                            } else {
-                                setAndPropagate(state, value)
-                            }
-                            updateMeta()
-                        }
-
-                        if (swr > 0) {
-                            // SWR: keep stale value visible during revalidation.
-                            // Finite swr enforces a window: if the request is
-                            // still in flight when it expires, flip to the
-                            // pending promise (loading state).
-                            let timeoutRef: Timer | undefined
-                            if (Number.isFinite(swr)) {
-                                timeoutRef = setTimeout(() => {
-                                    pendingTimeouts.delete(timeoutRef!)
-                                    if (cancelled || !revalidating) return
-                                    setAndPropagate(state, value)
-                                }, swr)
-                                pendingTimeouts.add(timeoutRef)
-                            }
-                            value.then(
-                                (resolved: any) => {
-                                    if (timeoutRef !== undefined) {
-                                        clearTimeout(timeoutRef)
-                                        pendingTimeouts.delete(timeoutRef)
-                                    }
-                                    handleResolve(resolved)
-                                },
-                                () => {
-                                    if (timeoutRef !== undefined) {
-                                        clearTimeout(timeoutRef)
-                                        pendingTimeouts.delete(timeoutRef)
-                                    }
-                                    handleReject()
-                                },
-                            )
-                        } else {
-                            // swr === 0: opt out of stale-while-revalidate;
-                            // show pending promise immediately on revalidate.
-                            setAndPropagate(state, value)
-                            value.then(handleResolve, handleReject)
-                        }
-                    } else {
-                        lastSuccessTime = Date.now()
-                        lastGoodValue = value
-                        setAndPropagate(state, value)
-                        updateMeta()
-                    }
-                }
-
-                const startInterval = () => {
-                    currentInterval = setInterval(tick, getMaxAge())
-                }
-
-                startInterval()
-                updateMeta()
-
-                // Subscribe to reactive config changes
-                const configUnsubs: (() => void)[] = []
-                if (isReactive(state.maxAge)) {
-                    configUnsubs.push(
-                        subscribe(
-                            state.maxAge as any,
-                            () => {
-                                clearInterval(currentInterval)
-                                startInterval()
-                                updateMeta()
-                            },
-                            false,
-                            data,
-                        ),
-                    )
-                }
-                if (state.staleWhileRevalidate && isReactive(state.staleWhileRevalidate)) {
-                    configUnsubs.push(
-                        subscribe(state.staleWhileRevalidate as any, () => updateMeta(), false, data),
-                    )
-                }
-                if (state.staleIfError && isReactive(state.staleIfError)) {
-                    configUnsubs.push(
-                        subscribe(state.staleIfError as any, () => updateMeta(), false, data),
-                    )
-                }
-
-                const cleanup = () => {
-                    cancelled = true
-                    clearInterval(currentInterval)
-                    for (const t of pendingTimeouts) clearTimeout(t)
-                    pendingTimeouts.clear()
-                    for (const unsub of configUnsubs) unsub()
-                }
-
-                if (globalState) {
-                    const entry = { cleanup, refCount: 1 }
-                    globalState.maxAgeInterval = entry
-                    setMaxAgeCleanup(data, state, () => {
-                        if (entry.refCount <= 0) return
-                        entry.refCount--
-                        if (entry.refCount === 0) {
-                            entry.cleanup()
-                            if (globalState.maxAgeInterval === entry) {
-                                globalState.maxAgeInterval = undefined
-                            }
-                        }
-                    })
-                } else {
-                    setMaxAgeCleanup(data, state, cleanup)
-                }
-            }
+            installMaxAgeTimer(state, data)
         }
         // Mount this state and all its transitive dependencies
         if (!isFamily(state)) {


### PR DESCRIPTION
## Summary
- Fixes a bug where `globalAtom.resetSelf()` cleared `atom.maxAgeInterval` but left per-store subscribers in place. Since the interval is only created on the 0→1 subscriber transition, the timer was never rebuilt, leaving `maxAge`-driven revalidation silently broken for that atom until its last subscriber fully detached.
- Extracts the maxAge timer setup from `subscribe.ts` into an exported `installMaxAgeTimer` helper.
- `resetSelf` now calls the helper for every store with remaining subscribers, mirroring the first-subscriber path.
- Replaces the prior `"resetSelf clears maxAge interval for global atom"` test (which codified the buggy behavior) with:
  - `"resetSelf rebuilds maxAge interval while subscribers remain"` — asserts revalidation continues.
  - `"resetSelf stops maxAge interval when no subscribers remain"` — asserts no runaway timer when the atom is idle.

## Test plan
- [x] `bun test` in `packages/valdres` — 271 pass, 1 todo, 0 fail
- [x] `bun test` in `packages/@valdres/public-ip` — 23 pass
- [x] Full workspace `bun test` — same failure count as `main` (pre-existing SSR/browser-env failures unrelated to this change)
- [x] `bun run tsc --noEmit` — no new errors in `subscribe.ts` / `globalAtom.ts`
- [x] New red test fails before the fix, passes after

🤖 Generated with [Claude Code](https://claude.com/claude-code)