### PR TITLE
Fix spurious SelectorCircularDependencyError from leaked cycle-set entry

### DIFF
--- a/.changeset/fix-selector-cycle-leak.md
+++ b/.changeset/fix-selector-cycle-leak.md
@@ -1,0 +1,10 @@
+---
+"valdres": patch
+---
+
+Fix spurious `SelectorCircularDependencyError` for selectors with no real
+cycle. `evaluateSelector` now runs its cleanup in a `finally` so the
+module-level `sharedCircularDepSet` is always cleared on exit — including
+when an inner selector throws a non-cycle error and the outer's `catch`
+re-raises a `SelectorEvaluationError`. Previously the entry leaked, and the
+next read of the outer selector tripped the cycle check on a stale entry.

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -81,135 +81,138 @@ export const evaluateSelector = <V>(
     }
     circularDependencySet.add(selector)
 
-    // Abort signal support: on first eval we allocate an AbortController and
-    // pass its signal to the selector. After eval, handleSelectorResult marks
-    // the entry as `false` for sync results, so subsequent sync evaluations
-    // skip allocation entirely (~140ns saved per eval on the hot path).
-    // For async results the controller stays, and re-evaluation aborts it.
-    const prev = data.abortControllers.get(selector)
-    let options: { signal: AbortSignal; storeId: string }
-    if (prev === false) {
-        // Known-sync selector — use cached options, no allocation
-        let cached = syncOptionsCache.get(data)
-        if (!cached) {
-            cached = { signal: neverAbortedSignal, storeId: data.id }
-            syncOptionsCache.set(data, cached)
-        }
-        options = cached
-    } else {
-        if (prev) prev.abort()
-        const abortController = new AbortController()
-        data.abortControllers.set(selector, abortController)
-        options = { signal: abortController.signal, storeId: data.id }
-    }
-
-    // Lazily populated: tracks ALL deps read during this evaluation (sync +
-    // async). Only allocated when the result turns out to be a promise.
-    let allDepsThisEval: Set<State> | undefined
-
-    let result
     try {
-        // @ts-ignore, @ts-todo
-        result = selector.get(state => {
-            // Deferred get calls (setTimeout, after await) use late binding
-            if (evaluationComplete) {
-                // Track for reconciliation (unless this is a stale closure)
-                if (!evalCtx.revoked && allDepsThisEval) {
-                    allDepsThisEval.add(state)
-                }
-                if (evalCtx.revoked) {
-                    // Stale closure — the selector has been re-evaluated since
-                    // this closure was created. Read the value without
-                    // registering deps or mounting.
-                    return getState(state, data, new Set<Atom>())
-                }
-                return lateGet(state, selector, data)
+        // Abort signal support: on first eval we allocate an AbortController and
+        // pass its signal to the selector. After eval, handleSelectorResult marks
+        // the entry as `false` for sync results, so subsequent sync evaluations
+        // skip allocation entirely (~140ns saved per eval on the hot path).
+        // For async results the controller stays, and re-evaluation aborts it.
+        const prev = data.abortControllers.get(selector)
+        let options: { signal: AbortSignal; storeId: string }
+        if (prev === false) {
+            // Known-sync selector — use cached options, no allocation
+            let cached = syncOptionsCache.get(data)
+            if (!cached) {
+                cached = { signal: neverAbortedSignal, storeId: data.id }
+                syncOptionsCache.set(data, cached)
             }
-            const value = getState(
-                state,
-                data,
-                initializedAtomsSet,
-                circularDependencySet,
-            )
-            updatedDepsArray.push(state)
-            if (!depsChanged && (!currentDependencies || !currentDependencies.has(state))) {
-                depsChanged = true
-            }
-            if (isPromiseLike(value))
-                throw new SuspendAndWaitForResolveError(value)
-
-            return value
-        }, options)
-    } catch (error) {
-        if (error instanceof NeedsInitError) {
-            // Clean up circular dependency tracking so retry works
-            circularDependencySet.delete(selector)
-            throw error
-        }
-        if (error instanceof SuspendAndWaitForResolveError) {
-            result = error
-        } else if (error instanceof SelectorEvaluationError) {
-            throw error
+            options = cached
         } else {
-            throw new SelectorEvaluationError(error)
+            if (prev) prev.abort()
+            const abortController = new AbortController()
+            data.abortControllers.set(selector, abortController)
+            options = { signal: abortController.signal, storeId: data.id }
         }
-    }
 
-    evaluationComplete = true
+        // Lazily populated: tracks ALL deps read during this evaluation (sync +
+        // async). Only allocated when the result turns out to be a promise.
+        let allDepsThisEval: Set<State> | undefined
 
-    const isAsyncResult =
-        result instanceof SuspendAndWaitForResolveError || isPromiseLike(result)
+        let result
+        try {
+            // @ts-ignore, @ts-todo
+            result = selector.get(state => {
+                // Deferred get calls (setTimeout, after await) use late binding
+                if (evaluationComplete) {
+                    // Track for reconciliation (unless this is a stale closure)
+                    if (!evalCtx.revoked && allDepsThisEval) {
+                        allDepsThisEval.add(state)
+                    }
+                    if (evalCtx.revoked) {
+                        // Stale closure — the selector has been re-evaluated since
+                        // this closure was created. Read the value without
+                        // registering deps or mounting.
+                        return getState(state, data, new Set<Atom>())
+                    }
+                    return lateGet(state, selector, data)
+                }
+                const value = getState(
+                    state,
+                    data,
+                    initializedAtomsSet,
+                    circularDependencySet,
+                )
+                updatedDepsArray.push(state)
+                if (!depsChanged && (!currentDependencies || !currentDependencies.has(state))) {
+                    depsChanged = true
+                }
+                if (isPromiseLike(value))
+                    throw new SuspendAndWaitForResolveError(value)
 
-    // For sync selectors, check if dep count changed (handles removed deps).
-    // For async selectors, skip — the dep count is incomplete until the
-    // promise resolves.
-    if (!isAsyncResult && !depsChanged && currentDependencies && currentDependencies.size !== updatedDepsArray.length) {
-        depsChanged = true
-    }
-
-    if (depsChanged || !currentDependencies) {
-        const updatedDependencies = new Set<State<any>>(updatedDepsArray)
-        // For async selectors, retain all previous deps so they aren't
-        // prematurely removed (and unmounted) before the continuation runs.
-        // Stale deps are cleaned up when the promise resolves (see
-        // the reconciliation logic in handleSelectorResult).
-        if (isAsyncResult && currentDependencies) {
-            for (const dep of currentDependencies) {
-                updatedDependencies.add(dep)
+                return value
+            }, options)
+        } catch (error) {
+            if (error instanceof NeedsInitError) throw error
+            if (error instanceof SuspendAndWaitForResolveError) {
+                result = error
+            } else if (error instanceof SelectorEvaluationError) {
+                throw error
+            } else {
+                throw new SelectorEvaluationError(error)
             }
         }
-        const prev = currentDependencies ?? new Set<State<any>>()
-        for (const state of updatedDependencies) {
-            if (!prev.has(state)) {
-                const set = getOrInitDependentsSet(state, data)
-                set.add(selector)
-                if (addedDepsOut) addedDepsOut.add(state)
-            }
+
+        evaluationComplete = true
+
+        const isAsyncResult =
+            result instanceof SuspendAndWaitForResolveError || isPromiseLike(result)
+
+        // For sync selectors, check if dep count changed (handles removed deps).
+        // For async selectors, skip — the dep count is incomplete until the
+        // promise resolves.
+        if (!isAsyncResult && !depsChanged && currentDependencies && currentDependencies.size !== updatedDepsArray.length) {
+            depsChanged = true
         }
-        if (!isAsyncResult) {
-            for (const state of prev) {
-                if (!updatedDependencies.has(state)) {
-                    const set = getOrInitDependentsSet(state, data)
-                    set.delete(selector)
-                    if (removedDepsOut) removedDepsOut.add(state)
+
+        if (depsChanged || !currentDependencies) {
+            const updatedDependencies = new Set<State<any>>(updatedDepsArray)
+            // For async selectors, retain all previous deps so they aren't
+            // prematurely removed (and unmounted) before the continuation runs.
+            // Stale deps are cleaned up when the promise resolves (see
+            // the reconciliation logic in handleSelectorResult).
+            if (isAsyncResult && currentDependencies) {
+                for (const dep of currentDependencies) {
+                    updatedDependencies.add(dep)
                 }
             }
+            const prev = currentDependencies ?? new Set<State<any>>()
+            for (const state of updatedDependencies) {
+                if (!prev.has(state)) {
+                    const set = getOrInitDependentsSet(state, data)
+                    set.add(selector)
+                    if (addedDepsOut) addedDepsOut.add(state)
+                }
+            }
+            if (!isAsyncResult) {
+                for (const state of prev) {
+                    if (!updatedDependencies.has(state)) {
+                        const set = getOrInitDependentsSet(state, data)
+                        set.delete(selector)
+                        if (removedDepsOut) removedDepsOut.add(state)
+                    }
+                }
+            }
+            data.stateDependencies.set(selector, updatedDependencies)
         }
-        data.stateDependencies.set(selector, updatedDependencies)
-    }
 
-    // Store tracking set so handleSelectorResult can reconcile when the
-    // promise resolves. Only needed for native-promise selectors —
-    // SuspendAndWaitForResolveError re-evaluates via initSelector instead.
-    if (isPromiseLike(result)) {
-        // Build the tracking set from sync deps discovered so far. Late
-        // `get` calls (after await) will add to this set dynamically.
-        allDepsThisEval = new Set<State>(updatedDepsArray)
-        pendingAsyncDeps.set(result, allDepsThisEval)
-    }
+        // Store tracking set so handleSelectorResult can reconcile when the
+        // promise resolves. Only needed for native-promise selectors —
+        // SuspendAndWaitForResolveError re-evaluates via initSelector instead.
+        if (isPromiseLike(result)) {
+            // Build the tracking set from sync deps discovered so far. Late
+            // `get` calls (after await) will add to this set dynamically.
+            allDepsThisEval = new Set<State>(updatedDepsArray)
+            pendingAsyncDeps.set(result, allDepsThisEval)
+        }
 
-    circularDependencySet.delete(selector)
-    return result
+        return result
+    } finally {
+        // sharedCircularDepSet is module-level, so cleanup must run on every
+        // exit path — including SelectorEvaluationError rethrows and any
+        // throw from the dep-tracking code above. Otherwise the selector
+        // leaks into the set and the next read trips a spurious cycle check.
+        circularDependencySet.delete(selector)
+    }
 }
 
 export const handleSelectorResult = <Value>(

--- a/packages/valdres/src/selector.test.ts
+++ b/packages/valdres/src/selector.test.ts
@@ -384,6 +384,73 @@ describe("selector", () => {
         // expect(onChangeDerived).toHaveBeenCalledTimes(1)
     })
 
+    test("selector that throws does not leak into circular-dep tracking", () => {
+        // Regression: a shared module-level WeakSet is used for circular
+        // dependency detection. Before this fix, an inner selector throwing
+        // a non-cycle error left both the inner and the outer in the set,
+        // so the next read of the outer falsely tripped the cycle check.
+        const store1 = store()
+        const atom1 = atom(0, { name: "atom1" })
+
+        let shouldThrow = true
+        const innerSelector = selector(
+            get => {
+                get(atom1)
+                if (shouldThrow) throw new Error("transient")
+                return "inner ok"
+            },
+            { name: "inner" },
+        )
+        const outerSelector = selector(get => get(innerSelector), {
+            name: "outer",
+        })
+
+        expect(() => store1.get(outerSelector)).toThrow(
+            "Selector eval crashed",
+        )
+
+        shouldThrow = false
+
+        // Must not throw SelectorCircularDependencyError — the dependency
+        // graph is statically acyclic.
+        expect(store1.get(outerSelector)).toBe("inner ok")
+    })
+
+    test("subscription propagation does not leak after selector throws", () => {
+        // Same leak, exercised via the reEvaluteSelector path
+        // (propagateUpdatedAtoms passes circularDependencySet=undefined,
+        //  which defaults to the shared set).
+        const store1 = store()
+        const atom1 = atom(0, { name: "atom1" })
+
+        let shouldThrow = false
+        const innerSelector = selector(
+            get => {
+                const v = get(atom1)
+                if (shouldThrow) throw new Error("transient")
+                return v + 1
+            },
+            { name: "inner" },
+        )
+        const outerSelector = selector(get => get(innerSelector) * 2, {
+            name: "outer",
+        })
+
+        const unsub = store1.sub(outerSelector, () => {})
+        expect(store1.get(outerSelector)).toBe(2)
+
+        // Atom change while inner throws — propagation should not corrupt
+        // the shared circular-dep set even though re-evaluation crashes.
+        shouldThrow = true
+        store1.set(atom1, 1)
+
+        shouldThrow = false
+        store1.set(atom1, 2)
+
+        expect(store1.get(outerSelector)).toBe(6)
+        unsub()
+    })
+
     test("store.get does not leak stale atoms after a selector throws", () => {
         const store1 = store()
         const atom1 = atom(1, { name: "atom1" })


### PR DESCRIPTION
## Summary

- `evaluateSelector` switched to a module-level `sharedCircularDepSet` for circular-dep detection in beta.1, but cleanup only ran on the `NeedsInitError` branch and at the tail of the function. Any other throw — a `SelectorEvaluationError` rethrow, a wrapped non-cycle error, or anything from the dep-tracking code after the inner `catch` — left the selector in the set, so the next read tripped the cycle check against a stale entry.
- Wrap the body in `try/finally` so the `delete` runs on every exit path. `NeedsInitError` rethrow semantics are preserved — `finally` deletes the entry before the throw unwinds. The old per-call `new WeakSet` hid the bug because it was GC'd after each top-level call.
- Surfaced in shiftx as a `SelectorCircularDependencyError` on `@shiftx/process/allInsertPositionsSelector` (statically acyclic) when dragging-and-dropping a decision outside a dropzone — downgrading `valdres`/`valdres-react` to `0.2.0-pre.28` resolved it.

## Test plan

- [x] New regression test: inner selector throws once; second `store.get(outer)` succeeds (fails before fix with "Circular dependency detected in 'outer'").
- [x] New regression test for the `reEvaluteSelector` propagation path (passes `circularDependencySet=undefined`, defaults to the shared set).
- [x] `bun test` in `packages/valdres` — 290 pass, 0 fail.
- [x] `bun --filter '*' test` across the monorepo — all packages green.
- [x] `bunx changeset status --since=origin/main` — `valdres: patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)