### PR TITLE
Fix workspace:^ leaking into published beta manifests

### DIFF
--- a/.changeset/fix-workspace-protocol-publish.md
+++ b/.changeset/fix-workspace-protocol-publish.md
@@ -22,14 +22,14 @@
 "@valdres/browser-screen-details": patch
 "@valdres/browser-visibility": patch
 "@valdres/browser-window": patch
-"@valdres/color-mode": patch
-"@valdres/hotkeys": patch
+"@valdres/color-mode": minor
+"@valdres/hotkeys": minor
 "@valdres/public-ip": patch
-"@valdres-react/color-mode": patch
-"@valdres-react/draggable": patch
-"@valdres-react/hotkeys": patch
+"@valdres-react/color-mode": minor
+"@valdres-react/draggable": minor
+"@valdres-react/hotkeys": minor
 "@valdres-react/jotai": patch
-"@valdres-react/panable": patch
+"@valdres-react/panable": minor
 "@valdres-react/recoil": patch
 ---
 
@@ -41,3 +41,9 @@ which doesn't understand the workspace protocol — so the bare shortcut got
 published verbatim. Publishable packages now use plain semver ranges for
 inter-package deps; changesets keeps them in lockstep on every bump, and
 `verify-publish` fails CI if any `workspace:` reference sneaks back in.
+
+The six Lerna-era packages still on the `pre` dist-tag (`@valdres/color-mode`,
+`@valdres/hotkeys`, `@valdres-react/color-mode`, `@valdres-react/draggable`,
+`@valdres-react/hotkeys`, `@valdres-react/panable`) get a `minor` bump so
+they land on `0.3.0-beta.0` — a clean transition from the old `0.2.0-pre.28`
+line to the unified `beta` dist-tag.

--- a/.changeset/fix-workspace-protocol-publish.md
+++ b/.changeset/fix-workspace-protocol-publish.md
@@ -1,0 +1,43 @@
+---
+"valdres": patch
+"valdres-react": patch
+"valdres-angular": patch
+"valdres-solid": patch
+"valdres-svelte": patch
+"valdres-vue": patch
+"@valdres/bandwidth": patch
+"@valdres/browser-color-scheme": patch
+"@valdres/browser-contrast": patch
+"@valdres/browser-device-motion": patch
+"@valdres/browser-device-orientation": patch
+"@valdres/browser-focus": patch
+"@valdres/browser-geolocation": patch
+"@valdres/browser-keyboard": patch
+"@valdres/browser-online": patch
+"@valdres/browser-presence": patch
+"@valdres/browser-reduced-data": patch
+"@valdres/browser-reduced-motion": patch
+"@valdres/browser-reduced-transparency": patch
+"@valdres/browser-screen": patch
+"@valdres/browser-screen-details": patch
+"@valdres/browser-visibility": patch
+"@valdres/browser-window": patch
+"@valdres/color-mode": patch
+"@valdres/hotkeys": patch
+"@valdres/public-ip": patch
+"@valdres-react/color-mode": patch
+"@valdres-react/draggable": patch
+"@valdres-react/hotkeys": patch
+"@valdres-react/jotai": patch
+"@valdres-react/panable": patch
+"@valdres-react/recoil": patch
+---
+
+Fix `workspace:^` leaking into published manifests. The previous beta releases
+shipped with literal `"valdres": "workspace:^"` in their `dependencies`, which
+npm cannot resolve. Changesets only rewrites pinned workspace specs (e.g.
+`workspace:^1.2.3`), and `changeset publish` shells out to `npm publish` —
+which doesn't understand the workspace protocol — so the bare shortcut got
+published verbatim. Publishable packages now use plain semver ranges for
+inter-package deps; changesets keeps them in lockstep on every bump, and
+`verify-publish` fails CI if any `workspace:` reference sneaks back in.

