### PR TITLE
Add five browser-* packages for prefers-* media queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,42 @@
         "typescript": "5.9.2",
       },
     },
+    "packages/@valdres/browser-color-scheme": {
+      "name": "@valdres/browser-color-scheme",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
+    "packages/@valdres/browser-contrast": {
+      "name": "@valdres/browser-contrast",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-focus": {
       "name": "@valdres/browser-focus",
       "version": "0.2.0-pre.28",
@@ -170,6 +206,60 @@
         "@valdres/browser-focus": "0.2.0-pre.28",
         "@valdres/browser-visibility": "0.2.0-pre.28",
       },
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
+    "packages/@valdres/browser-reduced-data": {
+      "name": "@valdres/browser-reduced-data",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
+    "packages/@valdres/browser-reduced-motion": {
+      "name": "@valdres/browser-reduced-motion",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
+    "packages/@valdres/browser-reduced-transparency": {
+      "name": "@valdres/browser-reduced-transparency",
+      "version": "0.2.0-pre.28",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -1070,6 +1160,10 @@
 
     "@valdres-react/recoil": ["@valdres-react/recoil@workspace:packages/@valdres-react/recoil"],
 
+    "@valdres/browser-color-scheme": ["@valdres/browser-color-scheme@workspace:packages/@valdres/browser-color-scheme"],
+
+    "@valdres/browser-contrast": ["@valdres/browser-contrast@workspace:packages/@valdres/browser-contrast"],
+
     "@valdres/browser-focus": ["@valdres/browser-focus@workspace:packages/@valdres/browser-focus"],
 
     "@valdres/browser-geolocation": ["@valdres/browser-geolocation@workspace:packages/@valdres/browser-geolocation"],
@@ -1079,6 +1173,12 @@
     "@valdres/browser-online": ["@valdres/browser-online@workspace:packages/@valdres/browser-online"],
 
     "@valdres/browser-presence": ["@valdres/browser-presence@workspace:packages/@valdres/browser-presence"],
+
+    "@valdres/browser-reduced-data": ["@valdres/browser-reduced-data@workspace:packages/@valdres/browser-reduced-data"],
+
+    "@valdres/browser-reduced-motion": ["@valdres/browser-reduced-motion@workspace:packages/@valdres/browser-reduced-motion"],
+
+    "@valdres/browser-reduced-transparency": ["@valdres/browser-reduced-transparency@workspace:packages/@valdres/browser-reduced-transparency"],
 
     "@valdres/browser-screen": ["@valdres/browser-screen@workspace:packages/@valdres/browser-screen"],
 
@@ -2940,6 +3040,14 @@
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.25.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.7", "@babel/helper-validator-identifier": "^7.25.7", "to-fast-properties": "^2.0.0" } }, "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ=="],
 
+    "@valdres/browser-color-scheme/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-color-scheme/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-contrast/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-contrast/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
     "@valdres/browser-focus/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-focus/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
@@ -2955,6 +3063,18 @@
     "@valdres/browser-presence/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-presence/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-reduced-data/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-reduced-data/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-reduced-motion/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-reduced-motion/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-reduced-transparency/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-reduced-transparency/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-screen/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-color-scheme/bunfig.toml
+++ b/packages/@valdres/browser-color-scheme/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-color-scheme/dev/index.html
+++ b/packages/@valdres/browser-color-scheme/dev/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-color-scheme demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-color-scheme</h1>
+        <p class="muted">
+            Reactive wrapper for
+            <code>matchMedia("(prefers-color-scheme: dark)")</code>. Flip your
+            OS / browser dark-mode setting and this card updates live.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-color-scheme/dev/index.tsx
+++ b/packages/@valdres/browser-color-scheme/dev/index.tsx
@@ -1,0 +1,48 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { colorSchemeAtom, type ColorScheme } from "../src"
+
+type Entry = { at: string; scheme: ColorScheme }
+
+const Demo = () => {
+    const scheme = useValue(colorSchemeAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<ColorScheme | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === scheme) return
+        lastLogged.current = scheme
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), scheme },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [scheme])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${scheme === "dark" ? " on" : ""}`} />
+                <span className="label">{scheme}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.scheme}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-color-scheme/dev/server.ts
+++ b/packages/@valdres/browser-color-scheme/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3021),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-color-scheme demo: ${server.url}`)

--- a/packages/@valdres/browser-color-scheme/package.json
+++ b/packages/@valdres/browser-color-scheme/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-color-scheme",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-color-scheme/src/atoms/colorSchemeAtom.test.ts
+++ b/packages/@valdres/browser-color-scheme/src/atoms/colorSchemeAtom.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { colorSchemeAtom } from "./colorSchemeAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("colorSchemeAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        colorSchemeAtom.resetSelf()
+    })
+
+    test("initial value reflects matchMedia at first read", () => {
+        installMatchMedia(true)
+        const s = store()
+        expect(s.get(colorSchemeAtom)).toBe("dark")
+    })
+
+    test("updates when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        expect(s.get(colorSchemeAtom)).toBe("light")
+
+        mq.set(true)
+        expect(s.get(colorSchemeAtom)).toBe("dark")
+
+        mq.set(false)
+        expect(s.get(colorSchemeAtom)).toBe("light")
+    })
+})

