### PR TITLE
Remove selector-init trampoline in favor of plain recursion

### DIFF
--- a/.changeset/remove-selector-trampoline.md
+++ b/.changeset/remove-selector-trampoline.md
@@ -11,4 +11,6 @@ exception-as-control-flow), and brings N=500 sub+unsub within parity of jotai.
 stack capacity (~thousands of levels in practice) will now throw a
 `RangeError` (possibly wrapped in `SelectorEvaluationError`) instead of
 falling back to iterative evaluation. This matches jotai's failure mode and
-applies only to chains far deeper than realistic application code.
+applies only to chains far deeper than realistic application code. The
+`processes deep atom a graph beyond maxDepth` jotai-compat test is now
+skipped since valdres no longer exceeds jotai's guarantees there.

--- a/.changeset/remove-selector-trampoline.md
+++ b/.changeset/remove-selector-trampoline.md
@@ -1,0 +1,14 @@
+---
+"valdres": minor
+---
+
+Remove the iterative selector-init trampoline. Selector evaluation now uses
+plain recursion all the way down, matching jotai's strategy. This eliminates
+the ~26x perf cliff at chain depths >100 (caused by `NeedsInitError`
+exception-as-control-flow), and brings N=500 sub+unsub within parity of jotai.
+
+**Behavior change:** selector chains beyond the JavaScript engine's call
+stack capacity (~thousands of levels in practice) will now throw a
+`RangeError` (possibly wrapped in `SelectorEvaluationError`) instead of
+falling back to iterative evaluation. This matches jotai's failure mode and
+applies only to chains far deeper than realistic application code.

--- a/packages/@valdres-react/jotai/COMPAT_TODO.md
+++ b/packages/@valdres-react/jotai/COMPAT_TODO.md
@@ -16,7 +16,7 @@ Valdres notifies listeners at different points in the write cycle:
 
 ### Deep recursion / stack overflow (1)
 Deeply nested or circular selector graphs blow the stack:
-- [ ] `processes deep atom a graph beyond maxDepth` — skipped; valdres now matches jotai's behavior here (plain recursion, JS stack ceiling applies). Removed iterative trampoline removed a 26x perf cliff at depth >100.
+- [ ] `processes deep atom a graph beyond maxDepth` — skipped; valdres now matches jotai's behavior here (plain recursion, JS stack ceiling applies). Removing the iterative trampoline eliminated a 26x perf cliff at depth >100.
 - [x] `should not inf on subscribe or unsubscribe`
 
 ### Error resilience in listeners (1)

--- a/packages/@valdres-react/jotai/COMPAT_TODO.md
+++ b/packages/@valdres-react/jotai/COMPAT_TODO.md
@@ -16,7 +16,7 @@ Valdres notifies listeners at different points in the write cycle:
 
 ### Deep recursion / stack overflow (1)
 Deeply nested or circular selector graphs blow the stack:
-- [x] `processes deep atom a graph beyond maxDepth`
+- [ ] `processes deep atom a graph beyond maxDepth` — skipped; valdres now matches jotai's behavior here (plain recursion, JS stack ceiling applies). Removed iterative trampoline removed a 26x perf cliff at depth >100.
 - [x] `should not inf on subscribe or unsubscribe`
 
 ### Error resilience in listeners (1)

--- a/packages/@valdres-react/jotai/jotai-tests/vanilla/store.test.ts
+++ b/packages/@valdres-react/jotai/jotai-tests/vanilla/store.test.ts
@@ -988,7 +988,13 @@ test("should call subscribers after setAtom updates atom value on mount but not 
     expect(listener).toHaveBeenCalledTimes(0)
 })
 
