### PR TITLE
Move publish workflow .npmrc out of the workspace

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,8 +35,11 @@ jobs:
       - name: Verify publish pipeline
         run: bun run verify-publish
 
-      - name: Create .npmrc
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+      - name: Configure npm auth
+        # Write the token to $HOME/.npmrc, not the workspace, so it can never
+        # be swept into a commit by `git add .` (which is what changesets/action
+        # does when opening the Version Packages PR — see PR #123 fallout).
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > "$HOME/.npmrc"
 
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 dist-tarball
 todo.md
 .env.local
+.npmrc
 bench-results.ndjson
 bench-results-node.ndjson
 bench-results.json


### PR DESCRIPTION
## Summary

The publish workflow run after merging #123 [failed](https://github.com/eigilsagafos/valdres/actions/runs/26255304854/job/77276440559) because `changesets/action` (in Version Packages PR mode) does `git add . && git commit && git push`, and the workflow created `.npmrc` containing the `NPM_TOKEN` at the repo root just before that step. The `git add .` swept the token into the commit and GitHub's push protection (correctly) blocked the push — the `changeset-release/main` branch was never created on the remote, and no token leaked.

This is a pre-existing bug in the workflow shape that only surfaced now because this is the first time the action has been in "Version Packages PR" mode under changesets (every prior release ran straight through to publish without committing).

## Fix (two layers)

1. **Move `.npmrc` to `$HOME/.npmrc`** so the token never lives in the working tree. `bunx changeset publish` / `npm publish` still pick it up from the user config.
2. **Gitignore `.npmrc`** so the same shape can't recur if anyone reverts the workflow change or runs `npm login` locally.

## Test plan

- [ ] After merge, the publish workflow runs successfully and opens the Version Packages PR with the expected version bumps (`1.0.0-beta.1` / `0.1.0-beta.1` / `0.3.0-beta.0`).
- [ ] The version PR commit does **not** contain `.npmrc`.
- [ ] Once the Version Packages PR is merged, `ci-publish.sh` authenticates against npm via `$HOME/.npmrc` and publishes the corrected manifests.

## Note on token safety

No rotation needed — push protection blocked the push at the wire before any commit containing the token reached GitHub's data store, and the token is redacted from workflow logs by default. But if you want belt-and-braces, rotating `NPM_TOKEN` is cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)