### PR TITLE
Skip heap snapshot on first LeakDetector round

### DIFF
--- a/packages/test/src/LeakDetector.ts
+++ b/packages/test/src/LeakDetector.ts
@@ -26,7 +26,7 @@ export class LeakDetector {
         for (let round = 0; round < 10; round++) {
             fullGC()
             releaseWeakRefs()
-            generateHeapSnapshot()
+            if (round > 0) generateHeapSnapshot()
             fullGC()
             releaseWeakRefs()
             await Bun.sleep(0)


### PR DESCRIPTION
## Summary
- Skip `generateHeapSnapshot()` on round 0 of `LeakDetector.isLeaking()`. Heap snapshots walk the entire heap and are only needed to force JSC WeakMap ephemeron cleanup — for the common `WeakRef`-only case, `fullGC()` + `releaseWeakRefs()` clears the ref on the first round.
- Rounds 1–9 still run snapshots, so any test that actually needs ephemeron cleanup falls back to the original strategy before declaring a leak. CI flakiness characteristics should be identical.

## Impact (local measurements)
| | Before | After |
|---|---:|---:|
| `memoryleaks.test.ts` | 5.60s | 1.35s |
| `@valdres-react/jotai` full | 9.94s | 5.15s |
| Monorepo (`bun --filter '*' --parallel test`) | ~10s | ~6s |

## Test plan
- [ ] CI passes across all jobs
- [ ] Run CI a few times to check for any new flakiness in the memory leak tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)