-test("processes deep atom a graph beyond maxDepth", () => {
+// Valdres previously used an iterative trampoline to handle arbitrarily
+// deep selector chains, which let it pass this test where jotai itself
+// throws. The trampoline was removed in favor of plain recursion (matching
+// jotai's strategy and removing a 26x perf cliff at depth >100); the
+// failure mode at extreme depths is now the JS engine's stack limit, the
+// same as jotai.
+test.skip("processes deep atom a graph beyond maxDepth", () => {
     function getMaxDepth() {
         let depth = 0
         function d(): number {

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -11,7 +11,7 @@ import { isSelector } from "../utils/isSelector"
 import { isSelectorFamily } from "../utils/isSelectorFamily"
 import { equal } from "./equal"
 import { initAtom } from "./initAtom"
-import { initSelector, NeedsInitError, _evalDepth, MAX_EVAL_DEPTH } from "./initSelector"
+import { initSelector } from "./initSelector"
 import {
     createAtomFamilyIndex,
     renderAtomFamilyIndex,
@@ -78,11 +78,6 @@ export function getState<
         return data.values.get(state)
     }
     if (isSelector<Value>(state)) {
-        if (_evalDepth >= MAX_EVAL_DEPTH) {
-            // Approaching stack limit — signal the trampoline to handle
-            // this dependency iteratively instead of recursing deeper.
-            throw new NeedsInitError(state)
-        }
         initSelector<Value>(
             state,
             data,

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -23,29 +23,6 @@ import { setValueInData } from "./setValueInData"
 
 export { isSuspendError } from "./asyncDependencyTracking"
 
-/**
- * Thrown by getState when recursion depth exceeds MAX_EVAL_DEPTH and a selector
- * still needs initialization. The outermost initSelector catches this and
- * switches to an iterative trampoline to evaluate the dependency chain.
- */
-export class NeedsInitError {
-    selector: Selector
-    constructor(selector: Selector) {
-        this.selector = selector
-    }
-}
-
-/** Recursion depth for selector initialization. Exported for getState to check. */
-export let _evalDepth = 0
-
-/** Whether we're inside a trampoline loop (prevents nested trampolines). */
-let _inTrampoline = false
-
-/** Max selector init recursion depth before switching to trampoline mode.
- *  Each level uses ~8-10 JS stack frames, so 100 levels ≈ 800-1000 frames,
- *  safely under the typical ~10000 frame limit. */
-export const MAX_EVAL_DEPTH = 100
-
 // Shared WeakSet for circular dependency detection — safe to reuse because
 // evaluation is synchronous and each selector adds/deletes itself.
 const sharedCircularDepSet = new WeakSet()
@@ -160,7 +137,6 @@ export const evaluateSelector = <V>(
                 return value
             }, options)
         } catch (error) {
-            if (error instanceof NeedsInitError) throw error
             if (error instanceof SuspendAndWaitForResolveError) {
                 result = error
             } else if (error instanceof SelectorEvaluationError) {
@@ -329,11 +305,11 @@ export const handleSelectorResult = <Value>(
     }
 }
 
-const initSelectorDirect = <V>(
+export const initSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any>,
+    circularDependencySet: WeakSet<any> = sharedCircularDepSet,
 ): boolean => {
     const existingValue = data.values.get(selector)
     const updatedValue = evaluate(
@@ -354,83 +330,6 @@ const initSelectorDirect = <V>(
     } else {
         setValueInData<V>(selector, updatedValue as V, data)
         return true
-    }
-}
-
-/**
- * Iterative trampoline for initializing deeply nested selector chains.
- * Instead of recursing through getState → initSelector → evaluateSelector → getState,
- * getState throws NeedsInitError when it encounters an uninitialized selector
- * during trampoline mode. The trampoline catches this and evaluates deps first.
- */
-const initSelectorTrampoline = <V>(
-    selector: Selector<V>,
-    data: StoreData,
-    initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any>,
-): void => {
-    const stack: Selector[] = [selector]
-    const inStack = new Set<Selector>([selector])
-
-    while (stack.length > 0) {
-        const current = stack[stack.length - 1]!
-        if (data.values.has(current)) {
-            stack.pop()
-            inStack.delete(current)
-            continue
-        }
-        try {
-            initSelectorDirect(
-                current,
-                data,
-                initializedAtomsSet,
-                circularDependencySet,
-            )
-            stack.pop()
-            inStack.delete(current)
-        } catch (e) {
-            if (e instanceof NeedsInitError) {
-                if (inStack.has(e.selector)) {
-                    throw new SelectorCircularDependencyError()
-                }
-                stack.push(e.selector)
-                inStack.add(e.selector)
-            } else {
-                throw e
-            }
-        }
-    }
-}
-
-export const initSelector = <V>(
-    selector: Selector<V>,
-    data: StoreData,
-    initializedAtomsSet: Set<Atom>,
-    circularDependencySet = sharedCircularDepSet,
-): boolean => {
-    const isTopLevel = _evalDepth === 0 && !_inTrampoline
-    _evalDepth++
-    const existingValue = data.values.get(selector)
-    try {
-        return initSelectorDirect(selector, data, initializedAtomsSet, circularDependencySet)
-    } catch (e) {
-        if (e instanceof NeedsInitError && isTopLevel) {
-            // Depth limit was hit — switch to iterative trampoline
-            _inTrampoline = true
-            try {
-                initSelectorTrampoline(selector, data, initializedAtomsSet, circularDependencySet)
-            } finally {
-                _inTrampoline = false
-            }
-            const newValue = data.values.get(selector)
-            const areEqual = isPromiseLike(existingValue) || isPromiseLike(newValue)
-                ? existingValue === newValue
-                : selector.equal(existingValue as V, newValue as V)
-            return !areEqual
-        }
-        throw e
-    } finally {
-        _evalDepth--
     }
 }
 

--- a/packages/valdres/src/selector.test.ts
+++ b/packages/valdres/src/selector.test.ts
@@ -745,12 +745,15 @@ describe("async selector", () => {
 
         test("chains beyond stack capacity throw, matching jotai", () => {
             // Discover a chain depth that the JS stack genuinely can't hold,
-            // by finding the trivial-call ceiling and scaling well past it.
-            // Selector init burns far more frames per level than a trivial
-            // recursive call, so 2x the trivial ceiling is a comfortable
-            // overshoot. The exact error class doesn't matter (raw RangeError
-            // vs SelectorEvaluationError wrap) — the contract is just that
-            // we throw rather than silently truncating or hanging.
+            // by finding the trivial-call ceiling and scaling past it. Selector
+            // init burns far more frames per level than a trivial recursive
+            // call, so 2x trivial ceiling is a comfortable overshoot. The cap
+            // keeps the test cheap on engines with segmented stacks (e.g. JSC
+            // can hit 50k+); 10k selectors is still well past selector init's
+            // overflow point on every engine we care about. The exact error
+            // class doesn't matter (raw RangeError vs SelectorEvaluationError
+            // wrap) — the contract is that we throw rather than silently
+            // truncating or hanging.
             const getMaxDepth = (): number => {
                 let depth = 0
                 const d = (): number => {
@@ -759,7 +762,7 @@ describe("async selector", () => {
                 }
                 return d()
             }
-            const overflowDepth = getMaxDepth() * 2
+            const overflowDepth = Math.min(getMaxDepth() * 2, 10_000)
             const store1 = store()
             const base = atom(0)
             const chain: any[] = [base]

--- a/packages/valdres/src/selector.test.ts
+++ b/packages/valdres/src/selector.test.ts
@@ -708,56 +708,66 @@ describe("async selector", () => {
     })
 
     describe("deep selector chains", () => {
-        test("initializes a chain deeper than MAX_EVAL_DEPTH via get()", () => {
+        // 200 levels is the previous test depth (which exercised the old
+        // trampoline). It's deep enough to prove non-trivial chains work
+        // and shallow enough to fit comfortably inside the JS stack on all
+        // engines we care about.
+        const DEEP = 200
+
+        test("initializes a deep chain via get()", () => {
             const store1 = store()
             const base = atom(42)
             const chain: any[] = [base]
-            for (let i = 0; i < 200; i++) {
+            for (let i = 0; i < DEEP; i++) {
                 const prev = chain[i]
                 chain.push(selector(get => get(prev)))
             }
-            // get() triggers initSelector for the entire chain
-            expect(store1.get(chain[200])).toBe(42)
+            expect(store1.get(chain[DEEP])).toBe(42)
         })
 
         test("propagates updates through a deep chain via sub() and set()", () => {
             const store1 = store()
             const base = atom(0)
             const chain: any[] = [base]
-            for (let i = 0; i < 200; i++) {
+            for (let i = 0; i < DEEP; i++) {
                 const prev = chain[i]
                 chain.push(selector(get => get(prev)))
             }
             const callback = mock(() => {})
-            const unsub = store1.sub(chain[200], callback)
-            expect(store1.get(chain[200])).toBe(0)
+            const unsub = store1.sub(chain[DEEP], callback)
+            expect(store1.get(chain[DEEP])).toBe(0)
 
             store1.set(base, 7)
             expect(callback).toHaveBeenCalledTimes(1)
-            expect(store1.get(chain[200])).toBe(7)
+            expect(store1.get(chain[DEEP])).toBe(7)
             unsub()
         })
 
-        test("handles chain at JS stack limit without overflow", () => {
-            // Discover the actual max recursion depth for this runtime
-            function getMaxDepth() {
+        test("chains beyond stack capacity throw, matching jotai", () => {
+            // Discover a chain depth that the JS stack genuinely can't hold,
+            // by finding the trivial-call ceiling and scaling well past it.
+            // Selector init burns far more frames per level than a trivial
+            // recursive call, so 2x the trivial ceiling is a comfortable
+            // overshoot. The exact error class doesn't matter (raw RangeError
+            // vs SelectorEvaluationError wrap) — the contract is just that
+            // we throw rather than silently truncating or hanging.
+            const getMaxDepth = (): number => {
                 let depth = 0
-                function d(): number {
+                const d = (): number => {
                     ++depth
                     try { return d() } catch { return depth }
                 }
                 return d()
             }
-            const maxDepth = Math.min(getMaxDepth(), 5000)
+            const overflowDepth = getMaxDepth() * 2
             const store1 = store()
             const base = atom(0)
             const chain: any[] = [base]
-            for (let i = 0; i < maxDepth; i++) {
+            for (let i = 0; i < overflowDepth; i++) {
                 const prev = chain[i]
                 chain.push(selector(get => get(prev)))
             }
-            expect(() => store1.sub(chain[maxDepth], () => {})).not.toThrow()
-            expect(() => store1.set(base, 1)).not.toThrow()
+            expect(() => store1.get(chain[overflowDepth])).toThrow()
         }, 10_000)
     })
 })

--- a/packages/valdres/test/performance/selector.bench.ts
+++ b/packages/valdres/test/performance/selector.bench.ts
@@ -92,11 +92,7 @@ describe("selector", () => {
     // graph — O(N²) total. The cache makes each check O(1). Build cost is
     // paid equally by both sides because we rebuild each iteration (cleanup
     // destroys the chain).
-    // Both N values stay within the recursive-init path (MAX_EVAL_DEPTH=100),
-    // so the only thing varying across them is the cleanup walk cost. Beyond
-    // depth ~100 the build phase hits the exception-based trampoline and the
-    // signal we want to measure gets drowned out.
-    for (const N of [50, 100]) {
+    for (const N of [50, 100, 500]) {
         test(`sub+unsub on chain of ${N} unsubscribed derived deps`, async () => {
             await assertFaster(
                 `sub+unsub on chain of ${N} unsubscribed derived deps`,


### PR DESCRIPTION
## Summary

The iterative selector-init trampoline (`NeedsInitError` + work-stack) existed as a fallback past `MAX_EVAL_DEPTH=100`. Exception-as-control-flow costs ~10–50µs per throw, creating a 26x perf cliff at depth 101 (80µs → 2ms). This PR matches jotai's strategy: pure recursion, accept the engine's stack ceiling as the limit. Apps with 1000+ deep chains are mythological; the perf win on realistic depths is worth the lost guarantee.

- Removes `NeedsInitError`, `MAX_EVAL_DEPTH`, `_evalDepth`, `_inTrampoline`, `initSelectorDirect`, `initSelectorTrampoline`
- Collapses `initSelector` from ~100 lines to ~20
- 130 lines removed, 44 added

## Perf (head-to-head vs jotai, sub+unsub on chain of N unsubscribed derived deps)

| Depth | Before | After |
|-------|--------|-------|
| N=50  | 1.0x parity | 1.0x parity |
| N=100 | 1.1x faster | 1.1x faster |
| N=500 | ~26x slower (trampoline) | **1.1x faster** (275µs vs 300µs) |

## Behavior change

Selector chains beyond the JS engine's call stack capacity (~thousands of levels in practice) now throw `RangeError` (possibly wrapped in `SelectorEvaluationError`) instead of falling back to iterative evaluation. Matches jotai's failure mode. Applies only to chains far deeper than realistic application code.

## Test plan

- [x] `bun test` in `packages/valdres`: 291/291 pass
- [x] `bun test --timeout 60000 --concurrency 1 ./packages/valdres/test/performance/selector.bench.ts`: 7/7 pass, all within 2.0x `assertFaster` threshold
- [x] Deep-chain happy path tests updated to depth 200 (the prior trampoline-exercising depth, now pure recursion)
- [x] New overflow test asserts we throw past the engine's stack ceiling
- [x] Changeset added — minor bump for `valdres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)