### PR TITLE
Move selector eval state to StoreData

### DIFF
--- a/.changeset/per-store-selector-eval-state.md
+++ b/.changeset/per-store-selector-eval-state.md
@@ -1,0 +1,18 @@
+---
+"valdres": patch
+---
+
+Move selector evaluation state (`circularDepSet`, `latestEvalContext`) from
+module-level to `StoreData`. Two fixes:
+
+- The same selector evaluated across two stores no longer triggers a spurious
+  `SelectorCircularDependencyError` when one store's evaluation
+  synchronously asks another store for the same selector.
+- Async selectors with deferred (post-await) `get` calls now correctly
+  register dependencies even when the same selector is evaluated concurrently
+  in another store. Previously the second store's eval would mark the first
+  store's eval context `revoked`, causing the deferred `get` to fall into the
+  read-only "stale closure" branch and silently drop dep registration.
+
+Both sets allocate lazily on first access (same pattern as the other per-store
+maps), so store creation overhead is unchanged.

--- a/packages/valdres/src/lib/asyncDependencyTracking.ts
+++ b/packages/valdres/src/lib/asyncDependencyTracking.ts
@@ -10,11 +10,6 @@ import { isLive, mountTransitiveDeps, onLiveDependencyAdded } from "./mountAtom"
 // resolves, handleSelectorResult reads this to reconcile stale deps.
 export const pendingAsyncDeps = new WeakMap<Promise<any>, Set<State>>()
 
