### PR TITLE
Replace global-atom onInit with Jotai-style onMount lifecycle

### DIFF
--- a/packages/@valdres/browser-focus/src/atoms/focusAtom.test.ts
+++ b/packages/@valdres/browser-focus/src/atoms/focusAtom.test.ts
@@ -12,9 +12,10 @@ const setHasFocus = (value: boolean) => {
 describe("focusAtom", () => {
     afterAll(() => setHasFocus(true))
 
-    test("first read evaluates lazily and onInit wires event listeners", () => {
+    test("subscribing wires event listeners and reflects document focus", () => {
         setHasFocus(false)
         const s = store()
+        const unsub = s.sub(focusAtom, () => {})
         expect(s.get(focusAtom)).toBe(false)
 
         window.dispatchEvent(new Event("focus"))
@@ -22,5 +23,6 @@ describe("focusAtom", () => {
 
         window.dispatchEvent(new Event("blur"))
         expect(s.get(focusAtom)).toBe(false)
+        unsub()
     })
 })

--- a/packages/@valdres/browser-focus/src/atoms/focusAtom.ts
+++ b/packages/@valdres/browser-focus/src/atoms/focusAtom.ts
@@ -9,5 +9,5 @@ const getInitial = () => {
 export const focusAtom = atom<boolean>(getInitial, {
     global: true,
     name: "@valdres/browser-focus/focus",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-geolocation/src/atoms/permissionAtom.test.ts
+++ b/packages/@valdres/browser-geolocation/src/atoms/permissionAtom.test.ts
@@ -54,8 +54,9 @@ describe("permissionAtom", () => {
     test("marks permission unsupported when Permissions API is missing", () => {
         setPermissions(undefined)
         const s = store()
-        s.get(permissionAtom)
+        const unsub = s.sub(permissionAtom, () => {})
         expect(s.get(permissionAtom)).toBe("unsupported")
+        unsub()
     })
 
     test("resolves to the current state after query resolves", async () => {
@@ -64,9 +65,10 @@ describe("permissionAtom", () => {
             query: () => Promise.resolve(status),
         })
         const s = store()
-        s.get(permissionAtom)
+        const unsub = s.sub(permissionAtom, () => {})
         await flush()
         expect(s.get(permissionAtom)).toBe("granted")
+        unsub()
     })
 
     test("updates when the underlying PermissionStatus changes", async () => {
@@ -75,7 +77,7 @@ describe("permissionAtom", () => {
             query: () => Promise.resolve(status),
         })
         const s = store()
-        s.get(permissionAtom)
+        const unsub = s.sub(permissionAtom, () => {})
         await flush()
         expect(s.get(permissionAtom)).toBe("prompt")
 
@@ -84,6 +86,7 @@ describe("permissionAtom", () => {
 
         status._setState("denied")
         expect(s.get(permissionAtom)).toBe("denied")
+        unsub()
     })
 
     test("falls back to unsupported when query rejects", async () => {
@@ -91,8 +94,9 @@ describe("permissionAtom", () => {
             query: () => Promise.reject(new Error("nope")),
         })
         const s = store()
-        s.get(permissionAtom)
+        const unsub = s.sub(permissionAtom, () => {})
         await flush()
         expect(s.get(permissionAtom)).toBe("unsupported")
+        unsub()
     })
 })

--- a/packages/@valdres/browser-geolocation/src/atoms/permissionAtom.ts
+++ b/packages/@valdres/browser-geolocation/src/atoms/permissionAtom.ts
@@ -9,5 +9,5 @@ export const permissionAtom: GlobalAtom<PermissionValue> =
     atom<PermissionValue>("prompt", {
         global: true,
         name: "@valdres/browser-geolocation/permission",
-        onInit: () => subscribePermission(permissionAtom),
+        onMount: () => subscribePermission(permissionAtom),
     })

--- a/packages/@valdres/browser-geolocation/src/atoms/positionAtom.test.ts
+++ b/packages/@valdres/browser-geolocation/src/atoms/positionAtom.test.ts
@@ -62,6 +62,12 @@ const makePosition = (): GeolocationPosition =>
 
 describe("positionAtom", () => {
     let geo: FakeGeolocation
+    let activeUnsubs: Array<() => void> = []
+
+    const subscribe = (s: ReturnType<typeof store>) => {
+        const unsub = s.sub(positionAtom, () => {})
+        activeUnsubs.push(unsub)
+    }
 
     beforeEach(() => {
         geo = makeGeolocation()
@@ -73,6 +79,8 @@ describe("positionAtom", () => {
     })
 
     afterEach(() => {
+        for (const unsub of activeUnsubs) unsub()
+        activeUnsubs = []
         setGeolocation(null)
         positionAtom.resetSelf()
         geolocationStatusAtom.resetSelf()
@@ -80,16 +88,16 @@ describe("positionAtom", () => {
         geolocationOptionsAtom.resetSelf()
     })
 
-    test("calls watchPosition on first read and sets status to pending", () => {
+    test("calls watchPosition on first subscribe and sets status to pending", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         expect(typeof geo._success).toBe("function")
         expect(s.get(geolocationStatusAtom)).toBe("pending")
     })
 
     test("success updates position and marks status active", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         geo._success?.(makePosition())
 
         const snapshot = s.get(positionAtom)
@@ -101,7 +109,7 @@ describe("positionAtom", () => {
 
     test("permission-denied error sets status to error and preserves code", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         const err = {
             code: 1,
             message: "User denied Geolocation",
@@ -117,7 +125,7 @@ describe("positionAtom", () => {
 
     test("position-unavailable error sets status to error", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         const err = {
             code: 2,
             message: "Position unavailable",
@@ -134,13 +142,13 @@ describe("positionAtom", () => {
     test("missing geolocation API marks status unsupported", () => {
         setGeolocation(null)
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         expect(s.get(geolocationStatusAtom)).toBe("unsupported")
     })
 
     test("restart clears any previously-set error", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         const err = {
             code: 2,
             message: "Position unavailable",
@@ -163,7 +171,7 @@ describe("positionAtom", () => {
 
     test("options change restarts the watch with the new options", () => {
         const s = store()
-        s.get(positionAtom)
+        subscribe(s)
         expect(geo._options?.enableHighAccuracy).toBe(false)
         const firstId = geo._cleared.length
 

--- a/packages/@valdres/browser-geolocation/src/atoms/positionAtom.ts
+++ b/packages/@valdres/browser-geolocation/src/atoms/positionAtom.ts
@@ -3,12 +3,12 @@ import type { GlobalAtom } from "valdres"
 import type { GeolocationSnapshot } from "../../types/GeolocationSnapshot"
 import { bootstrap } from "../lib/bootstrap"
 
-// Starts navigator.geolocation.watchPosition on first read and keeps
-// running until positionAtom.resetSelf() is called. Not first-subscription
-// based, so it will hold GPS/Wi-Fi scanning open even with no subscribers.
+// Starts navigator.geolocation.watchPosition on first subscription. The
+// returned cleanup runs when the last subscriber unsubscribes, which stops
+// GPS/Wi-Fi scanning to keep battery usage in check.
 export const positionAtom: GlobalAtom<GeolocationSnapshot | null> =
     atom<GeolocationSnapshot | null>(null, {
         global: true,
         name: "@valdres/browser-geolocation/position",
-        onInit: () => bootstrap(positionAtom),
+        onMount: () => bootstrap(positionAtom),
     })

--- a/packages/@valdres/browser-keyboard/src/atoms/pressedKeysAtom.ts
+++ b/packages/@valdres/browser-keyboard/src/atoms/pressedKeysAtom.ts
@@ -5,5 +5,5 @@ import { bootstrap } from "../lib/bootstrap"
 export const pressedKeysAtom = atom<PressedKey[]>([], {
     global: true,
     name: "@valdres/browser-keyboard/pressedKeys",
-    onInit: () => bootstrap(),
+    onMount: () => bootstrap(),
 })

--- a/packages/@valdres/browser-online/src/atoms/onlineAtom.test.ts
+++ b/packages/@valdres/browser-online/src/atoms/onlineAtom.test.ts
@@ -12,9 +12,10 @@ const setOnLine = (value: boolean) => {
 describe("onlineAtom", () => {
     afterAll(() => setOnLine(true))
 
-    test("first read evaluates lazily and onInit wires event listeners", () => {
+    test("subscribing wires event listeners and reflects navigator state", () => {
         setOnLine(false)
         const s = store()
+        const unsub = s.sub(onlineAtom, () => {})
         expect(s.get(onlineAtom)).toBe(false)
 
         setOnLine(true)
@@ -24,5 +25,6 @@ describe("onlineAtom", () => {
         setOnLine(false)
         window.dispatchEvent(new Event("offline"))
         expect(s.get(onlineAtom)).toBe(false)
+        unsub()
     })
 })

--- a/packages/@valdres/browser-online/src/atoms/onlineAtom.ts
+++ b/packages/@valdres/browser-online/src/atoms/onlineAtom.ts
@@ -9,5 +9,5 @@ const getInitial = () => {
 export const onlineAtom = atom<boolean>(getInitial, {
     global: true,
     name: "@valdres/browser-online/online",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-presence/src/selectors/presenceSelector.test.ts
+++ b/packages/@valdres/browser-presence/src/selectors/presenceSelector.test.ts
@@ -33,6 +33,7 @@ describe("presenceSelector", () => {
         setHasFocus(true)
         setVisibility("visible")
         const s = store()
+        const unsub = s.sub(presenceSelector, () => {})
         expect(s.get(presenceSelector)).toBe(true)
 
         window.dispatchEvent(new Event("blur"))
@@ -40,12 +41,14 @@ describe("presenceSelector", () => {
 
         window.dispatchEvent(new Event("focus"))
         expect(s.get(presenceSelector)).toBe(true)
+        unsub()
     })
 
     test("is false when tab becomes hidden", () => {
         setHasFocus(true)
         setVisibility("visible")
         const s = store()
+        const unsub = s.sub(presenceSelector, () => {})
         expect(s.get(presenceSelector)).toBe(true)
 
         setVisibility("hidden")
@@ -55,12 +58,14 @@ describe("presenceSelector", () => {
         setVisibility("visible")
         document.dispatchEvent(new Event("visibilitychange"))
         expect(s.get(presenceSelector)).toBe(true)
+        unsub()
     })
 
     test("is false when both visibility and focus are lost", () => {
         setHasFocus(true)
         setVisibility("visible")
         const s = store()
+        const unsub = s.sub(presenceSelector, () => {})
         expect(s.get(presenceSelector)).toBe(true)
 
         window.dispatchEvent(new Event("blur"))
@@ -74,5 +79,6 @@ describe("presenceSelector", () => {
         setVisibility("visible")
         document.dispatchEvent(new Event("visibilitychange"))
         expect(s.get(presenceSelector)).toBe(true)
+        unsub()
     })
 })

--- a/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.test.ts
+++ b/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.test.ts
@@ -38,9 +38,10 @@ describe("reducedMotionAtom", () => {
         expect(s.get(reducedMotionAtom)).toBe("reduce")
     })
 
-    test("updates when media query change event fires", () => {
+    test("subscribing wires the media query listener and reflects changes", () => {
         const mq = installMatchMedia(false)
         const s = store()
+        const unsub = s.sub(reducedMotionAtom, () => {})
         expect(s.get(reducedMotionAtom)).toBe("no-preference")
 
         mq.set(true)
@@ -48,5 +49,6 @@ describe("reducedMotionAtom", () => {
 
         mq.set(false)
         expect(s.get(reducedMotionAtom)).toBe("no-preference")
+        unsub()
     })
 })

--- a/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.ts
+++ b/packages/@valdres/browser-reduced-motion/src/atoms/reducedMotionAtom.ts
@@ -20,5 +20,5 @@ const getInitial = (): ReducedMotion => {
 export const reducedMotionAtom = atom<ReducedMotion>(getInitial, {
     global: true,
     name: "@valdres/browser-reduced-motion/reducedMotion",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-screen-details/src/atoms/screenPermissionAtom.ts
+++ b/packages/@valdres/browser-screen-details/src/atoms/screenPermissionAtom.ts
@@ -12,5 +12,5 @@ const getInitial = (): ScreenPermissionState => {
 export const screenPermissionAtom = atom<ScreenPermissionState>(getInitial, {
     global: true,
     name: "@valdres/browser-screen-details/permission",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
+++ b/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
@@ -13,8 +13,7 @@ describe("screenAtom", () => {
 
     test("updates atom when window resize fires", () => {
         const s = store()
-        // touch atom so subscribe fires
-        s.get(screenAtom)
+        const unsub = s.sub(screenAtom, () => {})
 
         Object.defineProperty(window.screen, "width", {
             value: 3840,
@@ -29,5 +28,6 @@ describe("screenAtom", () => {
         const info = s.get(screenAtom)
         expect(info.width).toBe(3840)
         expect(info.height).toBe(2160)
+        unsub()
     })
 })

--- a/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
+++ b/packages/@valdres/browser-screen/src/atoms/screenAtom.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test"
+import { beforeEach, describe, expect, test } from "bun:test"
 import { store } from "valdres"
 import { screenAtom } from "./screenAtom"
 
 describe("screenAtom", () => {
+    // The atom is global; other test files exercising window-state mocks
+    // can leave a stale cached value. Reset so each test starts clean.
+    beforeEach(() => screenAtom.resetSelf())
+
     test("initial value reflects window.screen", () => {
         const s = store()
         const info = s.get(screenAtom)

--- a/packages/@valdres/browser-screen/src/atoms/screenAtom.ts
+++ b/packages/@valdres/browser-screen/src/atoms/screenAtom.ts
@@ -6,5 +6,5 @@ import { subscribe } from "../lib/subscribe"
 export const screenAtom = atom<ScreenInfo>(readScreen, {
     global: true,
     name: "@valdres/browser-screen/screen",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.test.ts
+++ b/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.test.ts
@@ -12,9 +12,10 @@ const setVisibility = (value: DocumentVisibilityState) => {
 describe("visibilityAtom", () => {
     afterAll(() => setVisibility("visible"))
 
-    test("first read evaluates lazily and onInit wires event listeners", () => {
+    test("subscribing wires event listeners and reflects document visibility", () => {
         setVisibility("hidden")
         const s = store()
+        const unsub = s.sub(visibilityAtom, () => {})
         expect(s.get(visibilityAtom)).toBe("hidden")
 
         setVisibility("visible")
@@ -24,5 +25,6 @@ describe("visibilityAtom", () => {
         setVisibility("hidden")
         document.dispatchEvent(new Event("visibilitychange"))
         expect(s.get(visibilityAtom)).toBe("hidden")
+        unsub()
     })
 })

--- a/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.ts
+++ b/packages/@valdres/browser-visibility/src/atoms/visibilityAtom.ts
@@ -9,5 +9,5 @@ const getInitial = (): DocumentVisibilityState => {
 export const visibilityAtom = atom<DocumentVisibilityState>(getInitial, {
     global: true,
     name: "@valdres/browser-visibility/visibility",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/browser-window/src/atoms/windowSizeAtom.test.ts
+++ b/packages/@valdres/browser-window/src/atoms/windowSizeAtom.test.ts
@@ -35,7 +35,7 @@ describe("windowSizeAtom", () => {
 
     test("updates when window resize fires", () => {
         const s = store()
-        s.get(windowSizeAtom)
+        const unsub = s.sub(windowSizeAtom, () => {})
 
         setInner(640, 480)
         window.dispatchEvent(new Event("resize"))
@@ -43,5 +43,6 @@ describe("windowSizeAtom", () => {
         const size = s.get(windowSizeAtom)
         expect(size.innerWidth).toBe(640)
         expect(size.innerHeight).toBe(480)
+        unsub()
     })
 })

--- a/packages/@valdres/browser-window/src/atoms/windowSizeAtom.test.ts
+++ b/packages/@valdres/browser-window/src/atoms/windowSizeAtom.test.ts
@@ -20,6 +20,9 @@ describe("windowSizeAtom", () => {
     beforeEach(() => {
         originalInnerWidth = window.innerWidth
         originalInnerHeight = window.innerHeight
+        // The atom is global; reset so a stale cache from other test
+        // files (or earlier runs) doesn't bleed into the assertion.
+        windowSizeAtom.resetSelf()
     })
 
     afterEach(() => {

--- a/packages/@valdres/browser-window/src/atoms/windowSizeAtom.ts
+++ b/packages/@valdres/browser-window/src/atoms/windowSizeAtom.ts
@@ -6,5 +6,5 @@ import { subscribe } from "../lib/subscribe"
 export const windowSizeAtom = atom<WindowSize>(readWindowSize, {
     global: true,
     name: "@valdres/browser-window/size",
-    onInit: () => subscribe(),
+    onMount: () => subscribe(),
 })

--- a/packages/@valdres/color-mode/src/systemColorModeAtom.test.ts
+++ b/packages/@valdres/color-mode/src/systemColorModeAtom.test.ts
@@ -8,19 +8,26 @@ describe("systemColorModeAtom", () => {
         const { togglePrefersColorScheme, eventListeners, reset } = mockWindow()
         const store1 = store()
         const subscription = mock(() => {})
+
+        // Reads alone don't mount listeners — only subscriptions do.
         expect(eventListeners.size).toBe(0)
         expect(store1.get(systemColorModeAtom)).toBe("dark")
-        expect(eventListeners.size).toBe(1)
-        togglePrefersColorScheme()
-        expect(store1.get(systemColorModeAtom)).toBe("light")
+        expect(eventListeners.size).toBe(0)
 
-        store1.sub(systemColorModeAtom, subscription)
+        const unsub = store1.sub(systemColorModeAtom, subscription)
+        expect(eventListeners.size).toBe(1)
         expect(subscription).toHaveBeenCalledTimes(0)
+
         togglePrefersColorScheme()
         expect(subscription).toHaveBeenCalledTimes(1)
+        expect(store1.get(systemColorModeAtom)).toBe("light")
+
+        togglePrefersColorScheme()
+        expect(subscription).toHaveBeenCalledTimes(2)
         expect(store1.get(systemColorModeAtom)).toBe("dark")
-        expect(eventListeners.size).toBe(1)
-        reset()
+
+        unsub()
         expect(eventListeners.size).toBe(0)
+        reset()
     })
 })

--- a/packages/@valdres/color-mode/src/systemColorModeAtom.ts
+++ b/packages/@valdres/color-mode/src/systemColorModeAtom.ts
@@ -6,7 +6,7 @@ import type { ColorMode } from "../types/ColorMode"
 export const systemColorModeAtom = atom<ColorMode>(getSystemColorMode, {
     global: true,
     name: "@valdres/color-mode/systemColorModeAtom",
-    onInit: () => {
+    onMount: () => {
         const listener = () => {
             systemColorModeAtom.setSelf(getSystemColorMode())
         }

--- a/packages/@valdres/color-mode/src/userSelectedColorModeAtom.test.ts
+++ b/packages/@valdres/color-mode/src/userSelectedColorModeAtom.test.ts
@@ -9,6 +9,7 @@ describe("userSelectedColorModeAtom", () => {
     test("default", () => {
         const { togglePrefersColorScheme, reset } = mockWindow()
         const rootStore = store()
+        const unsub = rootStore.sub(colorModeSelector, () => {})
         expect(rootStore.get(userSelectedColorModeAtom)).toBe("system")
         expect(rootStore.get(colorModeSelector)).toBe("dark")
         togglePrefersColorScheme()
@@ -17,6 +18,7 @@ describe("userSelectedColorModeAtom", () => {
         expect(rootStore.get(colorModeSelector)).toBe("dark")
         expect(rootStore.get(userSelectedColorModeAtom)).toBe("dark")
         expect(rootStore.get(systemColorModeAtom)).toBe("light")
+        unsub()
         reset()
     })
 })

--- a/packages/@valdres/public-ip/src/atoms/publicIp.test.ts
+++ b/packages/@valdres/public-ip/src/atoms/publicIp.test.ts
@@ -56,7 +56,11 @@ afterAll(() => {
 
 for (const { label, ipAtom, endpointsAtom, defaultEndpoint, ip, customIp } of cases) {
     describe(label, () => {
+        let activeUnsubs: Array<() => void> = []
+
         afterEach(() => {
+            for (const unsub of activeUnsubs) unsub()
+            activeUnsubs = []
             m.reset()
             ;(ipAtom as GlobalAtom<any>).resetSelf()
             endpointsAtom.resetSelf()
@@ -81,7 +85,7 @@ for (const { label, ipAtom, endpointsAtom, defaultEndpoint, ip, customIp } of ca
             publicIpMaxAgeAtom.setSelf(30)
             m.alwaysRespond(defaultEndpoint, ip)
             const s = store()
-            s.sub(ipAtom, () => {})
+            activeUnsubs.push(s.sub(ipAtom, () => {}))
             const before = m.calls.length
             await waitUntil(() => m.calls.length > before)
             expect(await s.get(ipAtom)).toBe(ip)

--- a/packages/@valdres/public-ip/src/lib/createPublicIpAtom.ts
+++ b/packages/@valdres/public-ip/src/lib/createPublicIpAtom.ts
@@ -1,7 +1,7 @@
 import { atom } from "valdres"
 import type { GlobalAtom } from "valdres"
 import { fetchPublicIp } from "../utils/fetchPublicIp"
-import { publicIpOnInit } from "./publicIpOnInit"
+import { subscribe } from "./subscribe"
 
 export const createPublicIpAtom = (
     name: string,
@@ -15,8 +15,8 @@ export const createPublicIpAtom = (
         global: true,
         name,
         maxAge: maxAgeAtom,
-        onInit: (): (() => void) =>
-            publicIpOnInit(ipAtom, endpointsAtom, validate),
+        onMount: (): (() => void) =>
+            subscribe(ipAtom, endpointsAtom, validate),
     })
     return ipAtom
 }

--- a/packages/@valdres/public-ip/src/lib/subscribe.ssr.test.ts
+++ b/packages/@valdres/public-ip/src/lib/subscribe.ssr.test.ts
@@ -6,7 +6,7 @@ import { publicIpV4EndpointsAtom } from "../atoms/publicIpV4EndpointsAtom"
 import { publicIpMaxAgeAtom } from "../atoms/publicIpMaxAgeAtom"
 import { mockFetch } from "../../test/mockFetch"
 
-describe("publicIpOnInit (SSR / no browser APIs)", () => {
+describe("subscribe (SSR / no browser APIs)", () => {
     let m: ReturnType<typeof mockFetch>
 
     beforeAll(() => {

--- a/packages/@valdres/public-ip/src/lib/subscribe.test.ts
+++ b/packages/@valdres/public-ip/src/lib/subscribe.test.ts
@@ -50,10 +50,13 @@ const removeFakeConnection = () => {
     delete (navigator as any).connection
 }
 
-describe("publicIpOnInit", () => {
+describe("subscribe", () => {
     const m = mockFetch()
+    let activeUnsubs: Array<() => void> = []
 
     afterEach(() => {
+        for (const unsub of activeUnsubs) unsub()
+        activeUnsubs = []
         m.reset()
         publicIpV4Atom.resetSelf()
         publicIpV4EndpointsAtom.resetSelf()
@@ -67,8 +70,8 @@ describe("publicIpOnInit", () => {
     test("refetches on window 'online' event", async () => {
         m.alwaysRespond("https://api4.ipify.org", "203.0.113.10")
         const s = store()
+        activeUnsubs.push(s.sub(publicIpV4Atom, () => {}))
         await s.get(publicIpV4Atom)
-        s.sub(publicIpV4Atom, () => {})
         const before = m.calls.length
         window.dispatchEvent(new Event("online"))
         await waitUntil(() => m.calls.length > before)
@@ -78,8 +81,8 @@ describe("publicIpOnInit", () => {
     test("refetches on document 'visibilitychange' when visible", async () => {
         m.alwaysRespond("https://api4.ipify.org", "203.0.113.11")
         const s = store()
+        activeUnsubs.push(s.sub(publicIpV4Atom, () => {}))
         await s.get(publicIpV4Atom)
-        s.sub(publicIpV4Atom, () => {})
         const before = m.calls.length
         document.dispatchEvent(new Event("visibilitychange"))
         await waitUntil(() => m.calls.length > before)
@@ -100,8 +103,8 @@ describe("publicIpOnInit", () => {
         test("refetches on connection 'change' event", async () => {
             m.alwaysRespond("https://api4.ipify.org", "203.0.113.12")
             const s = store()
+            activeUnsubs.push(s.sub(publicIpV4Atom, () => {}))
             await s.get(publicIpV4Atom)
-            s.sub(publicIpV4Atom, () => {})
             const before = m.calls.length
             fake.emit()
             await waitUntil(() => m.calls.length > before)
@@ -130,8 +133,8 @@ describe("publicIpOnInit", () => {
         test("does not refetch when signals fire", async () => {
             m.alwaysRespond("https://api4.ipify.org", "203.0.113.13")
             const s = store()
+            activeUnsubs.push(s.sub(publicIpV4Atom, () => {}))
             await s.get(publicIpV4Atom)
-            s.sub(publicIpV4Atom, () => {})
             const before = m.calls.length
             window.dispatchEvent(new Event("online"))
             document.dispatchEvent(new Event("visibilitychange"))

--- a/packages/@valdres/public-ip/src/lib/subscribe.ts
+++ b/packages/@valdres/public-ip/src/lib/subscribe.ts
@@ -45,7 +45,7 @@ const registerSharedListeners = () => {
     }
 }
 
-export const publicIpOnInit = (
+export const subscribe = (
     ipAtom: GlobalAtom<Promise<string> | string>,
     endpointsAtom: GlobalAtom<string[]>,
     validate: (value: string) => boolean,

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1324,9 +1324,12 @@ describe("subscriber error handling", () => {
         resolver!(999)
         await wait(1)
 
-        // The resolved value should NOT have been written to the store,
-        // because the subscription (and its interval) was cleaned up.
-        expect(store1.get(atom1)).toBe(1)
+        // The resolved value 999 must not have been written to the store —
+        // the cancelled in-flight promise should be ignored on resolution.
+        // (We assert via the raw cache to avoid triggering lazy maxAge
+        // revalidation on an unmounted read, which is unrelated to the
+        // cleanup invariant being verified here.)
+        expect(store1.data.values.get(atom1)).toBe(1)
     })
 
     test("atom with maxAge: last subscriber unsubscribing clears interval even if it was not the first", async () => {

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1332,6 +1332,45 @@ describe("subscriber error handling", () => {
         expect(store1.data.values.get(atom1)).toBe(1)
     })
 
+    test("stale init promise from before lazy eviction does not clobber new value", async () => {
+        const resolvers: Array<(v: string) => void> = []
+        let calls = 0
+        const a = atom<string | Promise<string>>(
+            () => {
+                calls++
+                const idx = calls
+                return new Promise<string>(resolve => {
+                    resolvers.push(value => resolve(`${value}-${idx}`))
+                })
+            },
+            { maxAge: 30, name: "test/stale-init-promise-guard" },
+        )
+        const s = store()
+
+        // First init kicks off promise#1.
+        const firstPending = s.get(a)
+        expect(typeof (firstPending as Promise<string>).then).toBe("function")
+        expect(calls).toBe(1)
+
+        await wait(50) // past maxAge
+
+        // Lazy eviction + re-init: promise#2.
+        s.get(a)
+        expect(calls).toBe(2)
+
+        // Resolve promise#2 → store updates to v-2.
+        resolvers[1]("v")
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(s.get(a)).toBe("v-2")
+
+        // Late resolve of stale promise#1 — must NOT clobber v-2.
+        resolvers[0]("v")
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(s.get(a)).toBe("v-2")
+    })
+
     test("atom with maxAge: last subscriber unsubscribing clears interval even if it was not the first", async () => {
         const setIntervalSpy = spyOn(global, "setInterval")
         const clearIntervalSpy = spyOn(global, "clearInterval")

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -297,26 +297,6 @@ describe("atom", () => {
         expect(onUnmount).toHaveBeenCalledTimes(0)
     })
 
-    test("onInit", () => {
-        const store1 = store()
-        const onInitCallback = mock(() => {})
-        const user1 = atom("Foo", {
-            onInit: onInitCallback,
-        })
-        expect(store1.get(user1)).toBe("Foo")
-        expect(onInitCallback).toHaveBeenCalledTimes(1)
-    })
-
-    test("onInit atom with no value", () => {
-        const store1 = store()
-        const onInitCallback = mock(setSelf => setSelf("Foo"))
-        const user1 = atom<string>(undefined, {
-            onInit: onInitCallback,
-        })
-        expect(store1.get(user1)).toBe("Foo")
-        expect(onInitCallback).toHaveBeenCalledTimes(1)
-    })
-
     test("atom with selector as default value", () => {
         const store1 = store()
         const atom1 = atom(1)

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -27,6 +27,7 @@ Object.defineProperties(lazyProto, {
     stateDependencies: makeLazyGetter("stateDependencies"),
     mounts: makeLazyGetter("mounts"),
     abortControllers: makeLazyGetter("abortControllers"),
+    lastValueWriteAt: makeLazyGetter("lastValueWriteAt"),
 })
 
 export type CreateStoreDataOptions = {

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -335,6 +335,59 @@ describe("globalAtom", () => {
         unsub()
     })
 
+    test("get on unmounted atom past maxAge re-runs defaultValue (lazy revalidation)", async () => {
+        let calls = 0
+        const a = atom<number>(
+            () => {
+                calls++
+                return calls
+            },
+            {
+                global: true,
+                name: "test/lazy-revalidate-on-stale-get",
+                maxAge: 50,
+            },
+        )
+        const s = store()
+        const initial = s.get(a)
+        const callsAfterInit = calls
+
+        // Re-read inside the freshness window: cached, no re-eval.
+        expect(s.get(a)).toBe(initial)
+        expect(calls).toBe(callsAfterInit)
+
+        await wait(75) // past maxAge
+
+        // Lazy revalidation: cache is stale; reading should re-run
+        // defaultValue and surface a newer value.
+        const fresh = s.get(a)
+        expect(calls).toBeGreaterThan(callsAfterInit)
+        expect(fresh).not.toBe(initial)
+    })
+
+    test("get within maxAge window returns cached value without re-eval", async () => {
+        let calls = 0
+        const a = atom<number>(
+            () => {
+                calls++
+                return calls
+            },
+            {
+                global: true,
+                name: "test/lazy-revalidate-fresh-cache",
+                maxAge: 200,
+            },
+        )
+        const s = store()
+        const initial = s.get(a)
+        const callsAfterInit = calls
+
+        await wait(20) // well within maxAge
+
+        expect(s.get(a)).toBe(initial)
+        expect(calls).toBe(callsAfterInit)
+    })
+
     test("global onMount receives (store, state) args like non-global atoms", () => {
         let receivedStore: unknown = null
         let receivedState: unknown = null

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -268,6 +268,73 @@ describe("globalAtom", () => {
         }
     })
 
+    test("resetSelf remounts atom when only a dependent selector is subscribed", () => {
+        let mountCalls = 0
+        let unmountCalls = 0
+        const a = atom("foo", {
+            global: true,
+            name: "test/reset-transitive-sub",
+            onMount: () => {
+                mountCalls++
+                return () => {
+                    unmountCalls++
+                }
+            },
+        })
+        const sel = selector(get => get(a))
+        const s = store()
+        const unsub = s.sub(sel, () => {})
+
+        // Selector subscribed → atom transitively mounted.
+        expect(mountCalls).toBe(1)
+        expect(unmountCalls).toBe(0)
+
+        a.resetSelf()
+
+        // Selector is still subscribed; atom should be remounted so listeners
+        // installed by onMount keep tracking external state.
+        expect(unmountCalls).toBe(1)
+        expect(mountCalls).toBe(2)
+
+        unsub()
+        expect(unmountCalls).toBe(2)
+    })
+
+    test("onMount throw rolls back the global mount counter", () => {
+        let calls = 0
+        let shouldThrow = true
+        const a = atom("foo", {
+            global: true,
+            name: "test/onmount-throws-rollback",
+            onMount: () => {
+                calls++
+                if (shouldThrow) {
+                    throw new Error("first mount fails")
+                }
+                return () => {}
+            },
+        })
+
+        // First sub: userOnMount throws. mountAtom rethrows.
+        const s1 = store()
+        let firstThrow: unknown
+        try {
+            s1.sub(a, () => {})
+        } catch (e) {
+            firstThrow = e
+        }
+        expect((firstThrow as Error)?.message).toBe("first mount fails")
+        expect(calls).toBe(1)
+
+        // A fresh sub on a different store should re-fire userOnMount —
+        // a stuck mountCount would leave it >0 and skip the user hook.
+        shouldThrow = false
+        const s2 = store()
+        const unsub = s2.sub(a, () => {})
+        expect(calls).toBe(2)
+        unsub()
+    })
+
     test("global onMount receives (store, state) args like non-global atoms", () => {
         let receivedStore: unknown = null
         let receivedState: unknown = null

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -335,6 +335,59 @@ describe("globalAtom", () => {
         unsub()
     })
 
+    test("after resetSelf, globalStore is re-added to stores on next interaction", () => {
+        const a = atom("foo", { global: true, name: "test/reset-globalStore-readd" })
+        const s1 = store()
+        const s2 = store()
+
+        s1.get(a)
+        s2.get(a)
+        const storesBeforeReset = a.stores.size
+        expect(storesBeforeReset).toBeGreaterThanOrEqual(3) // s1, s2, globalStore
+
+        a.resetSelf()
+        // No subscribers, so atom.stores collapses on reset.
+        expect(a.stores.size).toBe(0)
+
+        // First interaction (set from a fresh store) must re-establish
+        // globalStore in atom.stores so cross-store sync works.
+        const s3 = store()
+        s3.set(a, "synced")
+        expect(s3.get(a)).toBe("synced")
+        // Cross-store sync: another store reading should observe the value.
+        expect(s2.get(a)).toBe("synced")
+        // globalStore must be back in atom.stores.
+        const storesAfter = a.stores.size
+        expect(storesAfter).toBeGreaterThanOrEqual(2) // s3 + globalStore at minimum
+    })
+
+    test("resetSelf does not install maxAge timer for atoms with only transitive subs", async () => {
+        let callCount = 0
+        const a = atom<number>(
+            () => {
+                callCount++
+                return callCount
+            },
+            {
+                global: true,
+                name: "test/reset-maxage-transitive-only",
+                maxAge: 30,
+            },
+        )
+        const sel = selector(get => get(a))
+        const s = store()
+        s.sub(sel, () => {})
+
+        // Selector subscribed but the atom has no direct subscribers,
+        // so no maxAge timer should be installed before or after reset.
+        expect(a.maxAgeInterval).toBeUndefined()
+
+        a.resetSelf()
+
+        // After reset, still no direct sub on the atom — no timer.
+        expect(a.maxAgeInterval).toBeUndefined()
+    })
+
     test("get on unmounted atom past maxAge re-runs defaultValue (lazy revalidation)", async () => {
         let calls = 0
         const a = atom<number>(

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -51,42 +51,72 @@ describe("globalAtom", () => {
         expect(store2.get(numberAtom)).toBe("it works")
     })
 
-    test("onInit", () => {
+    test("onMount fires once across stores when first subscriber attaches", () => {
         const store1 = store()
         const store2 = store()
-        const onInit = mock(setSelf => {
-            setSelf("init works")
-        })
-        const testAtom = atom("foo", { global: true, onInit })
-        expect(store1.get(testAtom)).toBe("init works")
-        expect(store2.get(testAtom)).toBe("init works")
-        expect(onInit).toHaveBeenCalledTimes(1)
+        const onMount = mock(() => {})
+        const testAtom = atom("foo", { global: true, onMount })
+
+        expect(store1.get(testAtom)).toBe("foo")
+        expect(store2.get(testAtom)).toBe("foo")
+        expect(onMount).toHaveBeenCalledTimes(0)
+
+        const unsub1 = store1.sub(testAtom, () => {})
+        expect(onMount).toHaveBeenCalledTimes(1)
+
+        const unsub2 = store2.sub(testAtom, () => {})
+        expect(onMount).toHaveBeenCalledTimes(1)
+
+        unsub1()
+        unsub2()
     })
 
-    test("reset global atom", () => {
+    test("onMount cleanup fires when last subscriber across stores detaches", () => {
         const store1 = store()
         const store2 = store()
-        let initialized = false
-        const onInit = mock(() => {
-            initialized = true
-            return () => {
-                initialized = false
-            }
+        const cleanup = mock(() => {})
+        const testAtom = atom("foo", {
+            global: true,
+            onMount: () => cleanup,
         })
-        const testAtom = atom("foo", { global: true, onInit })
-        expect(initialized).toBe(false)
+
+        const unsub1 = store1.sub(testAtom, () => {})
+        const unsub2 = store2.sub(testAtom, () => {})
+        expect(cleanup).toHaveBeenCalledTimes(0)
+
+        unsub1()
+        expect(cleanup).toHaveBeenCalledTimes(0)
+
+        unsub2()
+        expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+
+    test("onMount re-fires after full unmount and re-subscribe", () => {
+        const store1 = store()
+        const onMount = mock(() => () => {})
+        const testAtom = atom("foo", { global: true, onMount })
+
+        const unsub1 = store1.sub(testAtom, () => {})
+        expect(onMount).toHaveBeenCalledTimes(1)
+        unsub1()
+
+        const unsub2 = store1.sub(testAtom, () => {})
+        expect(onMount).toHaveBeenCalledTimes(2)
+        unsub2()
+    })
+
+    test("reset global atom restores default across stores", () => {
+        const store1 = store()
+        const store2 = store()
+        const testAtom = atom("foo", { global: true })
         expect(store1.get(testAtom)).toBe("foo")
-        expect(initialized).toBe(true)
         expect(store2.get(testAtom)).toBe("foo")
         testAtom.setSelf("set self")
         expect(store1.get(testAtom)).toBe("set self")
         expect(store2.get(testAtom)).toBe("set self")
         testAtom.resetSelf()
-        expect(initialized).toBe(false)
         expect(store1.get(testAtom)).toBe("foo")
-        expect(initialized).toBe(true)
         expect(store2.get(testAtom)).toBe("foo")
-        store1.sub(testAtom, () => {})
     })
 
     test("reset support for global atom with selectors", () => {
@@ -180,20 +210,81 @@ describe("globalAtom", () => {
         expect(store1.get(testAtom)).not.toBe(42)
     })
 
-    test("onReset cleanup is called exactly once per resetSelf", () => {
+    test("onMount cleanup fires exactly once when last subscriber across stores unsubs", () => {
         const store1 = store()
         const store2 = store()
         const store3 = store()
-        const onResetMock = mock(() => {})
+        const cleanup = mock(() => {})
         const testAtom = atom("foo", {
             global: true,
-            onInit: () => onResetMock,
+            onMount: () => cleanup,
         })
-        store1.get(testAtom)
-        store2.get(testAtom)
-        store3.get(testAtom)
-        testAtom.resetSelf()
-        expect(onResetMock).toHaveBeenCalledTimes(1)
+        const u1 = store1.sub(testAtom, () => {})
+        const u2 = store2.sub(testAtom, () => {})
+        const u3 = store3.sub(testAtom, () => {})
+        u1()
+        u2()
+        expect(cleanup).toHaveBeenCalledTimes(0)
+        u3()
+        expect(cleanup).toHaveBeenCalledTimes(1)
+    })
+
+    test("resetSelf still clears value and remounts when cleanup throws", () => {
+        let mountCalls = 0
+        const a = atom("foo", {
+            global: true,
+            name: "test/reset-cleanup-throws",
+            onMount: () => {
+                mountCalls++
+                return () => {
+                    throw new Error("cleanup boom")
+                }
+            },
+        })
+        const s = store()
+        const unsub = s.sub(a, () => {})
+        expect(mountCalls).toBe(1)
+
+        a.setSelf("changed")
+        expect(s.get(a)).toBe("changed")
+
+        let caught: unknown
+        try {
+            a.resetSelf()
+        } catch (e) {
+            caught = e
+        }
+
+        expect((caught as Error)?.message).toBe("cleanup boom")
+        // Value reset went through despite the throwing cleanup.
+        expect(s.get(a)).toBe("foo")
+        // Active subscriber triggered a remount.
+        expect(mountCalls).toBe(2)
+        try {
+            unsub()
+        } catch {
+            // The remount installed another throwing cleanup;
+            // the unsub firing it is incidental to this test.
+        }
+    })
+
+    test("global onMount receives (store, state) args like non-global atoms", () => {
+        let receivedStore: unknown = null
+        let receivedState: unknown = null
+        const a = atom("foo", {
+            global: true,
+            name: "test/onMount-args",
+            onMount: (store, state) => {
+                receivedStore = store
+                receivedState = state
+                return () => {}
+            },
+        })
+        const s = store()
+        const unsub = s.sub(a, () => {})
+        expect(receivedStore).not.toBeNull()
+        expect(receivedState).toBe(a)
+        unsub()
     })
 
     test("resetSelf recovers if subscriber throws", () => {
@@ -306,31 +397,50 @@ describe("globalAtom", () => {
         expect(afterSecond).toBeGreaterThan(afterFirst)
     })
 
-    test("preserves fresh onInit registration when propagation triggers re-init", () => {
-        let registrationCount = 0
-        let cleanupCount = 0
+    test("resetSelf cycles mount lifecycle for stores with active subscribers", () => {
+        let mountCount = 0
+        let unmountCount = 0
         const a = atom("initial", {
             global: true,
-            name: "test-reset-oninit",
-            onInit: () => {
-                registrationCount++
+            name: "test-reset-mount-lifecycle",
+            onMount: () => {
+                mountCount++
                 return () => {
-                    cleanupCount++
+                    unmountCount++
                 }
             },
         })
         const s = store()
-        s.sub(a, () => {
-            s.get(a)
-        })
-        s.get(a)
+        const unsub = s.sub(a, () => {})
+        expect(mountCount).toBe(1)
+        expect(unmountCount).toBe(0)
 
-        const regBefore = registrationCount
-        const cleanupBefore = cleanupCount
         a.resetSelf()
 
-        expect(registrationCount - regBefore).toBe(1)
-        expect(cleanupCount - cleanupBefore).toBe(1)
+        // resetSelf is a "full restart": cleanup runs, then onMount re-fires
+        // for any subscribers that survived the reset.
+        expect(unmountCount).toBe(1)
+        expect(mountCount).toBe(2)
+
+        unsub()
+        expect(unmountCount).toBe(2)
+    })
+
+    test("resetSelf without subscribers does not invoke onMount", () => {
+        let mountCount = 0
+        const a = atom("initial", {
+            global: true,
+            name: "test-reset-no-subs",
+            onMount: () => {
+                mountCount++
+                return () => {}
+            },
+        })
+        const s = store()
+        s.get(a)
+        expect(mountCount).toBe(0)
+        a.resetSelf()
+        expect(mountCount).toBe(0)
     })
 
     test("setSelf with bare promise resolves into stored value across stores", async () => {

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -128,7 +128,12 @@ export const globalAtom = <Value = unknown>(
 
         for (const s of subscribedStores) {
             stores.add(s)
-            if (atom.maxAge) installMaxAgeTimer(atom, s)
+            // Match subscribe.ts: maxAge timer is installed only when the
+            // atom has a DIRECT subscriber. Transitive (selector-only)
+            // subscribers go through the lazy-revalidation path on read.
+            if (atom.maxAge && (s.subscriptions.get(atom)?.size ?? 0) > 0) {
+                installMaxAgeTimer(atom, s)
+            }
             try {
                 mountAtom(atom, s)
             } catch (e) {

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -7,7 +7,7 @@ import type { AtomOnSet } from "./../types/AtomOnSet"
 import type { AtomOptions } from "./../types/AtomOptions"
 import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
-import { mountAtom, unmountAtom } from "./mountAtom"
+import { isTransitivelySubscribed, mountAtom, unmountAtom } from "./mountAtom"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { installMaxAgeTimer } from "./subscribe"
@@ -52,7 +52,15 @@ export const globalAtom = <Value = unknown>(
         ? (...args: unknown[]) => {
               mountCount++
               if (mountCount === 1) {
-                  userCleanup = userOnMount(...args)
+                  try {
+                      userCleanup = userOnMount(...args)
+                  } catch (error) {
+                      // Roll back so a future mount retries userOnMount
+                      // instead of seeing a stuck non-zero counter.
+                      mountCount--
+                      userCleanup = undefined
+                      throw error
+                  }
               }
               return () => {
                   if (mountCount <= 0) return
@@ -81,7 +89,10 @@ export const globalAtom = <Value = unknown>(
         const snapshot = [...stores]
         const subscribedStores: StoreData[] = []
         for (const s of snapshot) {
-            if ((s.subscriptions.get(atom)?.size ?? 0) > 0) {
+            // Use transitive subscription so selector subscribers (which
+            // mount the atom via mountTransitiveDeps) keep their listeners
+            // alive across resetSelf.
+            if (isTransitivelySubscribed(atom, s)) {
                 subscribedStores.push(s)
             }
         }

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -7,6 +7,7 @@ import type { AtomOnSet } from "./../types/AtomOnSet"
 import type { AtomOptions } from "./../types/AtomOptions"
 import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
+import { mountAtom, unmountAtom } from "./mountAtom"
 import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { installMaxAgeTimer } from "./subscribe"
@@ -17,34 +18,53 @@ export const globalAtom = <Value = unknown>(
     options: AtomOptions<Value>,
 ) => {
     const stores = new Set<StoreData>()
-    let value: Value | undefined
-    let initialized = false
-    let onReset: (() => void) | void
     if (options.onSet)
         throw new Error("onSet on globalAtom is currently not supported")
 
+    // Sync the atom's current value into a store on first access. Called by
+    // initAtom whenever a store touches this atom for the first time.
     const onInit: AtomOnInit<Value> = (setSelf, data) => {
         setSelf(globalStore.get(atom))
-        if (!initialized && options.onInit) {
-            onReset = options.onInit(newVal => {
-                setSelf(newVal)
-                value = newVal
-            }, data)
-            initialized = true
-        }
         stores.add(data)
     }
 
     const onSet: AtomOnSet<Value> = (newValue, currentStore) => {
-        value = newValue
         if (stores.size > 1) {
             for (const store of stores) {
                 if (store.id !== currentStore.id) {
-                    setAtom(atom, value, store, true)
+                    setAtom(atom, newValue, store, true)
                 }
             }
         }
     }
+
+    // For global atoms, options.onMount fires when the FIRST subscriber across
+    // any store attaches, and its cleanup fires when the LAST subscriber across
+    // all stores detaches. mountAtom invokes the wrapper per-store; we collapse
+    // those into a single global lifecycle via a ref counter. The first store
+    // to mount is the one whose (store, state) gets forwarded to userOnMount.
+    let mountCount = 0
+    let userCleanup: (() => void) | void
+    const userOnMount = options.onMount as
+        | ((...args: unknown[]) => void | (() => void))
+        | undefined
+    const onMount = userOnMount
+        ? (...args: unknown[]) => {
+              mountCount++
+              if (mountCount === 1) {
+                  userCleanup = userOnMount(...args)
+              }
+              return () => {
+                  if (mountCount <= 0) return
+                  mountCount--
+                  if (mountCount === 0 && typeof userCleanup === "function") {
+                      const cleanup = userCleanup
+                      userCleanup = undefined
+                      cleanup()
+                  }
+              }
+          }
+        : undefined
 
     const getSelf = () => globalStore.get(atom)
 
@@ -52,42 +72,59 @@ export const globalAtom = <Value = unknown>(
         globalStore.set(atom, newValue)
 
     const resetSelf: GlobalAtomResetSelfFunc = () => {
-        value = undefined
-        initialized = false
+        // Snapshot stores that still have active subscribers so we can
+        // remount cleanly after the value is cleared. Reset is a "full
+        // restart" — cleanup current listeners, clear value, then re-arm
+        // listeners for stores that still want updates. Errors from any
+        // single store don't short-circuit the rest; the first one is
+        // rethrown after the reset finishes.
+        const snapshot = [...stores]
+        const subscribedStores: StoreData[] = []
+        for (const s of snapshot) {
+            if ((s.subscriptions.get(atom)?.size ?? 0) > 0) {
+                subscribedStores.push(s)
+            }
+        }
+
+        let firstError: unknown
+        const recordError = (e: unknown) => {
+            if (!firstError) firstError = e
+        }
+
+        for (const s of snapshot) {
+            try {
+                unmountAtom(atom, s)
+            } catch (e) {
+                recordError(e)
+            }
+        }
+
         if (atom.maxAgeInterval) {
             atom.maxAgeInterval.cleanup()
             atom.maxAgeInterval.refCount = 0
             atom.maxAgeInterval = undefined
         }
-        const snapshot = [...stores]
-        const previousOnReset = onReset
-        onReset = undefined
-        let firstError: unknown
-        try {
-            for (const store of snapshot) {
-                stores.delete(store)
-                store.values.delete(atom)
-                try {
-                    propagateUpdatedAtoms([atom], store)
-                } catch (e) {
-                    if (!firstError) firstError = e
-                }
-            }
-        } finally {
-            previousOnReset?.()
-        }
-        if (atom.maxAge) {
-            for (const store of snapshot) {
-                const subs = store.subscriptions.get(atom)
-                if (subs && subs.size > 0) {
-                    // Re-add the store so the timer's setAndPropagate can
-                    // reach subscribers whose callbacks don't sync re-read
-                    // (and therefore never re-ran onInit to rejoin `stores`).
-                    stores.add(store)
-                    installMaxAgeTimer(atom, store)
-                }
+
+        for (const store of snapshot) {
+            stores.delete(store)
+            store.values.delete(atom)
+            try {
+                propagateUpdatedAtoms([atom], store)
+            } catch (e) {
+                recordError(e)
             }
         }
+
+        for (const s of subscribedStores) {
+            stores.add(s)
+            if (atom.maxAge) installMaxAgeTimer(atom, s)
+            try {
+                mountAtom(atom, s)
+            } catch (e) {
+                recordError(e)
+            }
+        }
+
         if (firstError) throw firstError
     }
 
@@ -99,9 +136,9 @@ export const globalAtom = <Value = unknown>(
         equal,
         ...options,
         defaultValue,
-        name: options?.name,
         onInit,
         onSet,
+        onMount,
         setSelf,
         getSelf,
         resetSelf,

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -29,6 +29,11 @@ export const getAtomInitValue = <V = any>(
         if (isPromiseLike(value)) {
             value.then(
                 resolvedValue => {
+                    // Stale-promise guard: if a newer evaluation (e.g.
+                    // from lazy maxAge revalidation or resetSelf+re-init)
+                    // replaced our promise as the cached value, swallow
+                    // this resolution. Mirrors setAtom.handlePromise.
+                    if (data.values.get(atom) !== value) return
                     // @ts-ignore @ts-todo
                     setValueInData(atom, resolvedValue, data)
                     propagateUpdatedAtoms([atom], data)

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -27,17 +27,23 @@ export const setValueInData = <Value extends unknown>(
     // Family tracking is handled separately in initFamilyIndex.
     const isNewAtomInScope =
         "parent" in data && Object.hasOwn(atom, "defaultValue") && !data.values.has(atom)
+    let written: Value
     if (atom.mutable || isProd()) {
         data.values.set(atom, value)
-        if (isNewAtomInScope) trackScopeValue(atom, data as ScopedStoreData)
-        return value
+        written = value
     } else {
         // Skip deepFreeze for primitives — they are immutable by nature
         const frozenValue = value !== null && (typeof value === "object" || typeof value === "function")
             ? deepFreeze(value)
             : value
         data.values.set(atom, frozenValue)
-        if (isNewAtomInScope) trackScopeValue(atom, data as ScopedStoreData)
-        return frozenValue
+        written = frozenValue
     }
+    if (isNewAtomInScope) trackScopeValue(atom, data as ScopedStoreData)
+    // Record the write timestamp for atoms with maxAge so unmounted reads
+    // can lazily revalidate once the freshness window has elapsed.
+    if ((atom as Atom<Value>).maxAge !== undefined) {
+        data.lastValueWriteAt.set(atom, Date.now())
+    }
+    return written
 }

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -8,7 +8,9 @@ import type { ScopedStore, ScopeFn, Store } from "../types/Store"
 import type { ScopedStoreData, StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
 import { isAtom } from "../utils/isAtom"
+import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isSelector } from "../utils/isSelector"
+import { resolveReactive } from "../utils/resolveReactive"
 import { createStoreData } from "./createStoreData"
 import { deleteFamilyAtom } from "./deleteFamilyAtom"
 import { getState } from "./getState"
@@ -25,6 +27,31 @@ Only \`atom\` cam be set.
 const InvalidStateSetError = `Invalid state object passed to set().
 Only \`atom\` can be set.
 `
+
+/**
+ * Lazy maxAge revalidation guard. The maxAge timer (installMaxAgeTimer)
+ * is the source of truth for freshness while an atom has subscribers —
+ * during that time we leave the cache alone (otherwise we'd undo the
+ * stale-while-revalidate window that the timer relies on). When there's
+ * no active timer, we drop a cached value past its freshness window so
+ * the next read re-evaluates the default.
+ */
+const isCachedValueStale = (state: State, data: StoreData): boolean => {
+    const atom = state as Atom
+    const maxAge = atom.maxAge
+    if (maxAge === undefined) return false
+    if (isGlobalAtom(atom)) {
+        if (atom.maxAgeInterval !== undefined) return false
+    } else {
+        const subs = data.subscriptions.get(state)
+        if (subs && subs.size > 0) return false
+    }
+    const lastWrite = data.lastValueWriteAt.get(state)
+    if (lastWrite === undefined) return false
+    const ttl =
+        typeof maxAge === "number" ? maxAge : resolveReactive(maxAge, data)
+    return Date.now() - lastWrite > ttl
+}
 
 export function storeFromStoreData(
     data: ScopedStoreData,
@@ -72,7 +99,13 @@ export function storeFromStoreData(
 
     // --- get ---
     const getDefault: GetValue = (state: State) => {
-        if (data.values.has(state)) return data.values.get(state)
+        if (data.values.has(state)) {
+            if (!isCachedValueStale(state, data)) {
+                return data.values.get(state)
+            }
+            data.values.delete(state)
+            data.lastValueWriteAt.delete(state)
+        }
         let res
         try {
             res = getState(state, data, _initSet)

--- a/packages/valdres/src/types/Atom.ts
+++ b/packages/valdres/src/types/Atom.ts
@@ -1,5 +1,6 @@
 import type { AtomDefaultValue } from "./AtomDefaultValue"
 import type { AtomOnInit } from "./AtomOnInit"
+import type { AtomOnMount } from "./AtomOnMount"
 import type { AtomOnSet } from "./AtomOnSet"
 import type { EqualFunc } from "./EqualFunc"
 import type { Reactive } from "./Reactive"
@@ -17,9 +18,10 @@ export type Atom<Value = unknown> = {
     equal: EqualFunc<Value>
     defaultValue?: AtomDefaultValue<Value>
     name?: string
+    /** Internal cross-store sync hook for global atoms. Not user-facing. */
     onInit?: AtomOnInit<Value>
     onSet?: AtomOnSet<Value>
-    onMount?: () => void | (() => void)
+    onMount?: AtomOnMount
     maxAge?: Reactive<number>
     mutable?: boolean
     staleWhileRevalidate?: Reactive<number>

--- a/packages/valdres/src/types/AtomOnInit.ts
+++ b/packages/valdres/src/types/AtomOnInit.ts
@@ -1,5 +1,12 @@
 import type { StoreData } from "./StoreData"
 
+/**
+ * Internal cross-store sync hook for global atoms. Invoked by `initAtom`
+ * the first time a given store touches the atom, so the global atom can
+ * push the canonical value into the store and add the store to its
+ * cross-store sync set. Not user-facing — there is no `onInit` in
+ * `AtomOptions` anymore; the user-facing lifecycle is `onMount`.
+ */
 export type AtomOnInit<Value = unknown> = (
     setSelf: (value: Value) => void,
     store: StoreData,

--- a/packages/valdres/src/types/AtomOnMount.ts
+++ b/packages/valdres/src/types/AtomOnMount.ts
@@ -1,0 +1,15 @@
+/**
+ * Mount hook signature.
+ *
+ * Fires when the FIRST subscriber attaches to the atom (or, for global atoms,
+ * when the FIRST subscriber across any store attaches). Receives the store
+ * the mount happened in and the atom/selector itself, mirroring jotai's
+ * `onMount`. Optionally returns a cleanup that runs when the LAST subscriber
+ * detaches.
+ *
+ * The args are typed loosely (`any`) to avoid a circular type import between
+ * `Atom`/`Selector` and `Store`. In practice the `mountAtom` runtime always
+ * passes a fully-typed `Store` and `Atom`/`Selector` reference.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: see jsdoc above
+export type AtomOnMount = (store?: any, state?: any) => void | (() => void)

--- a/packages/valdres/src/types/AtomOptions.ts
+++ b/packages/valdres/src/types/AtomOptions.ts
@@ -1,17 +1,13 @@
+import type { AtomOnMount } from "./AtomOnMount"
 import type { AtomOnSet } from "./AtomOnSet"
 import type { EqualFunc } from "./EqualFunc"
 import type { Reactive } from "./Reactive"
-import type { StoreData } from "./StoreData"
 
 export type AtomOptions<Value = unknown> = {
     global?: boolean
     name?: string
-    onInit?: (
-        setSelf: (value: Value) => void,
-        store: StoreData,
-    ) => (() => void) | void
     onSet?: AtomOnSet<Value>
-    onMount?: () => () => void
+    onMount?: AtomOnMount
     maxAge?: Reactive<number>
     mutable?: boolean
     staleWhileRevalidate?: Reactive<number>

--- a/packages/valdres/src/types/Selector.ts
+++ b/packages/valdres/src/types/Selector.ts
@@ -1,3 +1,4 @@
+import type { AtomOnMount } from "./AtomOnMount"
 import type { EqualFunc } from "./EqualFunc"
 import type { GetValue } from "./GetValue"
 import type { SelectorFamily } from "./SelectorFamily"
@@ -16,5 +17,5 @@ export type Selector<
     name?: string
     family?: SelectorFamily<Value, FamilyArgs>
     familyArgs?: FamilyArgs
-    onMount?: () => void | (() => void)
+    onMount?: AtomOnMount
 }

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -10,6 +10,10 @@ export type RootStoreData = {
     stateDependencies: WeakMap<WeakKey, any>
     mounts: WeakMap<WeakKey, { cleanup?: () => void }>
     abortControllers: WeakMap<WeakKey, AbortController | false>
+    /** Per-atom timestamp of the last value write, used for lazy
+     *  maxAge revalidation when the atom is unmounted (no active timer
+     *  to keep the cache fresh). Only populated for atoms with `maxAge`. */
+    lastValueWriteAt: WeakMap<WeakKey, number>
     storeRef?: Store
     scopes: Map<string, ScopedStoreData>
     batchUpdates?: boolean


### PR DESCRIPTION
## Summary
- Removes user-facing `options.onInit`. Atom lifecycle is now `options.onMount` for both global and non-global atoms — fires on first subscriber, cleanup on last unsub, re-mountable.
- Global atoms get a cross-store ref-counting wrapper around `onMount`: user hook fires once globally on the first subscriber across any store, cleanup fires when the last subscriber across all stores detaches.
- `resetSelf` now cycles the mount lifecycle (cleanup + remount on stores that still have subs) rather than cleanup-then-lazy-reinit-on-next-read.
- 12 packages migrated from \`onInit:\` → \`onMount:\` (\`browser-*\`, \`color-mode\`, \`public-ip\`).
- **Lazy \`maxAge\` revalidation** — \`store.get\` now re-evaluates the default for atoms past their freshness window when no timer is keeping the cache live. Closes the gap where an unmounted atom's cached value sat indefinitely.

## Why
The previous \`onInit\` semantics (fire on any first read or write) had a re-entrancy bug when user code held a direct reference to the subscribe function and invoked it manually: the framework would also call it via the wrapper, double-firing user setup. Idempotent listeners (e.g. \`addEventListener\` with the same reference) masked the bug; per-call handlers (DPR media query, navigator.permissions) leaked listener pairs.

Switching to Jotai-style \`onMount\` removes the ambiguity entirely — reads no longer trigger setup, so there's no path where the framework re-fires a hook the user already called.

## Behavior changes worth flagging
- **\`store.get(atom)\` no longer wires up listeners.** Subscribe to get reactivity. Affected \`browser-*\` tests are updated.
- **\`resetSelf\` is a full restart** (cleanup + remount) rather than cleanup-then-lazy-reinit.
- **\`maxAge\` revalidates lazily on read when unmounted.** While subscribed, the existing interval timer (with \`staleWhileRevalidate\`) is the source of truth — lazy revalidation is suppressed so SWR semantics stay intact. Without subscribers, reading past \`maxAge\` re-runs \`defaultValue\`.
- **Removed**: \`AtomOptions.onInit\`. Internal \`Atom.onInit\` field stays as a framework-only cross-store sync hook for global atoms.

## Smaller fixes bundled
- \`resetSelf\` aggregates errors from per-store unmount/mount/propagate rather than aborting on first throw.
- \`resetSelf\` uses \`isTransitivelySubscribed\` instead of direct subscriber count, so selector subscribers see the atom remount correctly.
- \`mountCount\` rolls back if \`userOnMount\` throws (mountAtom's per-store cleanup wasn't enough — global ref count would otherwise stay elevated and skip future user hooks).
- \`mountCount\` has an underflow guard against double-cleanup.
- \`onMount\` wrapper forwards \`(store, state)\` args from \`mountAtom\` to the user hook (matches non-global signature).
- \`Atom.onMount\` / \`Selector.onMount\` / \`AtomOptions.onMount\` typed with a shared \`AtomOnMount\` type whose signature matches the runtime call.
- Renamed \`public-ip\`'s \`publicIpOnInit\` to \`subscribe\` for consistency with other \`browser-*\` packages.

## Performance
Benchmarks vs. \`main\` (jotai-relative ratio shown):

| Bench | Before | After | Delta |
|---|---:|---:|---|
| \`valdres get\` | 4ns | 7ns | +3ns (maxAge undefined-check on every read) |
| \`valdres set\` | 95ns | 84ns | within noise |
| \`get 1000 atoms\` | 3.6µs (50.3x) | 3.6µs (49.0x) | unchanged |
| \`set 1000 atoms\` | 47.8µs (10.2x) | 49.5µs (8.2x) | +1.7µs |
| \`selector(fn)\` | 10ns (5.2x) | 6ns (6.0x) | within noise |
| \`set + read 100 selectors\` | 37.2µs (3.0x) | 34.9µs (2.9x) | within noise |
| \`txn cross-atom 1000\` | 432.7µs (4.4x) | 417.1µs (3.7x) | within noise |

The +3ns on \`valdres get\` is the staleness-check overhead (one undefined check + early return for atoms without maxAge). Negligible at micro scale, invisible at macro scale.

## Test plan
- [x] valdres core: 285 pass / 0 fail
- [x] All 11 \`@valdres/*\` packages green
- [x] All 5 framework adapters (react/solid/svelte/vue/angular) green
- [x] \`@valdres-react/jotai\` + \`@valdres-react/recoil\` compat layers green
- [x] New tests cover: cross-store mount counter, cleanup on last unsub, re-mount after full unmount, resetSelf cycles mount lifecycle, resetSelf without subs is a no-op for mount, cleanup-throws error aggregation, transitive selector subscribers see remount, \`userOnMount\` throw rollback, \`(store, state)\` args passthrough, lazy maxAge revalidation past window, fresh cache returned within window.
- [ ] \`@valdres-react/hotkeys\` has 1 pre-existing fail unrelated to this PR (verified by stashing changes — fail reproduces on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)