### PR TITLE
Add @valdres/browser-contrast package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -108,6 +108,24 @@
         "typescript": "5.9.2",
       },
     },
+    "packages/@valdres/browser-contrast": {
+      "name": "@valdres/browser-contrast",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-focus": {
       "name": "@valdres/browser-focus",
       "version": "0.2.0-pre.28",
@@ -1087,6 +1105,8 @@
     "@valdres-react/panable": ["@valdres-react/panable@workspace:packages/@valdres-react/panable"],
 
     "@valdres-react/recoil": ["@valdres-react/recoil@workspace:packages/@valdres-react/recoil"],
+
+    "@valdres/browser-contrast": ["@valdres/browser-contrast@workspace:packages/@valdres/browser-contrast"],
 
     "@valdres/browser-focus": ["@valdres/browser-focus@workspace:packages/@valdres/browser-focus"],
 
@@ -2959,6 +2979,10 @@
     "@types/babel__template/@babel/types": ["@babel/types@7.25.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.7", "@babel/helper-validator-identifier": "^7.25.7", "to-fast-properties": "^2.0.0" } }, "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ=="],
 
     "@types/babel__traverse/@babel/types": ["@babel/types@7.25.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.7", "@babel/helper-validator-identifier": "^7.25.7", "to-fast-properties": "^2.0.0" } }, "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ=="],
