### PR TITLE
Fix benchmark README push from detached HEAD

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -147,4 +147,4 @@ jobs:
                   bun run scripts/update-bench-readme.ts
                   git add README.md BENCHMARKS.md
                   git diff --staged --quiet || git commit -m "Update benchmark results in README"
-                  git push
+                  git push origin HEAD:main


### PR DESCRIPTION
## Summary

The `Update README with benchmark table` step in the benchmark workflow fails with `fatal: You are not currently on a branch` when triggered via `workflow_dispatch`. Cause: `actions/checkout@v6` (upgraded in #110) leaves HEAD detached, and bare `git push` has no branch to push to.

One-line fix — push `HEAD:main` explicitly so it works regardless of how the workflow was triggered.

## Test plan

- [ ] Trigger the benchmark workflow manually via the Actions UI and confirm the README update commit lands on main