### PR TITLE
Stabilize benchmarks with paired per-batch measurement

### DIFF
--- a/packages/valdres/test/performance/bench-utils.ts
+++ b/packages/valdres/test/performance/bench-utils.ts
@@ -4,6 +4,14 @@ import { appendFileSync } from "fs"
 import { join } from "path"
 import { fileURLToPath } from "url"
 
+// Nanosecond clock. Bun exposes a native ns counter; everything else
+// falls back to performance.now() scaled to ns. Same strategy mitata
+// uses internally (its `now` isn't re-exported from the main entry).
+const now: () => number =
+    typeof Bun !== "undefined" && typeof Bun.nanoseconds === "function"
+        ? Bun.nanoseconds
+        : () => Math.ceil(1e6 * performance.now())
+
 const RUNTIME = typeof Bun !== "undefined" ? "bun" : "node"
 const __dir = typeof Bun !== "undefined"
     ? import.meta.dir
@@ -11,13 +19,33 @@ const __dir = typeof Bun !== "undefined"
 const RESULTS_FILE = RUNTIME === "bun" ? "bench-results.ndjson" : "bench-results-node.ndjson"
 const RESULTS_PATH = join(__dir, RESULTS_FILE)
 
-// Increase min samples and CPU time for more stable results.
-// Defaults: min_samples=2, min_cpu_time=642ms, warmup_samples=2
-const MEASURE_OPTS = {
-    min_samples: 20,
-    min_cpu_time: 1_500 * 1e6, // 1.5s in nanoseconds
-    warmup_samples: 5,
+// ── Paired per-batch measurement ─────────────────────────────────────────
+// The original back-to-back model ran each side for 1.5s in a fixed order.
+// A single noisy CPU window during one side's run could shift its median 2×
+// while the other side ran clean, blowing the ratio up even when neither
+// implementation changed.
+//
+// This pairs at the per-batch level — alternating ~30µs batches of valdres
+// and competitor — so any CPU stall hits both numerator and denominator in
+// the same ~60µs window and cancels out of the ratio. The pairing is so
+// tight statistically that the wall-clock budget per assertion drops from
+// ~3s to ~100ms while ratio stability *improves*.
+const PROBE_OPTS = {
+    min_samples: 4,
+    min_cpu_time: 20 * 1e6, // 20ms probe per side — enough to nail down per-op time
+    warmup_samples: 2,
 }
+// Sample count is sized by total wall-clock budget rather than a fixed N —
+// fast benchmarks get many samples (cheap to gather), slow ones get fewer
+// (each pair already represents a lot of work). 50 is the floor for a
+// statistically meaningful median ratio.
+const TARGET_MEASUREMENT_NS = 50 * 1e6 // ~50ms measurement per assertion
+const MIN_PAIRED_SAMPLES = 50
+const MAX_PAIRED_SAMPLES = 2000
+const TARGET_SLOW_BATCH_NS = 30_000 // slow side ≈ 30µs per batch
+const TARGET_FAST_BATCH_NS = 5_000 // faster side ≥ 5µs — well above timer noise
+const MAX_BATCH_SIZE = 100_000
+const WARMUP_ITERS = 200
 
 // ── IQR-based outlier removal ─────────────────────────────────────────────
 // Mitata only trims 1 sample from each end. For sub-microsecond benchmarks
@@ -78,36 +106,109 @@ export async function assertFaster(
     competitorFn: () => void,
     maxSlowerRatio: number = 1.0,
 ) {
-    // Deterministic but varied measurement order to eliminate systematic bias
-    // Derive from benchmark name so results are reproducible across runs
-    const hash = name.split("").reduce((h, c) => ((h << 5) - h + c.charCodeAt(0)) | 0, 0)
-    const runValdresFirst = hash % 2 === 0
-    const [firstStats, secondStats] = runValdresFirst
-        ? [await measure(valdresFn, MEASURE_OPTS), await measure(competitorFn, MEASURE_OPTS)]
-        : [await measure(competitorFn, MEASURE_OPTS), await measure(valdresFn, MEASURE_OPTS)]
-    const valdresStats = runValdresFirst ? firstStats : secondStats
-    const competitorStats = runValdresFirst ? secondStats : firstStats
+    // Probe — short mitata measurement on each side to estimate per-op time.
+    // The probe pays its own warmup cost so the main loop can use static
+    // batches without the JIT swallowing a tier-up mid-measurement.
+    const vProbe = await measure(valdresFn, PROBE_OPTS)
+    const cProbe = await measure(competitorFn, PROBE_OPTS)
+    const vNs = vProbe.p50
+    const cNs = cProbe.p50
 
-    // IQR-filter raw samples, then take median — much more resistant to
-    // GC pauses and CPU throttling than mitata's built-in p50
-    const valdres = iqrTrimmed(valdresStats.samples)
-    const competitor = iqrTrimmed(competitorStats.samples)
+    // Batch sized so the slow side reaches ~30µs (well above timer
+    // resolution) and the fast side stays at ≥5µs. One shared batch
+    // size keeps the pairing tight and the loop branch-free.
+    const slowNs = Math.max(vNs, cNs)
+    const fastNs = Math.min(vNs, cNs)
+    const batchSize = Math.max(
+        1,
+        Math.min(
+            MAX_BATCH_SIZE,
+            Math.ceil(
+                Math.max(
+                    TARGET_SLOW_BATCH_NS / slowNs,
+                    TARGET_FAST_BATCH_NS / fastNs,
+                ),
+            ),
+        ),
+    )
 
-    const ratio = valdres.median / competitor.median
-    const speedup = competitor.median / valdres.median
+    // Adaptive sample count — divide the wall-clock budget by what one
+    // pair actually costs. Fast benchmarks get thousands of pairs; slow
+    // ones get the floor (50).
+    const pairDurationNs = batchSize * (vNs + cNs)
+    const pairedSamples = Math.max(
+        MIN_PAIRED_SAMPLES,
+        Math.min(
+            MAX_PAIRED_SAMPLES,
+            Math.floor(TARGET_MEASUREMENT_NS / pairDurationNs),
+        ),
+    )
+
+    // Shared warmup — runs both functions interleaved so the JIT sees the
+    // exact call pattern the measurement loop will use. Warmup iterations
+    // scale with op cost so we don't waste seconds on slow benches.
+    const warmupIters = Math.min(WARMUP_ITERS, Math.max(5, pairedSamples >> 2))
+    for (let i = 0; i < warmupIters; i++) {
+        valdresFn()
+        competitorFn()
+    }
+
+    // Paired per-batch measurement. Each iteration:
+    //   1. time a batch of valdresFn
+    //   2. time a batch of competitorFn (immediately, same noise window)
+    // Alternating which side runs first per pair removes any
+    // "first-runner pays the cache miss" bias.
+    const valdresSamples = new Array<number>(pairedSamples)
+    const competitorSamples = new Array<number>(pairedSamples)
+
+    for (let i = 0; i < pairedSamples; i++) {
+        if ((i & 1) === 0) {
+            const t0 = now()
+            for (let j = 0; j < batchSize; j++) valdresFn()
+            const t1 = now()
+            for (let j = 0; j < batchSize; j++) competitorFn()
+            const t2 = now()
+            valdresSamples[i] = (t1 - t0) / batchSize
+            competitorSamples[i] = (t2 - t1) / batchSize
+        } else {
+            const t0 = now()
+            for (let j = 0; j < batchSize; j++) competitorFn()
+            const t1 = now()
+            for (let j = 0; j < batchSize; j++) valdresFn()
+            const t2 = now()
+            competitorSamples[i] = (t1 - t0) / batchSize
+            valdresSamples[i] = (t2 - t1) / batchSize
+        }
+    }
+
+    // Per-pair ratios — this is the authoritative measurement. Each ratio
+    // shares its own ~60µs noise window, so CPU stalls cancel.
+    const pairRatios = new Array<number>(pairedSamples)
+    for (let i = 0; i < pairedSamples; i++) {
+        pairRatios[i] = valdresSamples[i] / competitorSamples[i]
+    }
+    pairRatios.sort((a, b) => a - b)
+    const ratio = pairRatios[Math.floor(pairedSamples / 2)]
+    const speedup = 1 / ratio
+
+    // Per-side trimmed medians for the BENCHMARKS.md table / NDJSON output.
+    const valdres = iqrTrimmed(valdresSamples)
+    const competitor = iqrTrimmed(competitorSamples)
 
     const tag =
         ratio <= 1.0
             ? `${speedup.toFixed(1)}x faster`
             : `${ratio.toFixed(1)}x slower`
 
-    const trimInfo =
-        valdres.kept < valdres.total || competitor.kept < competitor.total
-            ? ` [trimmed ${valdres.total - valdres.kept}+${competitor.total - competitor.kept} outliers]`
-            : ""
+    // p10/p90 of paired ratios — narrow band means the methodology
+    // converged. Wide band means the run was noisy and the median
+    // absorbed it; the assertion is still meaningful.
+    const p10 = pairRatios[Math.floor(pairedSamples * 0.1)]
+    const p90 = pairRatios[Math.floor(pairedSamples * 0.9)]
+    const spreadInfo = ` [pair p10–p90 ${p10.toFixed(2)}–${p90.toFixed(2)}, n=${pairedSamples}, batch=${batchSize}]`
 
     console.log(
-        `  ${name}: valdres=${fmtNs(valdres.median)} jotai=${fmtNs(competitor.median)} (${tag})${trimInfo}`,
+        `  ${name}: valdres=${fmtNs(valdres.median)} jotai=${fmtNs(competitor.median)} (${tag})${spreadInfo}`,
     )
 
     const result = {
@@ -118,6 +219,9 @@ export async function assertFaster(
         tag,
         threshold: maxSlowerRatio,
         cv: Math.max(valdres.cv, competitor.cv),
+        pairRatioP10: p10,
+        pairRatioP90: p90,
+        batchSize,
     }
 
     appendFileSync(RESULTS_PATH, JSON.stringify(result) + "\n")
@@ -125,8 +229,17 @@ export async function assertFaster(
     expect(ratio).toBeLessThanOrEqual(maxSlowerRatio)
 }
 
+// Baseline reference measurements (obj.value, map.get, etc.) — no assertion,
+// just a single-side number for the BENCHMARKS.md table. Pair-based timing
+// isn't useful here, so we lean on mitata with a modest budget.
+const MEASURE_ONE_OPTS = {
+    min_samples: 10,
+    min_cpu_time: 200 * 1e6,
+    warmup_samples: 2,
+}
+
 export async function measureOne(name: string, fn: () => void) {
-    const stats = await measure(fn, MEASURE_OPTS)
+    const stats = await measure(fn, MEASURE_ONE_OPTS)
     const trimmed = iqrTrimmed(stats.samples)
 
     const trimInfo =


### PR DESCRIPTION
## Summary

Fixes the flaky `atomFamily(id) cache hit` benchmark (last seen on #119 at 5.1× vs 5.0× threshold) and slashes total bench-job time by ~3×.

**Root cause.** Each side was measured back-to-back for 1.5s in a fixed order. A noisy CPU window during one side's run shifted its median 2× while the other ran clean, blowing the ratio up. IQR trimming only handles transient outliers; sustained 1.5s pressure stays in the distribution. The threshold of 5.0 had only ~0.9× of headroom over the Node baseline of 4.1×.

**Fix.** Paired per-batch measurement: alternating ~30µs batches of valdres and competitor share the same ~60µs noise window, so CPU stalls hit numerator and denominator together and cancel out of the ratio. Sample count is sized by a 50ms wall-clock budget — fast benchmarks get 1000+ pairs, slow ones get the 50-sample floor.

Local validation: 13 consecutive runs of the previously-flaky benchmark, worst case 3.6×, almost all 2.6×. Pair `p10–p90` band is logged each run so future flakes are diagnosable.

## Trade-offs to know about

**Marketing numbers will shift on merge.** The new methodology removes noise that was biasing toward valdres on several benchmarks. Biggest shift locally: `store.get(atom)` 99.6× → 25.0×; `set + read 5 chained selectors` 8.0× → 2.2×. Mid-range wins (atom lifecycle, txn, set with subs) barely move. The cache-hit ratio at the centre of this PR is unchanged (~2.6×). New numbers are more reproducible run-to-run — anyone trying to verify the old headlines would currently fail.

**Recommend purging baseline history.** `check-bench-regression.ts` builds per-benchmark dynamic thresholds from historical CV. Old high-variance entries will keep the tolerances loose for a while. Trigger the workflow's `reset_baseline` input post-merge to start fresh.

**CI speed.** ~20s of measurement (was ~66s on main).

## Test plan

- [ ] CI bench job passes on the previously-flaky `atomFamily(id) cache hit`
- [ ] Full Bun bench suite passes
- [ ] Node bench suite passes (informational only, not gating)
- [ ] Inspect new BENCHMARKS.md / README numbers before announcing externally
- [ ] After merge, trigger `Benchmark` workflow with `reset_baseline=true` to purge stale CV history

🤖 Generated with [Claude Code](https://claude.com/claude-code)