-// Tracks the latest evaluation context per selector so that stale closures
-// (from previous evaluations) can detect they are outdated and avoid
-// registering phantom dependencies.
-export const latestEvalContext = new WeakMap<Selector, { revoked: boolean }>()
-
 export class SuspendAndWaitForResolveError extends Error {
     promise: Promise<any>
     constructor(promise: Promise<any>) {

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -3,16 +3,16 @@ import type { ScopedStoreData, StoreData } from "../types/StoreData"
 let nextId = 0
 const generateId = () => "__valdres_store_" + nextId++
 
-function makeLazyGetter(key: string) {
+function makeLazyGetter(key: string, factory: () => any = () => new WeakMap()) {
     return {
         get(this: any) {
-            const map = new WeakMap()
+            const value = factory()
             Object.defineProperty(this, key, {
-                value: map,
+                value,
                 writable: true,
                 configurable: true,
             })
-            return map
+            return value
         },
         configurable: true,
     }
@@ -29,6 +29,8 @@ Object.defineProperties(lazyProto, {
     liveDependentCount: makeLazyGetter("liveDependentCount"),
     abortControllers: makeLazyGetter("abortControllers"),
     lastValueWriteAt: makeLazyGetter("lastValueWriteAt"),
+    circularDepSet: makeLazyGetter("circularDepSet", () => new WeakSet()),
+    latestEvalContext: makeLazyGetter("latestEvalContext"),
 })
 
 export type CreateStoreDataOptions = {

--- a/packages/valdres/src/lib/initSelector.crossStore.test.ts
+++ b/packages/valdres/src/lib/initSelector.crossStore.test.ts
@@ -77,8 +77,7 @@ describe("cross-store selector eval — module-level state audit", () => {
 
         // After the deferred get(b) in store1, `b` should be a registered
         // dependency of `sel` in store1. With the bug, it isn't.
-        const s1Data = (s1 as any)._data ?? (s1 as any).data
-        const deps = s1Data.stateDependencies.get(sel) as Set<unknown> | undefined
+        const deps = s1.data.stateDependencies.get(sel) as Set<unknown> | undefined
         expect(deps).toBeDefined()
         expect(deps!.has(b)).toBe(true)
     })

--- a/packages/valdres/src/lib/initSelector.crossStore.test.ts
+++ b/packages/valdres/src/lib/initSelector.crossStore.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect } from "bun:test"
+import { store } from "../store"
+import { atom } from "../atom"
+import { selector } from "../selector"
+
+describe("cross-store selector eval — module-level state audit", () => {
+    test("short cross-store read works", () => {
+        const a2 = atom(10)
+        const s2sel = selector(get => get(a2) + 100)
+        const s2 = store()
+        const proxy = selector(_get => s2.get(s2sel))
+        const s1 = store()
+        expect(s1.get(proxy)).toBe(110)
+    })
+
+    test("deep chain in store2 read from inside a store1 selector body", () => {
+        const a2 = atom(0)
+        const chain2: any[] = [selector(get => get(a2) + 1)]
+        for (let i = 1; i < 150; i++) {
+            const prev = chain2[i - 1]
+            chain2.push(selector(get => get(prev) + 1))
+        }
+        const s2 = store()
+        const tail2 = chain2[chain2.length - 1]
+        const proxy = selector(_get => s2.get(tail2))
+        const s1 = store()
+        expect(s1.get(proxy)).toBe(150)
+    })
+
+    test("same selector nested-evaluated across two stores does NOT throw spurious cycle", () => {
+        // sel's body, while evaluating in store1, synchronously evaluates
+        // itself in store2. Two independent evaluations — not a real cycle.
+        const a = atom(1)
+        let allowCrossStore = false
+        const s2 = store()
+        const sel: any = selector(get => {
+            const v = get(a)
+            if (allowCrossStore) {
+                allowCrossStore = false
+                return v + s2.get(sel)
+            }
+            return v
+        })
+        const s1 = store()
+        allowCrossStore = true
+        expect(s1.get(sel)).toBe(2)
+    })
+
+    test("latestEvalContext: store2 eval does NOT revoke store1's deferred get tracking", async () => {
+        // sel returns a promise. Inside that promise's resolution, sel calls
+        // `get(b)` — a deferred (post-async) read. If latestEvalContext is
+        // module-level, store2's later eval of `sel` flips store1's evalCtx
+        // to `revoked: true`. Store1's deferred get then falls through the
+        // "stale closure" branch, returning the value WITHOUT registering
+        // the dep. Subsequent mutations of `b` won't dirty `sel` in store1.
+        const a = atom(1)
+        const b = atom(10)
+        const sel: any = selector((get, _opts) => {
+            const va = get(a)
+            return Promise.resolve().then(() => va + get(b))
+        })
+        const s1 = store()
+        const s2 = store()
+
+        // Initial eval in s1 — kicks off async resolution
+        const p1 = s1.get(sel)
+        expect(p1).toBeInstanceOf(Promise)
+
+        // Before s1's promise resolves, evaluate sel in s2.
+        // This calls latestEvalContext.set(sel, ctx2) and marks s1's ctx as revoked.
+        const p2 = s2.get(sel)
+        expect(p2).toBeInstanceOf(Promise)
+
+        // Let microtasks drain so the deferred get(b) in each store fires.
+        await p1
+        await p2
+
+        // After the deferred get(b) in store1, `b` should be a registered
+        // dependency of `sel` in store1. With the bug, it isn't.
+        const s1Data = (s1 as any)._data ?? (s1 as any).data
+        const deps = s1Data.stateDependencies.get(sel) as Set<unknown> | undefined
+        expect(deps).toBeDefined()
+        expect(deps!.has(b)).toBe(true)
+    })
+})

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -10,7 +10,6 @@ import {
     cleanUpRejectedPromise,
     getOrInitDependentsSet,
     lateGet,
-    latestEvalContext,
     pendingAsyncDeps,
 } from "./asyncDependencyTracking"
 import { getState } from "./getState"
@@ -23,10 +22,6 @@ import { setValueInData } from "./setValueInData"
 
 export { isSuspendError } from "./asyncDependencyTracking"
 
-// Shared WeakSet for circular dependency detection — safe to reuse because
-// evaluation is synchronous and each selector adds/deletes itself.
-const sharedCircularDepSet = new WeakSet()
-
 // Static signal for known-sync selectors — avoids AbortController allocation.
 const neverAbortedSignal = new AbortController().signal
 
@@ -37,7 +32,7 @@ export const evaluateSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet = sharedCircularDepSet,
+    circularDependencySet: WeakSet<any> = data.circularDepSet,
     addedDepsOut?: Set<State>,
     removedDepsOut?: Set<State>,
 ) => {
@@ -48,6 +43,7 @@ export const evaluateSelector = <V>(
 
     // Revoke any previous late-binding closure for this selector so that
     // deferred get calls from old evaluations become read-only.
+    const latestEvalContext = data.latestEvalContext
     const prevCtx = latestEvalContext.get(selector)
     if (prevCtx) prevCtx.revoked = true
     const evalCtx = { revoked: false }
@@ -201,10 +197,11 @@ export const evaluateSelector = <V>(
 
         return result
     } finally {
-        // sharedCircularDepSet is module-level, so cleanup must run on every
-        // exit path — including SelectorEvaluationError rethrows and any
-        // throw from the dep-tracking code above. Otherwise the selector
-        // leaks into the set and the next read trips a spurious cycle check.
+        // The set is reused across selector evaluations within the same
+        // store, so cleanup must run on every exit path — including
+        // SelectorEvaluationError rethrows and any throw from the
+        // dep-tracking code above. Otherwise the selector leaks into the
+        // set and the next read trips a spurious cycle check.
         circularDependencySet.delete(selector)
     }
 }
@@ -309,7 +306,7 @@ export const initSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any> = sharedCircularDepSet,
+    circularDependencySet: WeakSet<any> = data.circularDepSet,
 ): boolean => {
     const existingValue = data.values.get(selector)
     const updatedValue = evaluate(

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -32,7 +32,7 @@ export const evaluateSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any> = data.circularDepSet,
+    circularDependencySet: WeakSet<Selector> = data.circularDepSet,
     addedDepsOut?: Set<State>,
     removedDepsOut?: Set<State>,
 ) => {
@@ -306,7 +306,7 @@ export const initSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any> = data.circularDepSet,
+    circularDependencySet: WeakSet<Selector> = data.circularDepSet,
 ): boolean => {
     const existingValue = data.values.get(selector)
     const updatedValue = evaluate(
@@ -334,7 +334,7 @@ const evaluate = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<any>,
+    circularDependencySet: WeakSet<Selector>,
 ) => {
     let tmpValue
     try {

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -1,3 +1,4 @@
+import type { Selector } from "./Selector"
 import type { Store } from "./Store"
 import type { Subscription } from "./Subscription"
 
@@ -15,6 +16,16 @@ export type RootStoreData = {
      *  on sub/unsub and on dep add/remove instead of walking the graph. */
     liveDependentCount: WeakMap<WeakKey, number>
     abortControllers: WeakMap<WeakKey, AbortController | false>
+    /** Selectors currently mid-evaluation in this store. Used for cycle
+     *  detection. Per-store so that the same selector evaluated in two
+     *  stores doesn't trigger a spurious cycle. Add at evaluateSelector
+     *  entry, delete in `finally` — balanced over synchronous eval. */
+    circularDepSet: WeakSet<Selector>
+    /** Latest evaluation context per selector for revoking deferred (post-
+     *  await) `get` calls from superseded evaluations. Per-store so that
+     *  store2 evaluating a shared selector doesn't silently strip dep
+     *  registration from store1's in-flight async eval. */
+    latestEvalContext: WeakMap<Selector, { revoked: boolean }>
     /** Per-atom timestamp of the last value write, used for lazy
      *  maxAge revalidation when the atom is unmounted (no active timer
      *  to keep the cache fresh). Only populated for atoms with `maxAge`. */


### PR DESCRIPTION
## Summary

`circularDepSet` and `latestEvalContext` were module-level WeakSet/WeakMap shared across every store. Surfaced by the audit on `initSelector.ts`. Moves both onto `StoreData` using the existing lazy-getter prototype pattern.

## Bugs fixed (red tests in `packages/valdres/src/lib/initSelector.crossStore.test.ts`)

1. **Spurious cross-store cycle.** A selector evaluated in store1 that synchronously asks store2 for the same selector threw `SelectorCircularDependencyError` — the shared `WeakSet` treated independent evaluations as a re-entry.

2. **Lost dep registration on async deferred reads.** When two stores evaluated the same async selector concurrently, the second eval set `latestEvalContext` for the selector to a new context and marked the first store's context `revoked: true`. The first store's deferred (post-await) `get` then fell into the read-only "stale closure" branch, returning the value but skipping dep registration entirely. Atom mutations would silently fail to dirty the selector.

## Perf

Lazy allocation preserved (allocates on first selector eval per store; no allocation for stores that never read selectors). Bench deltas vs `origin/main`:

| Bench | Before | After |
| - | - | - |
| `selector(fn)` | 4ns | 3ns |
| set+read 10 selectors | 3.5µs | 3.7µs |
| set+read 100 selectors | 33.2µs | 31.5µs |
| sub+unsub 500 chain | 272µs | 260µs |
| set+read 5 chained | 2.8µs | 2.6µs |
| `createStore` | 139ns | 139ns |
| `store.get(atom)` | 8ns | 8ns |

All within noise; nothing regressed.

## Test plan

- [x] `bun test src/lib/initSelector.crossStore.test.ts` — 4 pass (the 2 new red tests now green, 2 existing cross-store sanity tests stay green)
- [x] `bun test src` (valdres core) — 251 pass, 0 fail
- [x] `bunx tsgo --noEmit` — clean
- [x] `bun test ./test/performance/{selector,atom,store,cleanup-walk}.bench.ts` — head-to-head ratios unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)