--- a/bun.lock
+++ b/bun.lock
@@ -19,14 +19,14 @@
       "name": "@valdres-react/color-mode",
       "version": "0.2.0-pre.28",
       "dependencies": {
-        "@valdres/color-mode": "workspace:^",
+        "@valdres/color-mode": "^0.2.0-pre.28",
       },
       "devDependencies": {
         "typescript": "5.9.2",
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres-react": "workspace:^",
+        "valdres-react": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres-react/draggable": {
@@ -37,14 +37,14 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres-react": "workspace:^",
+        "valdres-react": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres-react/hotkeys": {
       "name": "@valdres-react/hotkeys",
       "version": "0.2.0-pre.28",
       "dependencies": {
-        "@valdres/hotkeys": "workspace:^",
+        "@valdres/hotkeys": "^0.2.0-pre.28",
       },
       "devDependencies": {
         "@testing-library/react": "16.3.0",
@@ -55,8 +55,8 @@
       },
       "peerDependencies": {
         "react": ">=18",
-        "valdres": "workspace:^",
-        "valdres-react": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
+        "valdres-react": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres-react/jotai": {
@@ -84,8 +84,8 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "@valdres-react/draggable": "workspace:^",
-        "valdres-react": "workspace:^",
+        "@valdres-react/draggable": "^0.2.0-pre.28",
+        "valdres-react": "^1.0.0-beta.0",
       },
       "optionalPeers": [
         "@valdres-react/draggable",
@@ -115,7 +115,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-color-scheme": {
@@ -133,7 +133,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-contrast": {
@@ -151,7 +151,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-device-motion": {
@@ -173,7 +173,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-device-orientation": {
@@ -195,7 +195,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-focus": {
@@ -213,7 +213,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-geolocation": {
@@ -226,7 +226,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-keyboard": {
@@ -237,7 +237,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-online": {
@@ -250,15 +250,15 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-presence": {
       "name": "@valdres/browser-presence",
       "version": "1.0.0-beta.0",
       "dependencies": {
-        "@valdres/browser-focus": "workspace:^",
-        "@valdres/browser-visibility": "workspace:^",
+        "@valdres/browser-focus": "^1.0.0-beta.0",
+        "@valdres/browser-visibility": "^1.0.0-beta.0",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -272,7 +272,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-reduced-data": {
@@ -290,7 +290,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-reduced-motion": {
@@ -308,7 +308,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-reduced-transparency": {
@@ -326,7 +326,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-screen": {
@@ -339,7 +339,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-screen-details": {
@@ -352,7 +352,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-visibility": {
@@ -370,7 +370,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/browser-window": {
@@ -383,7 +383,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/color-mode": {
@@ -395,7 +395,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/hotkeys": {
@@ -407,8 +407,8 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "@valdres/browser-keyboard": "workspace:^",
-        "valdres": "workspace:^",
+        "@valdres/browser-keyboard": "^1.0.0-beta.0",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/@valdres/public-ip": {
@@ -426,7 +426,7 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/documentation": {
@@ -474,14 +474,14 @@
       },
       "peerDependencies": {
         "@angular/core": ">=17",
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/valdres-react": {
       "name": "valdres-react",
       "version": "1.0.0-beta.0",
       "dependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -510,7 +510,7 @@
       },
       "peerDependencies": {
         "solid-js": ">=1.8",
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/valdres-svelte": {
@@ -524,7 +524,7 @@
       },
       "peerDependencies": {
         "svelte": ">=5",
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
       },
     },
     "packages/valdres-vue": {
@@ -539,7 +539,7 @@
         "vue": "3.5.13",
       },
       "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
         "vue": ">=3.3",
       },
     },

