### PR TITLE
Split propagateUpdatedAtoms into top-level and scope-recursive entries

### DIFF
--- a/.changeset/split-propagate-updated-atoms.md
+++ b/.changeset/split-propagate-updated-atoms.md
@@ -1,0 +1,14 @@
+---
+"valdres": patch
+---
+
+Refactor `propagateUpdatedAtoms` into two purpose-built functions:
+`propagateAtomUpdate` for top-level updates (collect direct subscribers,
+walk dependent selectors, cross into scopes) and `propagateInScope` for
+scope-level recursion (selector walk + scope recursion only, since the
+parent scope already notified atom subscribers and family-index updates
+have already cascaded). Drops three dead parameters (`isRecursive`,
+externally-passed `subscriptions` and `families`) and the `selectorsOnly`
+boolean — these are now encoded by which function the caller chooses.
+Pure refactor: no behavior change, full test suite green, benchmarks
+unchanged.

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -8,7 +8,7 @@ import type { AtomOptions } from "./../types/AtomOptions"
 import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
 import { isTransitivelySubscribed, mountAtom, unmountAtom } from "./mountAtom"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { installMaxAgeTimer } from "./subscribe"
 import { globalStore } from "../globalStore"
@@ -120,7 +120,7 @@ export const globalAtom = <Value = unknown>(
             stores.delete(store)
             store.values.delete(atom)
             try {
-                propagateUpdatedAtoms([atom], store)
+                propagateAtomUpdate([atom], store)
             } catch (e) {
                 recordError(e)
             }

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -4,7 +4,7 @@ import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
 import { getState } from "./getState"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { setValueInData } from "./setValueInData"
 
@@ -36,7 +36,7 @@ export const getAtomInitValue = <V = any>(
                     if (data.values.get(atom) !== value) return
                     // @ts-ignore @ts-todo
                     setValueInData(atom, resolvedValue, data)
-                    propagateUpdatedAtoms([atom], data)
+                    propagateAtomUpdate([atom], data)
                 },
                 () => {
                     // On rejection, remove the rejected promise from the

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -16,8 +16,8 @@ import {
 import { getState } from "./getState"
 import { unmountOrphanedDeps } from "./mountAtom"
 import {
+    propagateAtomUpdate,
     propagateDirtySelectors,
-    propagateUpdatedAtoms,
 } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 
@@ -256,7 +256,7 @@ export const handleSelectorResult = <Value>(
             const initializedAtomsSet = new Set<Atom>()
             const res = initSelector(selector, data, initializedAtomsSet)
             if (initializedAtomsSet.size > 0) {
-                propagateUpdatedAtoms([...initializedAtomsSet], data)
+                propagateAtomUpdate([...initializedAtomsSet], data)
             }
             return res
         }).catch(() => {

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -33,6 +33,8 @@ export {
     renderAtomFamilyIndex,
 } from "./atomFamilyIndex"
 
+type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
+
 const reEvaluteSelector = (
     selector: Selector,
     data: StoreData,
@@ -143,11 +145,9 @@ export const propagateDeletedAtoms = (
         addSetToSet(data.subscriptions.get(atom), subscriptions)
 
         if (isFamilyAtom(atom)) {
-            // atom.family
             if (!families.has(atom.family)) {
                 families.set(atom.family, new Set())
             }
-
             // @ts-ignore
             families.get(atom.family).add(atom)
         }
@@ -164,9 +164,9 @@ export const propagateDeletedAtoms = (
     }
     propagateDirtySelectors(atoms, selectors, data, subscriptions, families)
     // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
-    // already updated the scope's family index via recursivelyUpdateIndexes,
-    // but selectors in those scopes that depend on the family still need to
-    // be re-evaluated so their subscribers get notified.
+    // already updated each scope's family index via recursivelyUpdateIndexes;
+    // selectors in those scopes that depend on the family still need to be
+    // re-evaluated so their subscribers get notified.
     if (families.size > 0 && data.scopes && data.scopes.size > 0) {
         const scopeFamilies = new Map<StoreData, AtomFamily<any>[]>()
         for (const family of families.keys()) {
@@ -183,36 +183,21 @@ export const propagateDeletedAtoms = (
             }
         }
         for (const [scope, familiesInScope] of scopeFamilies) {
-            propagateUpdatedAtoms(
-                familiesInScope,
-                scope,
-                undefined,
-                undefined,
-                false,
-                timestamp,
-                true,
-            )
+            propagateInScope(familiesInScope, scope)
         }
     }
 }
 
-export const propagateUpdatedAtoms = (
-    atoms: (Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>)[],
+// Top-level entry: notify direct atom subscribers, walk dependent selectors,
+// then cross-propagate into scopes.
+export const propagateAtomUpdate = (
+    atoms: AtomInput[],
     data: StoreData,
-    subscriptions?: Set<Subscription>,
-    families?: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
-    isRecursive = false,
-    timestamp = performance.now(),
-    selectorsOnly = false,
     isInitOnly = false,
 ) => {
     // Fast path: single non-family atom with no dependent selectors and no
     // scopes can skip the full graph walk entirely and just notify subscribers.
-    if (
-        atoms.length === 1 &&
-        !isRecursive &&
-        !selectorsOnly
-    ) {
+    if (atoms.length === 1) {
         const atom = atoms[0]
         if (!isFamilyAtom(atom) && !isAtomFamily(atom)) {
             const dependents = data.stateDependents.get(atom)
@@ -229,125 +214,123 @@ export const propagateUpdatedAtoms = (
         }
     }
 
-    if (!subscriptions) subscriptions = new Set()
-    if (!families) families = new Map()
-
+    const subscriptions = new Set<Subscription>()
+    const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
     const selectors = new Set<Selector>()
+
     for (const atom of atoms) {
         addSetToSet(data.stateDependents.get(atom), selectors)
-        if (!selectorsOnly) {
-            //**
-            // This check was added to make the test in selector.test.ts named
-            // "selector in scope dependent on atom not set in scope but in parent scope works correctly"
-            // pass. This was a quick fix to make it work. */
-            addSetToSet(data.subscriptions.get(atom), subscriptions)
-            if (isFamilyAtom(atom)) {
-                if (!families.has(atom.family)) {
-                    families.set(atom.family, new Set())
-                }
-
-                // @ts-ignore
-                families.get(atom.family).add(atom)
+        addSetToSet(data.subscriptions.get(atom), subscriptions)
+        if (isFamilyAtom(atom)) {
+            if (!families.has(atom.family)) {
+                families.set(atom.family, new Set())
             }
+            // @ts-ignore
+            families.get(atom.family).add(atom)
         }
     }
 
     if (families.size > 0) {
+        const timestamp = performance.now()
         for (const [family, familyAtoms] of families) {
             addSetToSet(data.stateDependents.get(family), selectors)
             addSetToSet(data.subscriptions.get(family), subscriptions)
             if (familyAtoms.size === 0)
                 throw new Error("Should not be possible")
-
             addFamilyAtomsToSet(family, familyAtoms, data, timestamp)
         }
     }
 
-    if (!isRecursive) {
-        propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly)
-        if (data.scopes && data.scopes.size > 0) {
-            if (atoms.length === 1) {
-                // Fast path for single-atom updates (most common case)
-                const atom = atoms[0]
-                const shadowingScopes = isAtomFamily(atom)
-                    ? undefined
-                    : data.scopeValueIndex.get(atom)
-                for (const [, scope] of data.scopes) {
-                    if (!shadowingScopes || !shadowingScopes.has(scope)) {
-                        propagateUpdatedAtoms(
-                            atoms,
-                            scope,
-                            undefined,
-                            undefined,
-                            false,
-                            timestamp,
-                            true,
-                            isInitOnly,
-                        )
-                    }
-                }
-            } else {
-                // Multi-atom path: precompute shadow sets once
-                let anyShadowed = false
-                let atomShadows: Map<any, Set<any>> | undefined
-                for (const atom of atoms) {
-                    if (!isAtomFamily(atom)) {
-                        const s = data.scopeValueIndex.get(atom)
-                        if (s && s.size > 0) {
-                            if (!atomShadows) atomShadows = new Map()
-                            atomShadows.set(atom, s)
-                            anyShadowed = true
-                        }
-                    }
-                }
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly)
 
-                if (!anyShadowed) {
-                    // No atom is shadowed, propagate all to every scope
-                    for (const [, scope] of data.scopes) {
-                        propagateUpdatedAtoms(
-                            atoms,
-                            scope,
-                            undefined,
-                            undefined,
-                            false,
-                            timestamp,
-                            true,
-                            isInitOnly,
-                        )
-                    }
-                } else {
-                    // Some atoms are shadowed, filter per scope
-                    for (const [, scope] of data.scopes) {
-                        const atomsToUpdateInScope = []
-                        for (const atom of atoms) {
-                            if (isAtomFamily(atom)) {
-                                // The scope has its own family index, but the parent
-                                // index may have changed (e.g. a member was deleted
-                                // from root). Re-evaluate dependent selectors in the
-                                // scope so subscribers get notified.
-                                atomsToUpdateInScope.push(atom)
-                            } else {
-                                const s = atomShadows!.get(atom)
-                                if (!s || !s.has(scope)) {
-                                    atomsToUpdateInScope.push(atom)
-                                }
-                            }
-                        }
-                        if (atomsToUpdateInScope.length > 0) {
-                            propagateUpdatedAtoms(
-                                atomsToUpdateInScope,
-                                scope,
-                                undefined,
-                                undefined,
-                                false,
-                                timestamp,
-                                true,
-                                isInitOnly,
-                            )
-                        }
-                    }
+    if (data.scopes && data.scopes.size > 0) {
+        propagateToScopes(atoms, data, isInitOnly)
+    }
+}
+
+// Scope-recursive entry: re-evaluate selectors that depend on these atoms in
+// this scope and cross into nested scopes. Skips collecting direct atom and
+// family subscribers — the parent scope already notified those, and family
+// index bookkeeping has already cascaded via recursivelyUpdateIndexes.
+export const propagateInScope = (
+    atoms: AtomInput[],
+    data: StoreData,
+    isInitOnly = false,
+) => {
+    const subscriptions = new Set<Subscription>()
+    const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
+    const selectors = new Set<Selector>()
+
+    for (const atom of atoms) {
+        addSetToSet(data.stateDependents.get(atom), selectors)
+    }
+
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly)
+
+    if (data.scopes && data.scopes.size > 0) {
+        propagateToScopes(atoms, data, isInitOnly)
+    }
+}
+
+const propagateToScopes = (
+    atoms: AtomInput[],
+    data: StoreData,
+    isInitOnly: boolean,
+) => {
+    if (atoms.length === 1) {
+        // Fast path for single-atom updates (most common case)
+        const atom = atoms[0]
+        const shadowingScopes = isAtomFamily(atom)
+            ? undefined
+            : data.scopeValueIndex.get(atom)
+        for (const [, scope] of data.scopes) {
+            if (!shadowingScopes || !shadowingScopes.has(scope)) {
+                propagateInScope(atoms, scope, isInitOnly)
+            }
+        }
+        return
+    }
+
+    // Multi-atom path: precompute shadow sets once
+    let anyShadowed = false
+    let atomShadows: Map<any, Set<any>> | undefined
+    for (const atom of atoms) {
+        if (!isAtomFamily(atom)) {
+            const s = data.scopeValueIndex.get(atom)
+            if (s && s.size > 0) {
+                if (!atomShadows) atomShadows = new Map()
+                atomShadows.set(atom, s)
+                anyShadowed = true
+            }
+        }
+    }
+
+    if (!anyShadowed) {
+        for (const [, scope] of data.scopes) {
+            propagateInScope(atoms, scope, isInitOnly)
+        }
+        return
+    }
+
+    // Some atoms are shadowed, filter per scope
+    for (const [, scope] of data.scopes) {
+        const atomsToUpdateInScope: AtomInput[] = []
+        for (const atom of atoms) {
+            if (isAtomFamily(atom)) {
+                // The scope has its own family index, but the parent
+                // index may have changed (e.g. a member was deleted
+                // from root). Re-evaluate dependent selectors in the
+                // scope so subscribers get notified.
+                atomsToUpdateInScope.push(atom)
+            } else {
+                const s = atomShadows!.get(atom)
+                if (!s || !s.has(scope)) {
+                    atomsToUpdateInScope.push(atom)
                 }
             }
+        }
+        if (atomsToUpdateInScope.length > 0) {
+            propagateInScope(atomsToUpdateInScope, scope, isInitOnly)
         }
     }
 }

--- a/packages/valdres/src/lib/resetAtom.ts
+++ b/packages/valdres/src/lib/resetAtom.ts
@@ -2,7 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { getAtomInitValue } from "./initAtom"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 
 export const resetAtom = <V>(
@@ -13,10 +13,10 @@ export const resetAtom = <V>(
     let value = getAtomInitValue(atom, data, initializedAtomsSet)
     setValueInData(atom, value, data)
     if (!isPromiseLike(value)) {
-        propagateUpdatedAtoms([atom], data)
+        propagateAtomUpdate([atom], data)
     }
     if (initializedAtomsSet.size > 0) {
-        throw new Error("Todo - propagateUpdatedAtoms on reset")
+        throw new Error("Todo - propagateAtomUpdate on reset")
     }
     return value
 }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -3,7 +3,7 @@ import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { getState } from "./getState"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { setValueInData } from "./setValueInData"
 
@@ -34,7 +34,7 @@ const handlePromise = <Value>(
                 // @ts-ignore
                 emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
             }
-            propagateUpdatedAtoms([atom], data)
+            propagateAtomUpdate([atom], data)
         })
         // Chained .catch so errors thrown inside the fulfilled handler
         // (e.g. from atom.onSet) don't surface as unhandled rejections.
@@ -44,7 +44,7 @@ const handlePromise = <Value>(
             // lets us avoid clobbering it.
             if (data.values.get(atom) !== promise) return
             setValueInData(atom, currentValue, data)
-            propagateUpdatedAtoms([atom], data)
+            propagateAtomUpdate([atom], data)
         })
 }
 
@@ -76,9 +76,9 @@ export const setAtom = <Value = any>(
         handlePromise(atom, promise, currentValue, data, skipOnSet)
         if (initializedAtomsSet && initializedAtomsSet.size > 0) {
             initializedAtomsSet.add(atom)
-            propagateUpdatedAtoms([...initializedAtomsSet], data)
+            propagateAtomUpdate([...initializedAtomsSet], data)
         } else {
-            propagateUpdatedAtoms([atom], data)
+            propagateAtomUpdate([atom], data)
         }
         return promise as Value
     }
@@ -98,9 +98,9 @@ export const setAtom = <Value = any>(
     }
     if (initializedAtomsSet && initializedAtomsSet.size > 0) {
         initializedAtomsSet.add(atom)
-        propagateUpdatedAtoms([...initializedAtomsSet], data)
+        propagateAtomUpdate([...initializedAtomsSet], data)
     } else {
-        propagateUpdatedAtoms([atom], data)
+        propagateAtomUpdate([atom], data)
     }
     return syncValue
 }

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -2,7 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { getState } from "./getState"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 
 export const setAtoms = (
@@ -32,6 +32,6 @@ export const setAtoms = (
         }
     }
     if (updatedAtoms.length > 0) {
-        propagateUpdatedAtoms(updatedAtoms, data)
+        propagateAtomUpdate(updatedAtoms, data)
     }
 }

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -14,7 +14,7 @@ import { resolveReactive } from "../utils/resolveReactive"
 import { createStoreData } from "./createStoreData"
 import { deleteFamilyAtom } from "./deleteFamilyAtom"
 import { getState } from "./getState"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { resetAtom } from "./resetAtom"
 import { setAtom } from "./setAtom"
 import { subscribe } from "./subscribe"
@@ -113,7 +113,7 @@ export function storeFromStoreData(
             if (_initSet.size) {
                 const atoms = [..._initSet]
                 _initSet.clear()
-                propagateUpdatedAtoms(atoms, data, undefined, undefined, false, undefined, false, true)
+                propagateAtomUpdate(atoms, data, true)
             }
         }
         return res

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -15,7 +15,7 @@ import type { CacheMeta } from "../types/Atom"
 import { equal } from "./equal"
 import { initAtom } from "./initAtom"
 import { initSelector } from "./initSelector"
-import { propagateUpdatedAtoms } from "./propagateUpdatedAtoms"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 import { setMaxAgeCleanup } from "./maxAgeCleanups"
 import { mountTransitiveDeps } from "./mountAtom"
@@ -40,7 +40,7 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
         for (const s of globalState!.stores) {
             if (s !== data && s.values.has(metaAtom)) {
                 setValueInData(metaAtom, s.values.get(metaAtom), data)
-                propagateUpdatedAtoms([metaAtom], data)
+                propagateAtomUpdate([metaAtom], data)
                 break
             }
         }
@@ -87,11 +87,11 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
         if (globalState) {
             for (const store of globalState.stores) {
                 setValueInData(metaAtom, meta, store)
-                propagateUpdatedAtoms([metaAtom], store)
+                propagateAtomUpdate([metaAtom], store)
             }
         } else {
             setValueInData(metaAtom, meta, data)
-            propagateUpdatedAtoms([metaAtom], data)
+            propagateAtomUpdate([metaAtom], data)
         }
     }
 
@@ -104,11 +104,11 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
         if (globalState) {
             for (const store of globalState.stores) {
                 setValueInData(atom, val, store)
-                propagateUpdatedAtoms([atom], store)
+                propagateAtomUpdate([atom], store)
             }
         } else {
             setValueInData(atom, val, data)
-            propagateUpdatedAtoms([atom], data)
+            propagateAtomUpdate([atom], data)
         }
     }
 


### PR DESCRIPTION
## Summary

Refactor `propagateUpdatedAtoms` — an 8-arg / 4-bool function juggling three jobs (notify direct subscribers, walk dependent selectors, cross into scopes) — into two purpose-built entries plus an extracted scope helper.

- **`propagateAtomUpdate(atoms, data, isInitOnly?)`** — top-level entry. Collects direct subscribers, builds the family map, walks dirty selectors, cross-propagates to scopes. Used by all 18 external call sites (`setAtom`, `setAtoms`, `resetAtom`, `subscribe`, `globalAtom`, `initAtom`, `initSelector`, `storeFromStoreData`).
- **`propagateInScope(atoms, data, isInitOnly?)`** — scope-recursive entry. Walks dependent selectors in the scope and recurses into nested scopes. Skips direct atom/family subscriber collection because the parent already notified them and family-index updates already cascaded via `recursivelyUpdateIndexes`.
- **`propagateToScopes`** — extracted shared helper that handles the single-atom fast path, multi-atom shadow precomputation, and the per-scope filter for partial shadowing.

### Why the old shape was painful

- `isRecursive` was always `false` at every call site (including internal recursive calls). Pure dead code.
- `subscriptions` and `families` parameters were always `undefined` at every call site — only ever materialized as internal locals.
- `selectorsOnly` was really *which entry point you're calling*, not a flag — a comment in the old code (`"This was a quick fix to make it work"`) flagged this.

### What changed beyond the rename

- Drops 4 parameters from the public-ish call surface.
- `performance.now()` deferred until family bookkeeping actually runs (small win on the non-family hot path).
- `timestamp` no longer threaded through scope recursion (was dead — only `addFamilyAtomsToSet`/`deleteFamilyAtomsFromSet` consumed it, and those only run at the top level).
- Stale TODO error string in `resetAtom.ts` updated to the new name.

Pure refactor — no behavior change. The fast path in `propagateAtomUpdate` (single non-family atom, no dependents, no scopes → just `callSubscribers`) is preserved.

## Test plan

- [x] `bun test` in `packages/valdres` — 291 pass / 1 todo / 0 fail
- [x] `bun --filter '*' test` across the whole monorepo — 0 fail across all valdres + valdres-react + browser-API packages
- [x] `test/performance/{atom,selector,scope,atomFamily,transaction,store,baseline}.bench.ts` — all `assertFaster` thresholds pass, numbers within run-to-run noise (e.g. `set(atom)` 86–87ns, `set with 10 subs` 105–106ns, `set + read 100 selectors` 32µs, `1000 scopes (no shadow)` 109–117µs)
- [x] Changeset added (`valdres: patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)