### PR TITLE
Reduce per-selector allocation in selector propagation

### DIFF
--- a/.changeset/lazy-deps-change-holder.md
+++ b/.changeset/lazy-deps-change-holder.md
@@ -1,0 +1,13 @@
+---
+"valdres": patch
+---
+
+Reduce per-dirty-selector allocations during propagation. `reEvaluteSelector`
+previously allocated two empty `Set<State>` plus a 5-tuple for every dirty
+selector — both Sets stayed empty in the steady-state case (same deps
+re-evaluated). They're now nested under a single `DepsChange` holder reused
+across each propagation loop (the linear first sweep and the topological
+settle); `evaluateSelector` only allocates the inner Sets when a dep is
+actually added or removed. Also drops the unused `didEvalCrash` / `error`
+return slots. Small (low single-digit percent) speedup on propagation-heavy
+workloads; primarily a cleanup.

--- a/.changeset/lazy-deps-change-holder.md
+++ b/.changeset/lazy-deps-change-holder.md
@@ -2,12 +2,11 @@
 "valdres": patch
 ---
 
-Internal cleanup: reduce per-dirty-selector allocations during propagation.
-`reEvaluteSelector` previously allocated two empty `Set<State>` plus a 5-tuple
-for every dirty selector — both Sets stayed empty in the steady-state case
-(same deps re-evaluated). They're now nested under a single `DepsChange` holder
-reused across each propagation loop (the linear first sweep and the topological
-settle); `evaluateSelector` only allocates the inner Sets when a dep is actually
-added or removed. Also drops the unused `didEvalCrash` / `error` return slots.
-Measures ~2–5% faster on allocation-heavy propagation microbenchmarks (within
-noise on the largest fan-outs); no behavior change.
+Internal cleanup: reduce allocations during selector propagation. Re-evaluating
+a dirty selector previously allocated two empty tracking Sets (for added/removed
+dependencies) on every pass, even though both stay empty in the common case
+where a selector's dependencies don't change. Those Sets are now allocated
+lazily — only when a dependency is actually added or removed — and the tracking
+state is reused across each propagation pass. Measures ~2–5% faster on
+allocation-heavy propagation microbenchmarks (within noise on the largest
+fan-outs); no behavior change.

--- a/.changeset/lazy-deps-change-holder.md
+++ b/.changeset/lazy-deps-change-holder.md
@@ -2,12 +2,12 @@
 "valdres": patch
 ---
 
-Reduce per-dirty-selector allocations during propagation. `reEvaluteSelector`
-previously allocated two empty `Set<State>` plus a 5-tuple for every dirty
-selector — both Sets stayed empty in the steady-state case (same deps
-re-evaluated). They're now nested under a single `DepsChange` holder reused
-across each propagation loop (the linear first sweep and the topological
-settle); `evaluateSelector` only allocates the inner Sets when a dep is
-actually added or removed. Also drops the unused `didEvalCrash` / `error`
-return slots. Small (low single-digit percent) speedup on propagation-heavy
-workloads; primarily a cleanup.
+Internal cleanup: reduce per-dirty-selector allocations during propagation.
+`reEvaluteSelector` previously allocated two empty `Set<State>` plus a 5-tuple
+for every dirty selector — both Sets stayed empty in the steady-state case
+(same deps re-evaluated). They're now nested under a single `DepsChange` holder
+reused across each propagation loop (the linear first sweep and the topological
+settle); `evaluateSelector` only allocates the inner Sets when a dep is actually
+added or removed. Also drops the unused `didEvalCrash` / `error` return slots.
+Measures ~2–5% faster on allocation-heavy propagation microbenchmarks (within
+noise on the largest fan-outs); no behavior change.

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -181,7 +181,7 @@ export const evaluateSelector = <V>(
                     const set = getOrInitDependentsSet(state, data)
                     set.add(selector)
                     if (depsChangeOut) {
-                        if (!depsChangeOut.added) depsChangeOut.added = new Set()
+                        if (!depsChangeOut.added) depsChangeOut.added = new Set<State>()
                         depsChangeOut.added.add(state)
                     }
                 }
