### PR TITLE
Fix root cause of selector leak flake — reorder releaseWeakRefs/gc in LeakDetector

### DIFF
--- a/packages/test/src/LeakDetector.ts
+++ b/packages/test/src/LeakDetector.ts
@@ -1,14 +1,21 @@
 import { generateHeapSnapshot } from "bun"
-import { fullGC, releaseWeakRefs } from "bun:jsc"
+import { releaseWeakRefs } from "bun:jsc"
 
 /**
- * Bun-native memory leak detector using WeakRef + bun:jsc primitives.
+ * Bun-native memory leak detector using WeakRef.
  *
- * Strategy: repeated generateHeapSnapshot() rounds to force full reachability
- * analysis. Each snapshot walks the entire heap, which is essential for
- * triggering WeakMap ephemeron cleanup in JSC. Lightweight GC rounds without
- * snapshots are insufficient — WeakMap entries are only cleared when the
- * engine performs a full reachability trace.
+ * The ECMAScript [[KeptAlive]] list pins WeakRef targets until a microtask
+ * checkpoint clears it. Inside a synchronous test, that pin survives
+ * across GCs and looks like a leak. releaseWeakRefs() invokes JSC's
+ * ClearKeptObjects directly so the target is actually collectable.
+ * Order matters: releaseWeakRefs MUST run before the GC.
+ *
+ * The remaining residue under heap pressure is JSC's conservative stack
+ * scan retaining recently-dead allocations through stale callee-saved
+ * register spills. We work around it with two GC passes per round, an
+ * intermediate generateHeapSnapshot (which advances the visitor and tends
+ * to overwrite spill slots), and a Bun.sleep(0) macrotask gap between
+ * rounds.
  *
  * Usage:
  *   const detector = new LeakDetector(someObject)
@@ -24,13 +31,13 @@ export class LeakDetector {
 
     async isLeaking(): Promise<boolean> {
         for (let round = 0; round < 10; round++) {
-            fullGC()
             releaseWeakRefs()
+            Bun.gc(true)
             if (round > 0) generateHeapSnapshot()
-            fullGC()
             releaseWeakRefs()
-            await Bun.sleep(0)
+            Bun.gc(true)
             if (this._ref.deref() === undefined) return false
+            await Bun.sleep(0)
         }
         return this._ref.deref() !== undefined
     }

--- a/packages/valdres/test/memoryleaks.test.ts
+++ b/packages/valdres/test/memoryleaks.test.ts
@@ -50,16 +50,6 @@ describe("memory leaks (selectors)", () => {
         expect(await detector.isLeaking()).toBe(false)
     })
 
-    // Flakes on CI under Bun, but the equivalent scenario ported to Node (V8)
-    // runs 0/50 leaks. Root cause is JSC's ephemeron resolution: the retained
-    // value {value:1} is held by a cyclic WeakMap chain (data.values →
-    // data.stateDependents → selector closure → atom key → back into values)
-    // that JSC only clears after several full GC + heap-trace passes with
-    // real-timer slack between them. V8 resolves the same chain in a single
-    // pass. See Bun issue #24285 (https://github.com/oven-sh/bun/issues/24285)
-    // which asks for a `bun.repeatedlyGcAndRunFinalizers()` primitive for
-    // exactly this pattern. The retry below is the workaround landed in
-    // PR #107; revisit once #24285 is resolved.
     test("old selector value is collected after dependency changes", async () => {
         const detector = (() => {
             const s = store()
@@ -70,12 +60,7 @@ describe("memory leaks (selectors)", () => {
             s.set(a, 2)
             return d
         })()
-        let leaking = await detector.isLeaking()
-        for (let i = 0; i < 5 && leaking; i++) {
-            await new Promise(r => setTimeout(r, 50))
-            leaking = await detector.isLeaking()
-        }
-        expect(leaking).toBe(false)
+        expect(await detector.isLeaking()).toBe(false)
     })
 
     test("chained selector values are collected", async () => {


### PR DESCRIPTION
## Summary

PR #107 added a test-scoped retry to mask a flake. This PR fixes the underlying cause and removes the retry.

The flake was the ECMAScript `[[KeptAlive]]` list pinning WeakRef targets across `LeakDetector.isLeaking`'s synchronous `gc()` loop. JSC's `ClearKeptObjects` runs at microtask checkpoints, but our detector called `bun:jsc.fullGC()` BEFORE `releaseWeakRefs()` — by the time `[[KeptAlive]]` was cleared, the GC pass that would have collected the target had already run.

Two fixes in `LeakDetector`:
- Reorder to `releaseWeakRefs()` first, then GC. This is what makes the actual difference.
- Switch `fullGC()` → `Bun.gc(true)`. The bun:jsc `fullGC()` does not sweep; `Bun.gc(true)` does a full GC + sweep.

## Background

- A focused investigation in the WebKit checkout (Source/JavaScriptCore/heap/MarkingConstraintSet.cpp:98-166, Heap.cpp:1584-1606) confirmed JSC's ephemeron output-constraint **does** iterate to fixpoint within a single GC. The earlier writeup blaming JSC ephemerons in the test comment was wrong — that comment is removed.
- The remaining residue under heap pressure is JSC's conservative stack scan retaining recently-dead allocations through stale callee-saved register spills. Two GC passes per round + an intermediate `generateHeapSnapshot` (which advances the marker and tends to overwrite spill slots) + a `Bun.sleep(0)` macrotask gap handle it.
- A separate, narrower Bun bug remains: Bun's microtask checkpoint does not call JSC's `ClearKeptObjects` automatically (V8/Node does). That's why we still need an explicit `releaseWeakRefs()` call. Tracking that upstream is out of scope for this PR.

## Test plan

- [x] Full valdres test suite, 30/30 trials in `ubuntu-22.04 + bun-1.3.13` Docker container that previously reproduced the ~30% flake rate
- [x] Local Mac, 20/20 trials of `memoryleaks.test.ts` (260ms/run)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)