### PR TITLE
Enforce changesets on PRs touching publishable code

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,8 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
@@ -25,6 +27,9 @@ jobs:
               run: bun run build:types
             - name: Verify publish (dry-run)
               run: DRY_RUN=1 bash scripts/ci-publish.sh
+            - name: Require changeset
+              if: github.event_name == 'pull_request'
+              run: bunx changeset status --since=origin/main
             - name: Test
               id: test
               run: bun run test:ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,21 +15,21 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  fetch-depth: 0
+                  fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
             - name: Install
               run: bun install
+            - name: Require changeset
+              if: github.event_name == 'pull_request'
+              run: bunx changeset status --since=origin/main
             - name: Build
               run: bun run build
             - name: Build types
               run: bun run build:types
             - name: Verify publish (dry-run)
               run: DRY_RUN=1 bash scripts/ci-publish.sh
-            - name: Require changeset
-              if: github.event_name == 'pull_request'
-              run: bunx changeset status --since=origin/main
             - name: Test
               id: test
               run: bun run test:ci

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Each `@valdres/browser-*` package wraps one browser API as global atoms. Canonic
 
 ## Releasing
 
-Changesets. Any PR touching a publishable package needs `bunx changeset` committed alongside it. Don't hand-edit `version` fields or CHANGELOGs — the Version Packages bot does that on merge. Repo is in `beta` prerelease mode.
+Changesets. Any PR touching a publishable package needs `bunx changeset` committed alongside it — CI enforces this via `bunx changeset status --since=origin/main`. For PRs that change publishable code but intentionally don't release (refactors, internal cleanup), run `bunx changeset --empty` to satisfy the check. Don't hand-edit `version` fields or CHANGELOGs — the Version Packages bot does that on merge. Repo is in `beta` prerelease mode.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For PRs that touch publishable code but intentionally don't trigger a release (r
 bunx changeset --empty
 ```
 
-The `Require changeset` check on each PR enforces that any change to a publishable package ships with a changeset (empty or otherwise).
+This still generates a `.changeset/*.md` file — commit it like a regular changeset. The `Require changeset` check on each PR enforces that any change to a publishable package ships with a changeset (empty or otherwise).
 
 When the PR merges to `main`, the `Publish` workflow opens (or updates) a **Version Packages** PR that applies the pending changesets, bumps versions, and updates CHANGELOGs. Merging that PR publishes the affected packages to npm.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ bunx changeset
 
 Pick the affected packages, the bump type (patch/minor/major), and write a short summary. Commit the generated `.changeset/*.md` file with your PR.
 
+For PRs that touch publishable code but intentionally don't trigger a release (refactors, internal cleanup, docs):
+
+```bash
+bunx changeset --empty
+```
+
+The `Require changeset` check on each PR enforces that any change to a publishable package ships with a changeset (empty or otherwise).
+
 When the PR merges to `main`, the `Publish` workflow opens (or updates) a **Version Packages** PR that applies the pending changesets, bumps versions, and updates CHANGELOGs. Merging that PR publishes the affected packages to npm.
 
 To preview what publishing would do locally:


### PR DESCRIPTION
## Summary

Adds a required CI step that fails PRs which change a publishable package without an accompanying changeset.

- `bunx changeset status --since=origin/main` exits non-zero when publishable code changed but no `.changeset/*.md` was added.
- For intentional no-release PRs (refactors, internal cleanup, docs), `bunx changeset --empty` satisfies the check.
- Bumps `actions/checkout` to `fetch-depth: 0` so the `--since` diff has full history.
- README updated to describe the contributor workflow.

After merge, mark the `test` check as **Required** in branch protection for `main`.

## Test plan

- [x] `bunx changeset status --since=origin/main` exits 0 on this PR (no publishable changes)
- [x] Verified locally that touching a publishable file without a changeset makes the command exit non-zero
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)