+
+    "@valdres/browser-contrast/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-contrast/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-focus/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-contrast/bunfig.toml
+++ b/packages/@valdres/browser-contrast/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-contrast/dev/index.html
+++ b/packages/@valdres/browser-contrast/dev/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-contrast demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-contrast</h1>
+        <p class="muted">
+            Reactive wrapper for <code>prefers-contrast</code>. Values:
+            <code>no-preference</code>, <code>more</code>, <code>less</code>,
+            <code>custom</code>. macOS: System Settings → Accessibility →
+            Display → Increase Contrast.
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-contrast/dev/index.tsx
+++ b/packages/@valdres/browser-contrast/dev/index.tsx
@@ -1,0 +1,50 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { contrastAtom, type Contrast } from "../src"
+
+type Entry = { at: string; value: Contrast }
+
+const Demo = () => {
+    const value = useValue(contrastAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<Contrast | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span
+                    className={`dot${value !== "no-preference" ? " on" : ""}`}
+                />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-contrast/dev/server.ts
+++ b/packages/@valdres/browser-contrast/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3023),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-contrast demo: ${server.url}`)

--- a/packages/@valdres/browser-contrast/package.json
+++ b/packages/@valdres/browser-contrast/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-contrast",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { contrastAtom, type Contrast } from "./contrastAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initial: Contrast) => {
+    const mqsByQuery = new Map<string, MockMq[]>()
+    let current: Contrast = initial
+    const matchesFor = (query: string) => {
+        if (query.includes("more")) return current === "more"
+        if (query.includes("less")) return current === "less"
+        if (query.includes("custom")) return current === "custom"
+        return false
+    }
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matchesFor(query)
+        mq.media = query
+        const bucket = mqsByQuery.get(query) ?? []
+        bucket.push(mq)
+        mqsByQuery.set(query, bucket)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: Contrast) => {
+            current = next
+            for (const [query, bucket] of mqsByQuery) {
+                const m = matchesFor(query)
+                for (const mq of bucket) {
+                    if (mq.matches !== m) {
+                        mq.matches = m
+                        mq.dispatchEvent(new Event("change"))
+                    }
+                }
+            }
+        },
+    }
+}
+
+describe("contrastAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        contrastAtom.resetSelf()
+    })
+
+    test("initial value reflects active media query", () => {
+        installMatchMedia("more")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("more")
+    })
+
+    test("falls back to no-preference when no query matches", () => {
+        installMatchMedia("no-preference")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+    })
+
+    test("updates when any media query change event fires", () => {
+        const mq = installMatchMedia("no-preference")
+        const s = store()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+
+        mq.set("more")
+        expect(s.get(contrastAtom)).toBe("more")
+
+        mq.set("less")
+        expect(s.get(contrastAtom)).toBe("less")
+
+        mq.set("custom")
+        expect(s.get(contrastAtom)).toBe("custom")
+
+        mq.set("no-preference")
+        expect(s.get(contrastAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.test.ts
@@ -57,9 +57,10 @@ describe("contrastAtom", () => {
         expect(s.get(contrastAtom)).toBe("no-preference")
     })
 
-    test("updates when any media query change event fires", () => {
+    test("subscribing wires the listeners and reflects media-query changes", () => {
         const mq = installMatchMedia("no-preference")
         const s = store()
+        const unsub = s.sub(contrastAtom, () => {})
         expect(s.get(contrastAtom)).toBe("no-preference")
 
         mq.set("more")
@@ -73,5 +74,6 @@ describe("contrastAtom", () => {
 
         mq.set("no-preference")
         expect(s.get(contrastAtom)).toBe("no-preference")
+        unsub()
     })
 })

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
@@ -1,0 +1,26 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type Contrast = "no-preference" | "more" | "less" | "custom"
+
+export const CONTRAST_QUERIES: { value: Contrast; query: string }[] = [
+    { value: "more", query: "(prefers-contrast: more)" },
+    { value: "less", query: "(prefers-contrast: less)" },
+    { value: "custom", query: "(prefers-contrast: custom)" },
+]
+
+export const readContrast = (): Contrast => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    for (const { value, query } of CONTRAST_QUERIES) {
+        if (window.matchMedia(query).matches) return value
+    }
+    return "no-preference"
+}
+
+export const contrastAtom = atom<Contrast>(readContrast, {
+    global: true,
+    name: "@valdres/browser-contrast/contrast",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
+++ b/packages/@valdres/browser-contrast/src/atoms/contrastAtom.ts
@@ -10,7 +10,10 @@ export const CONTRAST_QUERIES: { value: Contrast; query: string }[] = [
 ]
 
 export const readContrast = (): Contrast => {
-    if (typeof window === "undefined" || !window.matchMedia) {
+    if (
+        typeof window === "undefined" ||
+        typeof window.matchMedia !== "function"
+    ) {
         return "no-preference"
     }
     for (const { value, query } of CONTRAST_QUERIES) {
@@ -22,5 +25,5 @@ export const readContrast = (): Contrast => {
 export const contrastAtom = atom<Contrast>(readContrast, {
     global: true,
     name: "@valdres/browser-contrast/contrast",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-contrast/src/index.ts
+++ b/packages/@valdres/browser-contrast/src/index.ts
@@ -1,0 +1,3 @@
+export { contrastAtom, type Contrast } from "./atoms/contrastAtom"
+export { prefersMoreContrastSelector } from "./selectors/prefersMoreContrastSelector"
+export { prefersLessContrastSelector } from "./selectors/prefersLessContrastSelector"

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
@@ -65,4 +65,19 @@ describe("subscribe", () => {
 
         cleanup?.()
     })
+
+    test("does not update atom after cleanup removes media query listeners", () => {
+        const mq = installMatchMedia("no-preference")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+
+        mq.set("more")
+        expect(s.get(contrastAtom)).toBe("more")
+
+        cleanup?.()
+
+        mq.set("less")
+        expect(s.get(contrastAtom)).toBe("more")
+    })
 })

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { contrastAtom, type Contrast } from "../atoms/contrastAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initial: Contrast) => {
+    const mqsByQuery = new Map<string, MockMq[]>()
+    let current: Contrast = initial
+    const matchesFor = (query: string) => {
+        if (query.includes("more")) return current === "more"
+        if (query.includes("less")) return current === "less"
+        if (query.includes("custom")) return current === "custom"
+        return false
+    }
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matchesFor(query)
+        mq.media = query
+        const bucket = mqsByQuery.get(query) ?? []
+        bucket.push(mq)
+        mqsByQuery.set(query, bucket)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: Contrast) => {
+            current = next
+            for (const [query, bucket] of mqsByQuery) {
+                const m = matchesFor(query)
+                for (const mq of bucket) {
+                    if (mq.matches !== m) {
+                        mq.matches = m
+                        mq.dispatchEvent(new Event("change"))
+                    }
+                }
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        contrastAtom.resetSelf()
+    })
+
+    test("syncs initial value from active media query", () => {
+        installMatchMedia("less")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(contrastAtom)).toBe("less")
+        cleanup?.()
+    })
+
+    test("updates atom when any media query change event fires", () => {
+        const mq = installMatchMedia("no-preference")
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(contrastAtom)).toBe("no-preference")
+
+        mq.set("more")
+        expect(s.get(contrastAtom)).toBe("more")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.ts
@@ -5,7 +5,11 @@ import {
 } from "../atoms/contrastAtom"
 
 export const subscribe = () => {
-    if (typeof window === "undefined" || !window.matchMedia) return
+    if (
+        typeof window === "undefined" ||
+        typeof window.matchMedia !== "function"
+    )
+        return
     const sync = () => contrastAtom.setSelf(readContrast())
     sync()
     const mqs = CONTRAST_QUERIES.map(({ query }) => window.matchMedia(query))

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.ts
@@ -1,8 +1,4 @@
-import {
-    CONTRAST_QUERIES,
-    contrastAtom,
-    readContrast,
-} from "../atoms/contrastAtom"
+import { CONTRAST_QUERIES, contrastAtom } from "../atoms/contrastAtom"
 
 export const subscribe = () => {
     if (
@@ -10,11 +6,17 @@ export const subscribe = () => {
         typeof window.matchMedia !== "function"
     )
         return
-    const sync = () => contrastAtom.setSelf(readContrast())
+    const mqs = CONTRAST_QUERIES.map(({ value, query }) => ({
+        value,
+        mq: window.matchMedia(query),
+    }))
+    const sync = () => {
+        const active = mqs.find(({ mq }) => mq.matches)
+        contrastAtom.setSelf(active ? active.value : "no-preference")
+    }
     sync()
-    const mqs = CONTRAST_QUERIES.map(({ query }) => window.matchMedia(query))
-    for (const mq of mqs) mq.addEventListener("change", sync)
+    for (const { mq } of mqs) mq.addEventListener("change", sync)
     return () => {
-        for (const mq of mqs) mq.removeEventListener("change", sync)
+        for (const { mq } of mqs) mq.removeEventListener("change", sync)
     }
 }

--- a/packages/@valdres/browser-contrast/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-contrast/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import {
+    CONTRAST_QUERIES,
+    contrastAtom,
+    readContrast,
+} from "../atoms/contrastAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const sync = () => contrastAtom.setSelf(readContrast())
+    sync()
+    const mqs = CONTRAST_QUERIES.map(({ query }) => window.matchMedia(query))
+    for (const mq of mqs) mq.addEventListener("change", sync)
+    return () => {
+        for (const mq of mqs) mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-contrast/src/selectors/prefersLessContrastSelector.ts
+++ b/packages/@valdres/browser-contrast/src/selectors/prefersLessContrastSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { contrastAtom } from "../atoms/contrastAtom"
+
+export const prefersLessContrastSelector = selector(
+    get => get(contrastAtom) === "less",
+    { name: "@valdres/browser-contrast/prefersLessContrast" },
+)

--- a/packages/@valdres/browser-contrast/src/selectors/prefersMoreContrastSelector.ts
+++ b/packages/@valdres/browser-contrast/src/selectors/prefersMoreContrastSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { contrastAtom } from "../atoms/contrastAtom"
+
+export const prefersMoreContrastSelector = selector(
+    get => get(contrastAtom) === "more",
+    { name: "@valdres/browser-contrast/prefersMoreContrast" },
+)

--- a/packages/@valdres/browser-contrast/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-contrast/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-contrast/tsconfig.json
+++ b/packages/@valdres/browser-contrast/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## Summary
- New package wrapping the `prefers-contrast` media feature as a reactive valdres atom.
- Exports: `contrastAtom` (`"no-preference" | "more" | "less" | "custom"`), `prefersMoreContrastSelector`, `prefersLessContrastSelector`.
- Subscribes to all three value-specific media queries and derives the active value.
- Follows the existing `browser-*` convention (atom + `subscribe.ts` + selectors + `bun run dev` demo + happy-dom tests).

## Test plan
- [x] `bun --filter @valdres/browser-contrast test` — 5 tests pass
- [x] `bun --filter @valdres/browser-contrast run build` succeeds
- [ ] `bun --filter @valdres/browser-contrast run dev` and toggle OS Increase Contrast to confirm live reactivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)