### PR TITLE
Upgrade GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -28,7 +28,7 @@ jobs:
     benchmark:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Configure git identity
               run: |
@@ -38,7 +38,7 @@ jobs:
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22.17"
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -7,11 +7,11 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: "22.x"
             - name: Install
@@ -26,7 +26,7 @@ jobs:
               env:
                   NODE_ENV: production
             - name: Upload website artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v5
               with:
                   path: "packages/documentation/docs/dist"
     deploy:
@@ -44,4 +44,4 @@ jobs:
         steps:
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
+              uses: actions/deploy-pages@v5 # or specific "vX.X.X" version tag for this action

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     test:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
@@ -27,7 +27,7 @@ jobs:
               continue-on-error: true
             - name: Test Report
               if: always()
-              uses: actions/github-script@v7
+              uses: actions/github-script@v9
               with:
                   script: |
                       const fs = require('fs');


### PR DESCRIPTION
## Summary

Addresses the [Node.js 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) by bumping all third-party actions to majors that run on Node 24.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/github-script` | v7 | **v9** |
| `actions/setup-node` | v4 | **v6** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

## Breaking-change review

- **`github-script@v9`** drops `require('@actions/github')` and forbids redeclaring `getOctokit`. The inline test-report script only uses standard `github.rest.*`, `core.*`, `context.*`, and Node built-ins (`fs`, `child_process`) — compatible as-is.
- **`setup-node@v5+`** auto-caches when `package.json` has a `packageManager` field. This repo doesn't set that field, so behavior is unchanged.
- **`upload-pages-artifact@v4+`** excludes dotfiles from the artifact. The VitePress `dist/` output doesn't rely on dotfiles.

## Test plan

- [ ] `Test` workflow runs successfully on this PR (validates `checkout@v6` + `github-script@v9` test-report script)
- [ ] `Benchmark` workflow runs successfully on this PR (validates `checkout@v6` + `setup-node@v6`)
- [ ] After merge: `Publish Docs` workflow runs successfully on `main` (validates `upload-pages-artifact@v5` + `deploy-pages@v5`)
- [ ] No more "Node.js 20 actions are deprecated" warnings in the Actions summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)