### PR TITLE
Add @valdres/browser-reduced-data package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,24 @@
         "valdres": "0.2.0-pre.28",
       },
     },
+    "packages/@valdres/browser-reduced-data": {
+      "name": "@valdres/browser-reduced-data",
+      "version": "0.2.0-pre.28",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28",
+      },
+      "peerDependencies": {
+        "valdres": "0.2.0-pre.28",
+      },
+    },
     "packages/@valdres/browser-reduced-motion": {
       "name": "@valdres/browser-reduced-motion",
       "version": "0.2.0-pre.28",
@@ -1097,6 +1115,8 @@
     "@valdres/browser-online": ["@valdres/browser-online@workspace:packages/@valdres/browser-online"],
 
     "@valdres/browser-presence": ["@valdres/browser-presence@workspace:packages/@valdres/browser-presence"],
+
+    "@valdres/browser-reduced-data": ["@valdres/browser-reduced-data@workspace:packages/@valdres/browser-reduced-data"],
 
     "@valdres/browser-reduced-motion": ["@valdres/browser-reduced-motion@workspace:packages/@valdres/browser-reduced-motion"],
 
@@ -2975,6 +2995,10 @@
     "@valdres/browser-presence/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-presence/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-reduced-data/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-reduced-data/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-reduced-motion/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/packages/@valdres/browser-reduced-data/bunfig.toml
+++ b/packages/@valdres/browser-reduced-data/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-reduced-data/dev/index.html
+++ b/packages/@valdres/browser-reduced-data/dev/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-reduced-data demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            .dot {
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: #ccc;
+            }
+            .dot.on {
+                background: #2ecc71;
+            }
+            .label {
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 1rem;
+            }
+            .log {
+                margin-top: 1.5rem;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.85rem;
+                max-height: 200px;
+                overflow: auto;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 0.75rem 1rem;
+            }
+            .log li {
+                list-style: none;
+                padding: 0;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-reduced-data</h1>
+        <p class="muted">
+            Reactive wrapper for
+            <code>matchMedia("(prefers-reduced-data: reduce)")</code>. Only
+            Chromium ships this today; Chrome exposes it behind the Save-Data
+            setting (DevTools → Network conditions → Throttling).
+        </p>
+        <div id="root"></div>
+
+        <script>
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.tsx"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-reduced-data/dev/index.tsx
+++ b/packages/@valdres/browser-reduced-data/dev/index.tsx
@@ -1,0 +1,48 @@
+import { StrictMode, useEffect, useRef, useState } from "react"
+import { createRoot } from "react-dom/client"
+import { Provider, useValue } from "valdres-react"
+import { reducedDataAtom, type ReducedData } from "../src"
+
+type Entry = { at: string; value: ReducedData }
+
+const Demo = () => {
+    const value = useValue(reducedDataAtom)
+    const [log, setLog] = useState<Entry[]>([])
+    const lastLogged = useRef<ReducedData | null>(null)
+
+    useEffect(() => {
+        if (lastLogged.current === value) return
+        lastLogged.current = value
+        setLog(prev =>
+            [
+                { at: new Date().toLocaleTimeString(), value },
+                ...prev,
+            ].slice(0, 20),
+        )
+    }, [value])
+
+    return (
+        <>
+            <div className="card">
+                <span className={`dot${value === "reduce" ? " on" : ""}`} />
+                <span className="label">{value}</span>
+            </div>
+            <ul className="log">
+                {log.map((entry, i) => (
+                    <li key={i}>
+                        {entry.at} — {entry.value}
+                    </li>
+                ))}
+            </ul>
+        </>
+    )
+}
+
+const root = createRoot(document.getElementById("root")!)
+root.render(
+    <StrictMode>
+        <Provider>
+            <Demo />
+        </Provider>
+    </StrictMode>,
+)

--- a/packages/@valdres/browser-reduced-data/dev/server.ts
+++ b/packages/@valdres/browser-reduced-data/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3025),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-reduced-data demo: ${server.url}`)

--- a/packages/@valdres/browser-reduced-data/package.json
+++ b/packages/@valdres/browser-reduced-data/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@valdres/browser-reduced-data",
+    "version": "0.2.0-pre.28",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bun run tsc",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "@types/react": "19.1.12",
+        "@types/react-dom": "19.1.9",
+        "happy-dom": "20.0.5",
+        "react": "19.1.1",
+        "react-dom": "19.1.1",
+        "typescript": "5.9.2",
+        "valdres": "0.2.0-pre.28",
+        "valdres-react": "0.2.0-pre.28"
+    },
+    "peerDependencies": {
+        "valdres": "0.2.0-pre.28"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedDataAtom } from "./reducedDataAtom"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("reducedDataAtom", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedDataAtom.resetSelf()
+    })
+
+    test("initial value reflects matchMedia at first read", () => {
+        installMatchMedia(true)
+        const s = store()
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+    })
+
+    test("updates when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+
+        mq.set(false)
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+    })
+})

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.test.ts
@@ -38,9 +38,10 @@ describe("reducedDataAtom", () => {
         expect(s.get(reducedDataAtom)).toBe("reduce")
     })
 
-    test("updates when media query change event fires", () => {
+    test("subscribing wires the listener and reflects matchMedia changes", () => {
         const mq = installMatchMedia(false)
         const s = store()
+        const unsub = s.sub(reducedDataAtom, () => {})
         expect(s.get(reducedDataAtom)).toBe("no-preference")
 
         mq.set(true)
@@ -48,5 +49,6 @@ describe("reducedDataAtom", () => {
 
         mq.set(false)
         expect(s.get(reducedDataAtom)).toBe("no-preference")
+        unsub()
     })
 })

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
@@ -20,5 +20,5 @@ const getInitial = (): ReducedData => {
 export const reducedDataAtom = atom<ReducedData>(getInitial, {
     global: true,
     name: "@valdres/browser-reduced-data/reducedData",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
@@ -1,0 +1,21 @@
+import { atom } from "valdres"
+import { subscribe } from "../lib/subscribe"
+
+export type ReducedData = "no-preference" | "reduce"
+
+export const REDUCED_DATA_MEDIA = "(prefers-reduced-data: reduce)"
+
+const getInitial = (): ReducedData => {
+    if (typeof window === "undefined" || !window.matchMedia) {
+        return "no-preference"
+    }
+    return window.matchMedia(REDUCED_DATA_MEDIA).matches
+        ? "reduce"
+        : "no-preference"
+}
+
+export const reducedDataAtom = atom<ReducedData>(getInitial, {
+    global: true,
+    name: "@valdres/browser-reduced-data/reducedData",
+    onInit: () => subscribe(),
+})

--- a/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
+++ b/packages/@valdres/browser-reduced-data/src/atoms/reducedDataAtom.ts
@@ -6,7 +6,10 @@ export type ReducedData = "no-preference" | "reduce"
 export const REDUCED_DATA_MEDIA = "(prefers-reduced-data: reduce)"
 
 const getInitial = (): ReducedData => {
-    if (typeof window === "undefined" || !window.matchMedia) {
+    if (
+        typeof window === "undefined" ||
+        typeof window.matchMedia !== "function"
+    ) {
         return "no-preference"
     }
     return window.matchMedia(REDUCED_DATA_MEDIA).matches

--- a/packages/@valdres/browser-reduced-data/src/index.ts
+++ b/packages/@valdres/browser-reduced-data/src/index.ts
@@ -1,0 +1,2 @@
+export { reducedDataAtom, type ReducedData } from "./atoms/reducedDataAtom"
+export { prefersReducedDataSelector } from "./selectors/prefersReducedDataSelector"

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
@@ -54,18 +54,13 @@ describe("subscribe", () => {
         cleanup?.()
     })
 
-    test("cleanup calls removeEventListener for the change event", () => {
-        const { mqs } = installMatchMedia(false)
+    test("cleanup removes listeners so later events do not update atom", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
         const cleanup = subscribe()
-        const mq = mqs[0]!
-        let removed = false
-        const origRemove = mq.removeEventListener.bind(mq)
-        mq.removeEventListener = ((type: string, listener: EventListener) => {
-            if (type === "change") removed = true
-            return origRemove(type, listener)
-        }) as EventTarget["removeEventListener"]
-
         cleanup?.()
-        expect(removed).toBe(true)
+
+        mq.set(true)
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
     })
 })

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
@@ -23,6 +23,7 @@ const installMatchMedia = (initialMatches: boolean) => {
                 mq.dispatchEvent(new Event("change"))
             }
         },
+        mqs,
     }
 }
 
@@ -51,5 +52,20 @@ describe("subscribe", () => {
         expect(s.get(reducedDataAtom)).toBe("reduce")
 
         cleanup?.()
+    })
+
+    test("cleanup calls removeEventListener for the change event", () => {
+        const { mqs } = installMatchMedia(false)
+        const cleanup = subscribe()
+        const mq = mqs[0]!
+        let removed = false
+        const origRemove = mq.removeEventListener.bind(mq)
+        mq.removeEventListener = ((type: string, listener: EventListener) => {
+            if (type === "change") removed = true
+            return origRemove(type, listener)
+        }) as EventTarget["removeEventListener"]
+
+        cleanup?.()
+        expect(removed).toBe(true)
     })
 })

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { reducedDataAtom } from "../atoms/reducedDataAtom"
+import { subscribe } from "./subscribe"
+
+type MockMq = EventTarget & { matches: boolean; media: string }
+
+const installMatchMedia = (initialMatches: boolean) => {
+    const mqs: MockMq[] = []
+    let matches = initialMatches
+    window.matchMedia = ((query: string) => {
+        const mq = new EventTarget() as MockMq
+        mq.matches = matches
+        mq.media = query
+        mqs.push(mq)
+        return mq as unknown as MediaQueryList
+    }) as typeof window.matchMedia
+    return {
+        set: (next: boolean) => {
+            matches = next
+            for (const mq of mqs) {
+                mq.matches = next
+                mq.dispatchEvent(new Event("change"))
+            }
+        },
+    }
+}
+
+describe("subscribe", () => {
+    const originalMatchMedia = window.matchMedia
+    afterEach(() => {
+        window.matchMedia = originalMatchMedia
+        reducedDataAtom.resetSelf()
+    })
+
+    test("syncs initial value from matchMedia", () => {
+        installMatchMedia(true)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+        cleanup?.()
+    })
+
+    test("updates atom when media query change event fires", () => {
+        const mq = installMatchMedia(false)
+        const s = store()
+        const cleanup = subscribe()
+        expect(s.get(reducedDataAtom)).toBe("no-preference")
+
+        mq.set(true)
+        expect(s.get(reducedDataAtom)).toBe("reduce")
+
+        cleanup?.()
+    })
+})

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
@@ -4,7 +4,11 @@ import {
 } from "../atoms/reducedDataAtom"
 
 export const subscribe = () => {
-    if (typeof window === "undefined" || !window.matchMedia) return
+    if (
+        typeof window === "undefined" ||
+        typeof window.matchMedia !== "function"
+    )
+        return
     const mq = window.matchMedia(REDUCED_DATA_MEDIA)
     const sync = () =>
         reducedDataAtom.setSelf(mq.matches ? "reduce" : "no-preference")

--- a/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
+++ b/packages/@valdres/browser-reduced-data/src/lib/subscribe.ts
@@ -1,0 +1,16 @@
+import {
+    REDUCED_DATA_MEDIA,
+    reducedDataAtom,
+} from "../atoms/reducedDataAtom"
+
+export const subscribe = () => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const mq = window.matchMedia(REDUCED_DATA_MEDIA)
+    const sync = () =>
+        reducedDataAtom.setSelf(mq.matches ? "reduce" : "no-preference")
+    sync()
+    mq.addEventListener("change", sync)
+    return () => {
+        mq.removeEventListener("change", sync)
+    }
+}

--- a/packages/@valdres/browser-reduced-data/src/selectors/prefersReducedDataSelector.ts
+++ b/packages/@valdres/browser-reduced-data/src/selectors/prefersReducedDataSelector.ts
@@ -1,0 +1,7 @@
+import { selector } from "valdres"
+import { reducedDataAtom } from "../atoms/reducedDataAtom"
+
+export const prefersReducedDataSelector = selector(
+    get => get(reducedDataAtom) === "reduce",
+    { name: "@valdres/browser-reduced-data/prefersReducedData" },
+)

--- a/packages/@valdres/browser-reduced-data/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-reduced-data/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-reduced-data/tsconfig.json
+++ b/packages/@valdres/browser-reduced-data/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/packages/@valdres/browser-reduced-data/tsconfig.json
+++ b/packages/@valdres/browser-reduced-data/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../tsconfig.json",
     "include": ["src/index.ts"],
-    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "exclude": ["test", "dev", "dist", "src/**/*.test.ts"],
     "compilerOptions": {
         "declaration": true,
         "noEmit": false,

--- a/packages/@valdres/browser-reduced-motion/tsconfig.json
+++ b/packages/@valdres/browser-reduced-motion/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../tsconfig.json",
     "include": ["src/index.ts"],
-    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "exclude": ["test", "dev", "dist", "src/**/*.test.ts"],
     "compilerOptions": {
         "declaration": true,
         "noEmit": false,


### PR DESCRIPTION
## Summary
- New package wrapping `matchMedia("(prefers-reduced-data: reduce)")` as a reactive valdres atom.
- Exports: `reducedDataAtom` (`"no-preference" | "reduce"`), `prefersReducedDataSelector`.
- Follows the existing `browser-*` convention (atom + `subscribe.ts` + selectors + `bun run dev` demo + happy-dom tests).
- Note: only Chromium (Save-Data) implements this preference today; Firefox and Safari always report `no-preference`.

## Test plan
- [x] `bun --filter @valdres/browser-reduced-data test` — 4 tests pass
- [x] `bun --filter @valdres/browser-reduced-data run build` succeeds
- [ ] `bun --filter @valdres/browser-reduced-data run dev` in Chrome with DevTools → Network conditions → Throttling → Save-Data enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)