--- a/packages/@valdres/browser-color-scheme/src/atoms/colorSchemeAtom.ts
+++ b/packages/@valdres/browser-color-scheme/src/atoms/colorSchemeAtom.ts
@@ -1,0 +1,17 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type ColorScheme = "light" | "dark"
+
+export const COLOR_SCHEME_MEDIA = "(prefers-color-scheme: dark)"
+
+const getInitial = (): ColorScheme => {
+    if (typeof window === "undefined" || !window.matchMedia) return "light"
+    return window.matchMedia(COLOR_SCHEME_MEDIA).matches ? "dark" : "light"
+}
+
+export const colorSchemeAtom = atom<ColorScheme>(getInitial, {
+    global: true,
+    name: "@valdres/browser-color-scheme/colorScheme",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-color-scheme/src/index.ts
+++ b/packages/@valdres/browser-color-scheme/src/index.ts
@@ -1,0 +1,3 @@
+export { colorSchemeAtom, type ColorScheme } from "./atoms/colorSchemeAtom"
+export { isDarkSelector } from "./selectors/isDarkSelector"
+export { isLightSelector } from "./selectors/isLightSelector"

--- a/packages/@valdres/browser-color-scheme/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-color-scheme/src/lib/subscribe.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { colorSchemeAtom } from "../atoms/colorSchemeAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        colorSchemeAtom.resetSelf()
+    })
+
+    test("syncs initial value from matchMedia", () => {
+        installMatchMedia(true)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(colorSchemeAtom)).toBe("dark")
+        cleanup?.()
+    })
+
+    test("updates atom when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(colorSchemeAtom)).toBe("light")
+
+        mq.set(true)
+        expect(s.get(colorSchemeAtom)).toBe("dark")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-color-scheme/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-color-scheme/src/lib/subscribe.ts
@@ -1,0 +1,12 @@
+import { COLOR_SCHEME_MEDIA, colorSchemeAtom } from "../atoms/colorSchemeAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const mq = window.matchMedia(COLOR_SCHEME_MEDIA)
+    const sync = () => colorSchemeAtom.setSelf(mq.matches ? "dark" : "light")
+    sync()
+    mq.addEventListener("change", sync)
+    return () => {
+        mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-color-scheme/src/selectors/isDarkSelector.ts
+++ b/packages/@valdres/browser-color-scheme/src/selectors/isDarkSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { colorSchemeAtom } from "../atoms/colorSchemeAtom"
+
+export const isDarkSelector = selector(
+    get => get(colorSchemeAtom) === "dark",
+    { name: "@valdres/browser-color-scheme/isDark" },
+)

--- a/packages/@valdres/browser-color-scheme/src/selectors/isLightSelector.ts
+++ b/packages/@valdres/browser-color-scheme/src/selectors/isLightSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { colorSchemeAtom } from "../atoms/colorSchemeAtom"
+
+export const isLightSelector = selector(
+    get => get(colorSchemeAtom) === "light",
+    { name: "@valdres/browser-color-scheme/isLight" },
+)

--- a/packages/@valdres/browser-color-scheme/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-color-scheme/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-color-scheme/tsconfig.json
+++ b/packages/@valdres/browser-color-scheme/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-contrast/bunfig.toml
+++ b/packages/@valdres/browser-contrast/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-contrast/dev/index.html
+++ b/packages/@valdres/browser-contrast/dev/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-contrast demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-contrast</h1>
+        <p class="muted">
+            Reactive wrapper for <code>prefers-contrast</code>. Values:
+            <code>no-preference</code>, <code>more</code>, <code>less</code>,
+            <code>custom</code>. macOS: System Settings → Accessibility →
+            Display → Increase Contrast.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-contrast/dev/index.tsx
+++ b/packages/@valdres/browser-contrast/dev/index.tsx
@@ -1,0 +1,50 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { contrastAtom, type Contrast } from "../src"
+
+type Entry = { at: string; value: Contrast }
+
+const Demo = () => {
+    const value = useValue(contrastAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<Contrast | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span
+                    className={`dot${value !== "no-preference" ? " on" : ""}`}
+                />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-contrast/dev/server.ts
+++ b/packages/@valdres/browser-contrast/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3023),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-contrast demo: ${server.url}`)

--- a/packages/@valdres/browser-contrast/package.json
+++ b/packages/@valdres/browser-contrast/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-contrast",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { contrastAtom, type Contrast } from "./contrastAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initial: Contrast) => {
+    const mqsByQuery = new Map<string, MockMq[]>()
+    let current: Contrast = initial
+    const matchesFor = (query: string) => {
+        if (query.includes("more")) return current === "more"
+        if (query.includes("less")) return current === "less"
+        if (query.includes("custom")) return current === "custom"
+        return false
+    }
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matchesFor(query)
+        mq.media = query
+        const bucket = mqsByQuery.get(query) ?? []
+        bucket.push(mq)
+        mqsByQuery.set(query, bucket)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: Contrast) => {
+            current = next
+            for (const [query, bucket] of mqsByQuery) {
+                const m = matchesFor(query)
+                for (const mq of bucket) {
+                    if (mq.matches !== m) {
+                        mq.matches = m
+                        mq.dispatchEvent(new Event("change"))
+                    }
+                }
+            }
+        },
+    }
+}
+
+describe("contrastAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        contrastAtom.resetSelf()
+    })
+
+    test("initial value reflects active media query", () => {
+        installMatchMedia("more")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("more")
+    })
+
+    test("falls back to no-preference when no query matches", () => {
+        installMatchMedia("no-preference")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+    })
+
+    test("updates when any media query change event fires", () => {
+        const mq = installMatchMedia("no-preference")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+
+        mq.set("more")
+        expect(s.get(contrastAtom)).toBe("more")
+
+        mq.set("less")
+        expect(s.get(contrastAtom)).toBe("less")
+
+        mq.set("custom")
+        expect(s.get(contrastAtom)).toBe("custom")
+
+        mq.set("no-preference")
+        expect(s.get(contrastAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
@@ -1,0 +1,26 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type Contrast = "no-preference" | "more" | "less" | "custom"
+
+export const CONTRAST_QUERIES: { value: Contrast; query: string }[] = [
+    { value: "more", query: "(prefers-contrast: more)" },
+    { value: "less", query: "(prefers-contrast: less)" },
+    { value: "custom", query: "(prefers-contrast: custom)" },
+]
+
+export const readContrast = (): Contrast => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    for (const { value, query } of CONTRAST_QUERIES) {
+        if (window.matchMedia(query).matches) return value
+    }
+    return "no-preference"
+}
+
+export const contrastAtom = atom<Contrast>(readContrast, {
+    global: true,
+    name: "@valdres/browser-contrast/contrast",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-contrast/src/index.ts
+++ b/packages/@valdres/browser-contrast/src/index.ts
@@ -1,0 +1,3 @@
+export { contrastAtom, type Contrast } from "./atoms/contrastAtom"
+export { prefersMoreContrastSelector } from "./selectors/prefersMoreContrastSelector"
+export { prefersLessContrastSelector } from "./selectors/prefersLessContrastSelector"

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { contrastAtom, type Contrast } from "../atoms/contrastAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initial: Contrast) => {
+    const mqsByQuery = new Map<string, MockMq[]>()
+    let current: Contrast = initial
+    const matchesFor = (query: string) => {
+        if (query.includes("more")) return current === "more"
+        if (query.includes("less")) return current === "less"
+        if (query.includes("custom")) return current === "custom"
+        return false
+    }
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matchesFor(query)
+        mq.media = query
+        const bucket = mqsByQuery.get(query) ?? []
+        bucket.push(mq)
+        mqsByQuery.set(query, bucket)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: Contrast) => {
+            current = next
+            for (const [query, bucket] of mqsByQuery) {
+                const m = matchesFor(query)
+                for (const mq of bucket) {
+                    if (mq.matches !== m) {
+                        mq.matches = m
+                        mq.dispatchEvent(new Event("change"))
+                    }
+                }
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        contrastAtom.resetSelf()
+    })
+
+    test("syncs initial value from active media query", () => {
+        installMatchMedia("less")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(contrastAtom)).toBe("less")
+        cleanup?.()
+    })
+
+    test("updates atom when any media query change event fires", () => {
+        const mq = installMatchMedia("no-preference")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+
+        mq.set("more")
+        expect(s.get(contrastAtom)).toBe("more")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import {
+    CONTRAST_QUERIES,
+    contrastAtom,
+    readContrast,
+} from "../atoms/contrastAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const sync = () => contrastAtom.setSelf(readContrast())
+    sync()
+    const mqs = CONTRAST_QUERIES.map(({ query }) => window.matchMedia(query))
+    for (const mq of mqs) mq.addEventListener("change", sync)
+    return () => {
+        for (const mq of mqs) mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-contrast/src/selectors/prefersLessContrastSelector.ts
+++ b/packages/@valdres/browser-contrast/src/selectors/prefersLessContrastSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { contrastAtom } from "../atoms/contrastAtom"
+
+export const prefersLessContrastSelector = selector(
+    get => get(contrastAtom) === "less",
+    { name: "@valdres/browser-contrast/prefersLessContrast" },
+)

--- a/packages/@valdres/browser-contrast/src/selectors/prefersMoreContrastSelector.ts
+++ b/packages/@valdres/browser-contrast/src/selectors/prefersMoreContrastSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { contrastAtom } from "../atoms/contrastAtom"
+
+export const prefersMoreContrastSelector = selector(
+    get => get(contrastAtom) === "more",
+    { name: "@valdres/browser-contrast/prefersMoreContrast" },
+)

--- a/packages/@valdres/browser-contrast/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-contrast/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-contrast/tsconfig.json
+++ b/packages/@valdres/browser-contrast/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-reduced-data/bunfig.toml
+++ b/packages/@valdres/browser-reduced-data/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-reduced-data/dev/index.html
+++ b/packages/@valdres/browser-reduced-data/dev/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-reduced-data demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-reduced-data</h1>
+        <p class="muted">
+            Reactive wrapper for
+            <code>matchMedia("(prefers-reduced-data: reduce)")</code>. Only
+            Chromium ships this today; Chrome exposes it behind the Save-Data
+            setting (DevTools → Network conditions → Throttling).
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-reduced-data/dev/index.tsx
+++ b/packages/@valdres/browser-reduced-data/dev/index.tsx
@@ -1,0 +1,48 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { reducedDataAtom, type ReducedData } from "../src"
+
+type Entry = { at: string; value: ReducedData }
+
+const Demo = () => {
+    const value = useValue(reducedDataAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<ReducedData | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${value === "reduce" ? " on" : ""}`} />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-reduced-data/dev/server.ts
+++ b/packages/@valdres/browser-reduced-data/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3025),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-reduced-data demo: ${server.url}`)

--- a/packages/@valdres/browser-reduced-data/package.json
+++ b/packages/@valdres/browser-reduced-data/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-reduced-data",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedDataAtom } from "./reducedDataAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("reducedDataAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedDataAtom.resetSelf()
+    })
+
+    test("initial value reflects matchMedia at first read", () => {
+        installMatchMedia(true)
+        const s = store()
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+    })
+
+    test("updates when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+
+        mq.set(false)
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
@@ -1,0 +1,21 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type ReducedData = "no-preference" | "reduce"
+
+export const REDUCED_DATA_MEDIA = "(prefers-reduced-data: reduce)"
+
+const getInitial = (): ReducedData => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    return window.matchMedia(REDUCED_DATA_MEDIA).matches
+        ? "reduce"
+        : "no-preference"
+}
+
+export const reducedDataAtom = atom<ReducedData>(getInitial, {
+    global: true,
+    name: "@valdres/browser-reduced-data/reducedData",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-reduced-data/src/index.ts
+++ b/packages/@valdres/browser-reduced-data/src/index.ts
@@ -1,0 +1,2 @@
+export { reducedDataAtom, type ReducedData } from "./atoms/reducedDataAtom"
+export { prefersReducedDataSelector } from "./selectors/prefersReducedDataSelector"

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedDataAtom } from "../atoms/reducedDataAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedDataAtom.resetSelf()
+    })
+
+    test("syncs initial value from matchMedia", () => {
+        installMatchMedia(true)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+        cleanup?.()
+    })
+
+    test("updates atom when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import {
+    REDUCED_DATA_MEDIA,
+    reducedDataAtom,
+} from "../atoms/reducedDataAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const mq = window.matchMedia(REDUCED_DATA_MEDIA)
+    const sync = () =>
+        reducedDataAtom.setSelf(mq.matches ? "reduce" : "no-preference")
+    sync()
+    mq.addEventListener("change", sync)
+    return () => {
+        mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-reduced-data/src/selectors/prefersReducedDataSelector.ts
+++ b/packages/@valdres/browser-reduced-data/src/selectors/prefersReducedDataSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { reducedDataAtom } from "../atoms/reducedDataAtom"
+
+export const prefersReducedDataSelector = selector(
+    get => get(reducedDataAtom) === "reduce",
+    { name: "@valdres/browser-reduced-data/prefersReducedData" },
+)

--- a/packages/@valdres/browser-reduced-data/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-reduced-data/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-reduced-data/tsconfig.json
+++ b/packages/@valdres/browser-reduced-data/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-reduced-motion/bunfig.toml
+++ b/packages/@valdres/browser-reduced-motion/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-reduced-motion/dev/index.html
+++ b/packages/@valdres/browser-reduced-motion/dev/index.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-reduced-motion demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-reduced-motion</h1>
+        <p class="muted">
+            Reactive wrapper for
+            <code>matchMedia("(prefers-reduced-motion: reduce)")</code>.
+            macOS: System Settings → Accessibility → Display → Reduce Motion.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-reduced-motion/dev/index.tsx
+++ b/packages/@valdres/browser-reduced-motion/dev/index.tsx
@@ -1,0 +1,48 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { reducedMotionAtom, type ReducedMotion } from "../src"
+
+type Entry = { at: string; value: ReducedMotion }
+
+const Demo = () => {
+    const value = useValue(reducedMotionAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<ReducedMotion | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${value === "reduce" ? " on" : ""}`} />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-reduced-motion/dev/server.ts
+++ b/packages/@valdres/browser-reduced-motion/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3022),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-reduced-motion demo: ${server.url}`)

--- a/packages/@valdres/browser-reduced-motion/package.json
+++ b/packages/@valdres/browser-reduced-motion/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-reduced-motion",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.test.ts
+++ b/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedMotionAtom } from "./reducedMotionAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("reducedMotionAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedMotionAtom.resetSelf()
+    })
+
+    test("initial value reflects matchMedia at first read", () => {
+        installMatchMedia(true)
+        const s = store()
+        expect(s.get(reducedMotionAtom)).toBe("reduce")
+    })
+
+    test("updates when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        expect(s.get(reducedMotionAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedMotionAtom)).toBe("reduce")
+
+        mq.set(false)
+        expect(s.get(reducedMotionAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.ts
+++ b/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.ts
@@ -1,0 +1,21 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type ReducedMotion = "no-preference" | "reduce"
+
+export const REDUCED_MOTION_MEDIA = "(prefers-reduced-motion: reduce)"
+
+const getInitial = (): ReducedMotion => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    return window.matchMedia(REDUCED_MOTION_MEDIA).matches
+        ? "reduce"
+        : "no-preference"
+}
+
+export const reducedMotionAtom = atom<ReducedMotion>(getInitial, {
+    global: true,
+    name: "@valdres/browser-reduced-motion/reducedMotion",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-reduced-motion/src/index.ts
+++ b/packages/@valdres/browser-reduced-motion/src/index.ts
@@ -1,0 +1,5 @@
+export {
+    reducedMotionAtom,
+    type ReducedMotion,
+} from "./atoms/reducedMotionAtom"
+export { prefersReducedMotionSelector } from "./selectors/prefersReducedMotionSelector"

--- a/packages/@valdres/browser-reduced-motion/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-motion/src/lib/subscribe.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedMotionAtom } from "../atoms/reducedMotionAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedMotionAtom.resetSelf()
+    })
+
+    test("syncs initial value from matchMedia", () => {
+        installMatchMedia(true)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedMotionAtom)).toBe("reduce")
+        cleanup?.()
+    })
+
+    test("updates atom when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedMotionAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedMotionAtom)).toBe("reduce")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-reduced-motion/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-reduced-motion/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import {
+    REDUCED_MOTION_MEDIA,
+    reducedMotionAtom,
+} from "../atoms/reducedMotionAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const mq = window.matchMedia(REDUCED_MOTION_MEDIA)
+    const sync = () =>
+        reducedMotionAtom.setSelf(mq.matches ? "reduce" : "no-preference")
+    sync()
+    mq.addEventListener("change", sync)
+    return () => {
+        mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-reduced-motion/src/selectors/prefersReducedMotionSelector.ts
+++ b/packages/@valdres/browser-reduced-motion/src/selectors/prefersReducedMotionSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { reducedMotionAtom } from "../atoms/reducedMotionAtom"
+
+export const prefersReducedMotionSelector = selector(
+    get => get(reducedMotionAtom) === "reduce",
+    { name: "@valdres/browser-reduced-motion/prefersReducedMotion" },
+)

--- a/packages/@valdres/browser-reduced-motion/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-reduced-motion/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-reduced-motion/tsconfig.json
+++ b/packages/@valdres/browser-reduced-motion/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-reduced-transparency/bunfig.toml
+++ b/packages/@valdres/browser-reduced-transparency/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-reduced-transparency/dev/index.html
+++ b/packages/@valdres/browser-reduced-transparency/dev/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-reduced-transparency demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-reduced-transparency</h1>
+        <p class="muted">
+            Reactive wrapper for
+            <code>matchMedia("(prefers-reduced-transparency: reduce)")</code>.
+            macOS: System Settings → Accessibility → Display → Reduce
+            Transparency.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-reduced-transparency/dev/index.tsx
+++ b/packages/@valdres/browser-reduced-transparency/dev/index.tsx
@@ -1,0 +1,48 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { reducedTransparencyAtom, type ReducedTransparency } from "../src"
+
+type Entry = { at: string; value: ReducedTransparency }
+
+const Demo = () => {
+    const value = useValue(reducedTransparencyAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<ReducedTransparency | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${value === "reduce" ? " on" : ""}`} />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-reduced-transparency/dev/server.ts
+++ b/packages/@valdres/browser-reduced-transparency/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3024),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-reduced-transparency demo: ${server.url}`)

--- a/packages/@valdres/browser-reduced-transparency/package.json
+++ b/packages/@valdres/browser-reduced-transparency/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-reduced-transparency",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-reduced-transparency/src/atoms/reducedTransparencyAtom.test.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/atoms/reducedTransparencyAtom.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedTransparencyAtom } from "./reducedTransparencyAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("reducedTransparencyAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedTransparencyAtom.resetSelf()
+    })
+
+    test("initial value reflects matchMedia at first read", () => {
+        installMatchMedia(true)
+        const s = store()
+        expect(s.get(reducedTransparencyAtom)).toBe("reduce")
+    })
+
+    test("updates when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        expect(s.get(reducedTransparencyAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedTransparencyAtom)).toBe("reduce")
+
+        mq.set(false)
+        expect(s.get(reducedTransparencyAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-reduced-transparency/src/atoms/reducedTransparencyAtom.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/atoms/reducedTransparencyAtom.ts
@@ -1,0 +1,21 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type ReducedTransparency = "no-preference" | "reduce"
+
+export const REDUCED_TRANSPARENCY_MEDIA = "(prefers-reduced-transparency: reduce)"
+
+const getInitial = (): ReducedTransparency => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    return window.matchMedia(REDUCED_TRANSPARENCY_MEDIA).matches
+        ? "reduce"
+        : "no-preference"
+}
+
+export const reducedTransparencyAtom = atom<ReducedTransparency>(getInitial, {
+    global: true,
+    name: "@valdres/browser-reduced-transparency/reducedTransparency",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-reduced-transparency/src/index.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/index.ts
@@ -1,0 +1,5 @@
+export {
+    reducedTransparencyAtom,
+    type ReducedTransparency,
+} from "./atoms/reducedTransparencyAtom"
+export { prefersReducedTransparencySelector } from "./selectors/prefersReducedTransparencySelector"

--- a/packages/@valdres/browser-reduced-transparency/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/lib/subscribe.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedTransparencyAtom } from "../atoms/reducedTransparencyAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedTransparencyAtom.resetSelf()
+    })
+
+    test("syncs initial value from matchMedia", () => {
+        installMatchMedia(true)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedTransparencyAtom)).toBe("reduce")
+        cleanup?.()
+    })
+
+    test("updates atom when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedTransparencyAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedTransparencyAtom)).toBe("reduce")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-reduced-transparency/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/lib/subscribe.ts
@@ -1,0 +1,18 @@
+import {
+    REDUCED_TRANSPARENCY_MEDIA,
+    reducedTransparencyAtom,
+} from "../atoms/reducedTransparencyAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const mq = window.matchMedia(REDUCED_TRANSPARENCY_MEDIA)
+    const sync = () =>
+        reducedTransparencyAtom.setSelf(
+            mq.matches ? "reduce" : "no-preference",
+        )
+    sync()
+    mq.addEventListener("change", sync)
+    return () => {
+        mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-reduced-transparency/src/selectors/prefersReducedTransparencySelector.ts
+++ b/packages/@valdres/browser-reduced-transparency/src/selectors/prefersReducedTransparencySelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { reducedTransparencyAtom } from "../atoms/reducedTransparencyAtom"
+
+export const prefersReducedTransparencySelector = selector(
+    get => get(reducedTransparencyAtom) === "reduce",
+    { name: "@valdres/browser-reduced-transparency/prefersReducedTransparency" },
+)

--- a/packages/@valdres/browser-reduced-transparency/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-reduced-transparency/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-reduced-transparency/tsconfig.json
+++ b/packages/@valdres/browser-reduced-transparency/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds 5 new packages following the existing `browser-*` convention, each wrapping a `prefers-*` CSS media query as a reactive valdres atom:
  - `@valdres/browser-color-scheme` — `light` / `dark` (+ `isDarkSelector`, `isLightSelector`)
  - `@valdres/browser-reduced-motion` — `no-preference` / `reduce` (+ `prefersReducedMotionSelector`)
  - `@valdres/browser-contrast` — `no-preference` / `more` / `less` / `custom` (+ more/less selectors)
  - `@valdres/browser-reduced-transparency` — `no-preference` / `reduce` (+ selector)
  - `@valdres/browser-reduced-data` — `no-preference` / `reduce` (+ selector)
- Each package has the same layout as `browser-visibility`: global atom driven by `matchMedia` + `subscribe.ts` event listener + tests + `bun run dev` demo page.
- Dev ports: 3021 (color-scheme), 3022 (reduced-motion), 3023 (contrast), 3024 (reduced-transparency), 3025 (reduced-data).
- Note: this does not yet deprecate `@valdres/color-mode`; that can be done in a follow-up since color-mode's user-override + system-fallback composition lives on top of the new `browser-color-scheme` atom.

## Test plan
- [x] `bun --filter '@valdres/browser-*' test` — 21 new tests pass across 5 packages
- [x] `bun run build` works for each new package
- [ ] Manually open each `bun run dev` demo and toggle the corresponding OS setting to confirm the atom reacts live

🤖 Generated with [Claude Code](https://claude.com/claude-code)