### PR TITLE
Give JSC time for ephemeron cleanup between LeakDetector rounds

### DIFF
--- a/packages/test/src/LeakDetector.ts
+++ b/packages/test/src/LeakDetector.ts
@@ -29,7 +29,12 @@ export class LeakDetector {
             if (round > 0) generateHeapSnapshot()
             fullGC()
             releaseWeakRefs()
-            await Bun.sleep(0)
+            // Round 0: microtask yield (fast path, no ephemeron cleanup
+            // needed). Snapshot rounds: 1ms real-timer delay so JSC can
+            // finish the ephemeron trace the snapshot schedules — under CI
+            // allocation pressure a microtask yield isn't enough for WeakMap
+            // chains to clear.
+            await Bun.sleep(round === 0 ? 0 : 1)
             if (this._ref.deref() === undefined) return false
         }
         return this._ref.deref() !== undefined


### PR DESCRIPTION
## Summary
- After #98 skipped the round-0 heap snapshot, the first leak test that genuinely needs ephemeron cleanup (`memory leaks (selectors) > old selector value is collected after dependency changes`) started flaking on CI. Confirmed consistent failures across PRs #100, #103, #104, #105.
- Root cause: `Bun.sleep(0)` between snapshot rounds is a microtask yield. Under CI allocation pressure JSC's ephemeron trace (scheduled by \`generateHeapSnapshot()\`) doesn't finish before the next round's \`deref()\` check, so WeakMap chains still appear live.
- Fix: use a 1ms real-timer delay on rounds 1–9. Round 0 stays at \`Bun.sleep(0)\` — #98's fast path for non-ephemeron cases is preserved.

## Impact
- Worst case adds ~9ms to a leak-detector call that exercises all 10 rounds.
- `packages/valdres/test/memoryleaks.test.ts` local run: ~1.0–1.6s vs ~0.7s before; still well below pre-#98's 5.6s.

## Test plan
- [x] \`bun test test/memoryleaks.test.ts\` — 24 pass / 0 fail (x4 consecutive runs)
- [ ] CI passes on this branch
- [ ] Re-running a currently-flaking PR (#105 or #100) against this branch shows the memoryleaks failure gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)