--- a/packages/@valdres-react/color-mode/package.json
+++ b/packages/@valdres-react/color-mode/package.json
@@ -23,14 +23,14 @@
         "test": "echo 'no tests'"
     },
     "dependencies": {
-        "@valdres/color-mode": "workspace:^"
+        "@valdres/color-mode": "^0.2.0-pre.28"
     },
     "devDependencies": {
         "typescript": "5.9.2",
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres-react": "workspace:^"
+        "valdres-react": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres-react/draggable/package.json
+++ b/packages/@valdres-react/draggable/package.json
@@ -27,7 +27,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres-react": "workspace:^"
+        "valdres-react": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres-react/hotkeys/package.json
+++ b/packages/@valdres-react/hotkeys/package.json
@@ -23,7 +23,7 @@
         "test": "echo 'no tests'"
     },
     "dependencies": {
-        "@valdres/hotkeys": "workspace:^"
+        "@valdres/hotkeys": "^0.2.0-pre.28"
     },
     "devDependencies": {
         "@testing-library/react": "16.3.0",
@@ -34,8 +34,8 @@
     },
     "peerDependencies": {
         "react": ">=18",
-        "valdres": "workspace:^",
-        "valdres-react": "workspace:^"
+        "valdres": "^1.0.0-beta.0",
+        "valdres-react": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres-react/jotai/package.json
+++ b/packages/@valdres-react/jotai/package.json
@@ -23,7 +23,7 @@
         "test": "bun test --reporter=dots"
     },
     "dependencies": {
-        "valdres-react": "workspace:^"
+        "valdres-react": "^1.0.0-beta.0"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "18.0.1",

--- a/packages/@valdres-react/panable/package.json
+++ b/packages/@valdres-react/panable/package.json
@@ -27,8 +27,8 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "@valdres-react/draggable": "workspace:^",
-        "valdres-react": "workspace:^"
+        "@valdres-react/draggable": "^0.2.0-pre.28",
+        "valdres-react": "^1.0.0-beta.0"
     },
     "peerDependenciesMeta": {
         "@valdres-react/draggable": {

--- a/packages/@valdres-react/recoil/package.json
+++ b/packages/@valdres-react/recoil/package.json
@@ -23,7 +23,7 @@
         "test": "bun test --parallel"
     },
     "dependencies": {
-        "valdres-react": "workspace:^"
+        "valdres-react": "^1.0.0-beta.0"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "18.0.1",

--- a/packages/@valdres/bandwidth/package.json
+++ b/packages/@valdres/bandwidth/package.json
@@ -30,7 +30,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-color-scheme/package.json
+++ b/packages/@valdres/browser-color-scheme/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-contrast/package.json
+++ b/packages/@valdres/browser-contrast/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-device-motion/package.json
+++ b/packages/@valdres/browser-device-motion/package.json
@@ -40,7 +40,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-device-orientation/package.json
+++ b/packages/@valdres/browser-device-orientation/package.json
@@ -40,7 +40,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-focus/package.json
+++ b/packages/@valdres/browser-focus/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-geolocation/package.json
+++ b/packages/@valdres/browser-geolocation/package.json
@@ -31,7 +31,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-keyboard/package.json
+++ b/packages/@valdres/browser-keyboard/package.json
@@ -28,7 +28,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-online/package.json
+++ b/packages/@valdres/browser-online/package.json
@@ -30,7 +30,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-presence/package.json
+++ b/packages/@valdres/browser-presence/package.json
@@ -25,8 +25,8 @@
         "test:ci": "bun test"
     },
     "dependencies": {
-        "@valdres/browser-focus": "workspace:^",
-        "@valdres/browser-visibility": "workspace:^"
+        "@valdres/browser-focus": "^1.0.0-beta.0",
+        "@valdres/browser-visibility": "^1.0.0-beta.0"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -40,7 +40,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-reduced-data/package.json
+++ b/packages/@valdres/browser-reduced-data/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-reduced-motion/package.json
+++ b/packages/@valdres/browser-reduced-motion/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-reduced-transparency/package.json
+++ b/packages/@valdres/browser-reduced-transparency/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-screen-details/package.json
+++ b/packages/@valdres/browser-screen-details/package.json
@@ -31,7 +31,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-screen/package.json
+++ b/packages/@valdres/browser-screen/package.json
@@ -31,7 +31,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-visibility/package.json
+++ b/packages/@valdres/browser-visibility/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/browser-window/package.json
+++ b/packages/@valdres/browser-window/package.json
@@ -31,7 +31,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/color-mode/package.json
+++ b/packages/@valdres/color-mode/package.json
@@ -28,7 +28,7 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/hotkeys/package.json
+++ b/packages/@valdres/hotkeys/package.json
@@ -28,8 +28,8 @@
         "valdres": "workspace:^"
     },
     "peerDependencies": {
-        "@valdres/browser-keyboard": "workspace:^",
-        "valdres": "workspace:^"
+        "@valdres/browser-keyboard": "^1.0.0-beta.0",
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/@valdres/public-ip/package.json
+++ b/packages/@valdres/public-ip/package.json
@@ -36,7 +36,7 @@
         "valdres-react": "workspace:^"
     },
     "peerDependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/valdres-angular/package.json
+++ b/packages/valdres-angular/package.json
@@ -29,7 +29,7 @@
     },
     "peerDependencies": {
         "@angular/core": ">=17",
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/valdres-react/package.json
+++ b/packages/valdres-react/package.json
@@ -23,7 +23,7 @@
         "test": "bun test --reporter=dots --parallel"
     },
     "dependencies": {
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",

--- a/packages/valdres-solid/package.json
+++ b/packages/valdres-solid/package.json
@@ -28,7 +28,7 @@
         "solid-js": "1.9.5"
     },
     "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
         "solid-js": ">=1.8"
     },
     "publishConfig": {

--- a/packages/valdres-svelte/package.json
+++ b/packages/valdres-svelte/package.json
@@ -31,7 +31,7 @@
     },
     "peerDependencies": {
         "svelte": ">=5",
-        "valdres": "workspace:^"
+        "valdres": "^1.0.0-beta.0"
     },
     "publishConfig": {
         "access": "public",

--- a/packages/valdres-vue/package.json
+++ b/packages/valdres-vue/package.json
@@ -31,7 +31,7 @@
         "vue": "3.5.13"
     },
     "peerDependencies": {
-        "valdres": "workspace:^",
+        "valdres": "^1.0.0-beta.0",
         "vue": ">=3.3"
     },
     "publishConfig": {

--- a/scripts/verify-publish.ts
+++ b/scripts/verify-publish.ts
@@ -98,8 +98,10 @@ for (const pkg of PUBLIC_PACKAGES) {
 
     console.log(`\nVerifying ${pkgName}...`)
 
-    // Save original so we can restore after prepack — prepack itself is now
-    // responsible for resolving any workspace: refs to concrete versions.
+    // Save original so we can restore after prepack writes its dist-shaped
+    // package.json. Publishable packages must already use plain semver for
+    // inter-package deps — prepack only rewrites `exports` and strips
+    // scripts/devDependencies; the `workspace:` check below is the gate.
     const originalContent = await Bun.file(pkgJsonPath).text()
 
     // Run prepack

--- a/scripts/verify-publish.ts
+++ b/scripts/verify-publish.ts
@@ -4,15 +4,20 @@
  * Runs: build → build:types → prepack for each public package, then checks:
  *   1. Exports point to real files in dist/
  *   2. Types files exist for each export
- *   3. No workspace:^ references remain in dependencies (after prepack)
+ *   3. No workspace: references remain in dependencies (after prepack)
  *   4. No scripts or devDependencies in prepacked package.json
  *   5. version field is present
  *
  * Always restores original package.json via postpublish, even on failure.
  *
- * Note: In the real publish flow, `changeset version` converts workspace:^
- * to real semver ranges BEFORE prepack runs. This script simulates that by
- * temporarily rewriting workspace:^ refs to the current version.
+ * Publishable packages must not use the `workspace:` protocol in
+ * dependencies / peerDependencies / optionalDependencies — changesets doesn't
+ * rewrite the bare `workspace:^` shortcut, and `changeset publish` shells out
+ * to `npm publish` which doesn't understand the protocol, so any leftover
+ * `workspace:` would ship verbatim and break consumers. The check below is
+ * the regression gate. (devDependencies are stripped by prepack, so they're
+ * allowed to use `workspace:^` for ergonomics with non-publishable packages
+ * like @valdres/test.)
  */
 
 const PUBLIC_PACKAGES = [
@@ -64,29 +69,6 @@ function warn(pkg: string, msg: string) {
 const rootDir = import.meta.dir + "/.."
 const prepackScript = `${import.meta.dir}/prepack.ts`
 
-// Build a map of package name → version for workspace: resolution
-const packageVersions: Record<string, string> = {}
-for (const pkg of PUBLIC_PACKAGES) {
-    const json = await Bun.file(`${rootDir}/${pkg}/package.json`).json()
-    packageVersions[json.name] = json.version
-}
-
-/** Replace workspace:^ refs with real ^version ranges (simulates changeset version) */
-function resolveWorkspaceRefs(json: any) {
-    for (const depField of ["dependencies", "peerDependencies", "devDependencies"]) {
-        const deps = json[depField]
-        if (!deps) continue
-        for (const [dep, version] of Object.entries(deps)) {
-            if (typeof version === "string" && version.startsWith("workspace:")) {
-                const realVersion = packageVersions[dep]
-                if (realVersion) {
-                    deps[dep] = version === "workspace:*" ? realVersion : `^${realVersion}`
-                }
-            }
-        }
-    }
-}
-
 // Step 1: Build all packages
 console.log("Building all packages...")
 const buildResult = Bun.spawnSync(["bun", "run", "build"], {
@@ -116,11 +98,9 @@ for (const pkg of PUBLIC_PACKAGES) {
 
     console.log(`\nVerifying ${pkgName}...`)
 
-    // Save original and write workspace-resolved version
+    // Save original so we can restore after prepack — prepack itself is now
+    // responsible for resolving any workspace: refs to concrete versions.
     const originalContent = await Bun.file(pkgJsonPath).text()
-    const json = JSON.parse(originalContent)
-    resolveWorkspaceRefs(json)
-    await Bun.write(pkgJsonPath, JSON.stringify(json, null, 4))
 
     // Run prepack
     const prepackResult = Bun.spawnSync(["bun", "run", prepackScript], {
@@ -155,7 +135,7 @@ for (const pkg of PUBLIC_PACKAGES) {
         }
 
         // Check: no workspace: references in any dependency field
-        for (const depField of ["dependencies", "peerDependencies"]) {
+        for (const depField of ["dependencies", "peerDependencies", "optionalDependencies"]) {
             const deps = packageJson[depField]
             if (!deps) continue
             for (const [dep, version] of Object.entries(deps)) {


### PR DESCRIPTION
## Summary

The `1.0.0-beta.0` (and `0.1.0-beta.0`) packages on npm shipped with literal `"valdres": "workspace:^"` in their `dependencies` / `peerDependencies`, which npm can't resolve. Consumers can't install them.

**Root cause:**

1. Changesets's `apply-release-plan` deliberately skips the bare `workspace:^` / `workspace:~` / `workspace:*` shortcuts — it only rewrites pinned forms like `workspace:^1.2.3` ([`@changesets/apply-release-plan` source](https://github.com/changesets/changesets/blob/main/packages/apply-release-plan/src/index.ts), `workspaceDepVersion === "^"` early return).
2. `changeset publish` shells out to `npm publish`, and npm has no concept of the workspace protocol. So the literal `workspace:^` ends up on the registry.
3. `scripts/verify-publish.ts` was silently masking the bug: a `resolveWorkspaceRefs()` helper pre-rewrote workspace deps *before* invoking prepack, with a comment claiming `changeset version` already does this (it doesn't). CI passed; real publishes were broken.

**Fix:**

- Migrate every publishable package's `dependencies` / `peerDependencies` / `optionalDependencies` from `workspace:^` to plain semver ranges (`^<version>`). Bun still links the local workspace package during dev because its version satisfies the range, and changesets keeps the ranges in lockstep on every bump via `updateInternalDependencies: "patch"`.
- `devDependencies` keep `workspace:^` for ergonomics with non-publishable packages like `@valdres/test` — prepack strips devDeps anyway.
- Non-publishable packages (`@valdres/test`, `@valdres/documentation`) keep `workspace:^` throughout — they're never published.
- Drop the misleading simulation in `verify-publish.ts`. Its "no `workspace:` in publishable deps after prepack" assertion is now a real CI gate against regressions (also extended to cover `optionalDependencies`).
- Add a changeset that patch-bumps every publishable package so the next merge to `main` ships a wave of corrected manifests (`1.0.0-beta.1` / `0.1.0-beta.1`).

## Test plan

- [x] `bun install` — workspace symlinks intact (`node_modules/valdres -> ../packages/valdres`); plain semver doesn't break workspace linking because Bun prefers a workspace match when the version range overlaps.
- [x] `bun run verify-publish` — all 32 publishable packages pass through build → types → prepack → assertions. Real publish pipeline now runs with no simulation, and the "no `workspace:` leaks" gate passes.
- [ ] CI's existing publish dry-run gate (`Run ci-publish.sh as a dry-run gate on every PR`) confirms publish pipeline.
- [ ] After merge: confirm the resulting Version Packages PR bumps every publishable package to the next beta (`1.0.0-beta.1` / `0.1.0-beta.1`) and that `valdres-react` etc. ship with `"valdres": "^1.0.0-beta.1"` instead of `workspace:^`.

## Follow-up (not in this PR)

The broken `1.0.0-beta.0` / `0.1.0-beta.0` versions are still on npm. Consider `npm deprecate '<pkg>@1.0.0-beta.0' "broken workspace: protocol in dependencies, use 1.0.0-beta.1 or later"` once the fixed wave ships, so anyone who already pinned to the broken version gets a warning. Happy to draft the commands in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)