@@ -192,7 +192,7 @@ export const evaluateSelector = <V>(
                         const set = getOrInitDependentsSet(state, data)
                         set.delete(selector)
                         if (depsChangeOut) {
-                            if (!depsChangeOut.removed) depsChangeOut.removed = new Set()
+                            if (!depsChangeOut.removed) depsChangeOut.removed = new Set<State>()
                             depsChangeOut.removed.add(state)
                         }
                     }

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -28,13 +28,23 @@ const neverAbortedSignal = new AbortController().signal
 // Cache the sync options object per store to avoid allocation on the hot path.
 const syncOptionsCache = new WeakMap<StoreData, { signal: AbortSignal; storeId: string }>()
 
+/**
+ * Holder for dep-change tracking during propagation. The Sets inside are
+ * allocated lazily by `evaluateSelector` only when deps actually changed —
+ * the steady-state case (same deps re-evaluated) does no allocation here.
+ * Callers should clear `added` / `removed` to `undefined` before reuse.
+ */
+export type DepsChange = {
+    added?: Set<State>
+    removed?: Set<State>
+}
+
 export const evaluateSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     circularDependencySet: WeakSet<Selector> = data.circularDepSet,
-    addedDepsOut?: Set<State>,
-    removedDepsOut?: Set<State>,
+    depsChangeOut?: DepsChange,
 ) => {
     const currentDependencies = data.stateDependencies.get(selector)
     const updatedDepsArray: State<any>[] = []
@@ -170,7 +180,10 @@ export const evaluateSelector = <V>(
                 if (!prev.has(state)) {
                     const set = getOrInitDependentsSet(state, data)
                     set.add(selector)
-                    if (addedDepsOut) addedDepsOut.add(state)
+                    if (depsChangeOut) {
+                        if (!depsChangeOut.added) depsChangeOut.added = new Set()
+                        depsChangeOut.added.add(state)
+                    }
                 }
             }
             if (!isAsyncResult) {
@@ -178,7 +191,10 @@ export const evaluateSelector = <V>(
                     if (!updatedDependencies.has(state)) {
                         const set = getOrInitDependentsSet(state, data)
                         set.delete(selector)
-                        if (removedDepsOut) removedDepsOut.add(state)
+                        if (depsChangeOut) {
+                            if (!depsChangeOut.removed) depsChangeOut.removed = new Set()
+                            depsChangeOut.removed.add(state)
+                        }
                     }
                 }
             }

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -38,7 +38,7 @@ export {
 
 type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 
-const reEvaluteSelector = (
+const reEvaluateSelector = (
     selector: Selector,
     data: StoreData,
     updatedAtoms: Set<Atom>,
@@ -53,16 +53,16 @@ const reEvaluteSelector = (
             undefined,
             depsChange,
         )
-        const udpatedValue = handleSelectorResult(rawValue, selector, data)
+        const updatedValue = handleSelectorResult(rawValue, selector, data)
 
         // Use reference equality for promises — deep equal treats all
         // promises as structurally identical (both have zero own keys).
         const areEqual =
-            isPromiseLike(existingValue) || isPromiseLike(udpatedValue)
-                ? existingValue === udpatedValue
-                : selector.equal(existingValue, udpatedValue, updatedAtoms)
+            isPromiseLike(existingValue) || isPromiseLike(updatedValue)
+                ? existingValue === updatedValue
+                : selector.equal(existingValue, updatedValue, updatedAtoms)
         if (areEqual) return false
-        setValueInData(selector, udpatedValue, data)
+        setValueInData(selector, updatedValue, data)
         return true
     } catch {
         data.values.delete(selector)
@@ -464,7 +464,7 @@ const propagateDownstreamTopo = (
 
         depsChange.added = undefined
         depsChange.removed = undefined
-        const wasValueUpdated = reEvaluteSelector(
+        const wasValueUpdated = reEvaluateSelector(
             selector,
             data,
             updatedInitializedAtoms,
@@ -545,7 +545,7 @@ const propagateSelectorUpdates = (
         }
         depsChange.added = undefined
         depsChange.removed = undefined
-        const wasValueUpdated = reEvaluteSelector(
+        const wasValueUpdated = reEvaluateSelector(
             selector,
             data,
             updatedInitializedAtoms,

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -13,6 +13,7 @@ import {
     addFamilyAtomsToSet,
     deleteFamilyAtomsFromSet,
 } from "./atomFamilyIndex"
+import type { DepsChange } from "./initSelector"
 import {
     evaluateSelector,
     handleSelectorResult,
@@ -41,18 +42,16 @@ const reEvaluteSelector = (
     selector: Selector,
     data: StoreData,
     updatedAtoms: Set<Atom>,
-): [boolean, boolean, unknown, Set<State>, Set<State>] => {
-    const existingValue = data.values.get(selector)
-    const addedDeps = new Set<State>()
-    const removedDeps = new Set<State>()
+    depsChange: DepsChange,
+    existingValue: unknown,
+): boolean => {
     try {
         const rawValue = evaluateSelector(
             selector,
             data,
             updatedAtoms,
             undefined,
-            addedDeps,
-            removedDeps,
+            depsChange,
         )
         const udpatedValue = handleSelectorResult(rawValue, selector, data)
 
@@ -62,15 +61,12 @@ const reEvaluteSelector = (
             isPromiseLike(existingValue) || isPromiseLike(udpatedValue)
                 ? existingValue === udpatedValue
                 : selector.equal(existingValue, udpatedValue, updatedAtoms)
-        if (areEqual) {
-            return [false, false, undefined, addedDeps, removedDeps]
-        } else {
-            setValueInData(selector, udpatedValue, data)
-            return [true, false, undefined, addedDeps, removedDeps]
-        }
-    } catch (error) {
+        if (areEqual) return false
+        setValueInData(selector, udpatedValue, data)
+        return true
+    } catch {
         data.values.delete(selector)
-        return [true, true, error, addedDeps, removedDeps]
+        return true
     }
 }
 
@@ -433,6 +429,10 @@ const propagateDownstreamTopo = (
 
     // FIFO head pointer preserves the original BFS sibling order — nested
     // writes that side-effect into peer selectors during eval depend on it.
+    // Reused across every re-evaluated selector. evaluateSelector only
+    // allocates the inner Sets when deps actually changed, so steady-state
+    // settling does zero allocation here.
+    const depsChange: DepsChange = {}
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
@@ -462,22 +462,31 @@ const propagateDownstreamTopo = (
             continue
         }
 
-        const [wasValueUpdated, , , addedDeps, removedDeps] = reEvaluteSelector(
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluteSelector(
             selector,
             data,
             updatedInitializedAtoms,
+            depsChange,
+            currentValue,
         )
-        if (
-            (addedDeps.size > 0 || removedDeps.size > 0) &&
-            isLive(selector, data)
-        ) {
-            for (const dep of addedDeps) {
-                onLiveDependencyAdded(dep, data)
-                mountTransitiveDeps(dep, data)
+        // Casts work around a tsgo control-flow narrowing quirk where
+        // property accesses lose their narrowing after a function call.
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if ((added || removed) && isLive(selector, data)) {
+            if (added) {
+                for (const dep of added) {
+                    onLiveDependencyAdded(dep, data)
+                    mountTransitiveDeps(dep, data)
+                }
             }
-            for (const dep of removedDeps) {
-                onLiveDependencyRemoved(dep, data)
-                unmountOrphanedDeps(dep, data)
+            if (removed) {
+                for (const dep of removed) {
+                    onLiveDependencyRemoved(dep, data)
+                    unmountOrphanedDeps(dep, data)
+                }
             }
         }
 
@@ -518,6 +527,8 @@ const propagateSelectorUpdates = (
 
     let downstreamSeeds: Set<Selector> | undefined
 
+    // Reused across every re-evaluated selector — see propagateDownstreamTopo.
+    const depsChange: DepsChange = {}
     for (const selector of selectors) {
         const currentValue = data.values.get(selector)
         if (isPromiseLike(currentValue) && isInitOnly) continue
@@ -532,22 +543,31 @@ const propagateSelectorUpdates = (
             data.values.delete(selector)
             continue
         }
-        const [wasValueUpdated, , , addedDeps, removedDeps] = reEvaluteSelector(
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluteSelector(
             selector,
             data,
             updatedInitializedAtoms,
+            depsChange,
+            currentValue,
         )
-        if (
-            (addedDeps.size > 0 || removedDeps.size > 0) &&
-            isLive(selector, data)
-        ) {
-            for (const dep of addedDeps) {
-                onLiveDependencyAdded(dep, data)
-                mountTransitiveDeps(dep, data)
+        // Casts work around a tsgo control-flow narrowing quirk where
+        // property accesses lose their narrowing after a function call.
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if ((added || removed) && isLive(selector, data)) {
+            if (added) {
+                for (const dep of added) {
+                    onLiveDependencyAdded(dep, data)
+                    mountTransitiveDeps(dep, data)
+                }
             }
-            for (const dep of removedDeps) {
-                onLiveDependencyRemoved(dep, data)
-                unmountOrphanedDeps(dep, data)
+            if (removed) {
+                for (const dep of removed) {
+                    onLiveDependencyRemoved(dep, data)
+                    unmountOrphanedDeps(dep, data)
+                }
             }
         }
         if (!wasValueUpdated) continue

--- a/packages/valdres/src/selector.test.ts
+++ b/packages/valdres/src/selector.test.ts
@@ -417,7 +417,7 @@ describe("selector", () => {
     })
 
     test("subscription propagation does not leak after selector throws", () => {
-        // Same leak, exercised via the reEvaluteSelector path
+        // Same leak, exercised via the reEvaluateSelector path
         // (propagateUpdatedAtoms passes circularDependencySet=undefined,
         //  which defaults to the shared set).
         const store1 = store()


### PR DESCRIPTION
## Summary

Internal cleanup that trims allocation in the selector propagation path.

- `reEvaluteSelector` allocated two empty `Set<State>` plus a 5-tuple for *every* dirty selector, even though both Sets stay empty in the common case (deps unchanged across re-eval).
- The Sets now live in a single `DepsChange` holder, reused across each propagation loop (the linear first sweep and the topological settle). `evaluateSelector` allocates the inner Sets lazily, only when a dep is actually added or removed.
- Drops the unused `didEvalCrash` / `error` slots from `reEvaluteSelector`'s return — they were destructured into holes (`[wasValueUpdated, , , …]`) at both call sites and never read.

`evaluateSelector` is internal (not in the package's public exports), so the signature change has no external impact.

## Performance

Primarily a cleanup, not a perf win. Measured A/B vs the merge base (2 rounds x 9 samples, medians): **~2-5% faster** on allocation-heavy propagation microbenchmarks (set atom -> many dependent selectors, fanout, chains, diamond), **within noise on the largest fan-outs** (200 subscribers, wide diamond). No regression in any scenario. Real-app impact is expected to be negligible; the value here is allocation hygiene + dead-code removal.

## Test plan
- [x] `bun test` — 327 valdres tests pass
- [x] `bun --filter '*' test` — full monorepo suite passes
- [x] `bun --filter '*' build:types` (tsgo) — clean
- [x] CI green (`test`, `benchmark_pr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
