### PR TITLE
Move pending-default suspense placeholder off the Promise instance

### DIFF
--- a/.changeset/pending-default-on-store.md
+++ b/.changeset/pending-default-on-store.md
@@ -1,0 +1,14 @@
+---
+"valdres": patch
+---
+
+Move the pending-default suspense placeholder for atoms declared with no
+`defaultValue` from monkey-patched `__isEmptyAtomPromise__` /
+`__resolveEmptyAtomPromise__` / `__emptyAtomPromiseOrigin__` properties on
+Promise instances to a `WeakMap` on the store data. The Promise returned by
+`get()` is now a plain Promise with no internal markers leaked to user code.
+
+Fixes two latent bugs along the way: a sync `set()` after an in-flight async
+`set()` on an empty atom now resolves the suspense placeholder (previously it
+hung); and `set()` from a scoped store on an empty atom inited in a parent
+now resolves the placeholder via the scope chain (previously hung).

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -29,6 +29,7 @@ Object.defineProperties(lazyProto, {
     liveDependentCount: makeLazyGetter("liveDependentCount"),
     abortControllers: makeLazyGetter("abortControllers"),
     lastValueWriteAt: makeLazyGetter("lastValueWriteAt"),
+    pendingDefaults: makeLazyGetter("pendingDefaults"),
 })
 
 export type CreateStoreDataOptions = {

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -29,7 +29,6 @@ Object.defineProperties(lazyProto, {
     liveDependentCount: makeLazyGetter("liveDependentCount"),
     abortControllers: makeLazyGetter("abortControllers"),
     lastValueWriteAt: makeLazyGetter("lastValueWriteAt"),
-    pendingDefaults: makeLazyGetter("pendingDefaults"),
 })
 
 export type CreateStoreDataOptions = {
@@ -44,6 +43,11 @@ export function createStoreData(id?: string, parent?: StoreData, options?: Creat
     data.values = new WeakMap()
     data.scopes = new Map()
     data.scopeValueIndex = new WeakMap()
+    // Eager (not lazy) because resolvePendingDefault in setAtom walks every
+    // store in the scope chain on every setAtom call. Lazy would still
+    // allocate on first setAtom — eager just makes that explicit and avoids
+    // touching the prototype getter on the hot path.
+    data.pendingDefaults = new WeakMap()
     if (options?.batchUpdates) {
         data.batchUpdates = true
     }

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -14,14 +14,11 @@ export const getAtomInitValue = <V = any>(
     initializedAtomsSet: Set<Atom>,
 ) => {
     if (atom.defaultValue === undefined) {
-        let promiseResolve: (value: any) => void
-        const promise = new Promise(resolve => {
-            promiseResolve = resolve
+        let resolve!: (value: any) => void
+        const promise = new Promise(r => {
+            resolve = r
         })
-        // @ts-ignore @ts-todo
-        promise.__isEmptyAtomPromise__ = true
-        // @ts-ignore @ts-todo
-        promise.__resolveEmptyAtomPromise__ = promiseResolve
+        data.pendingDefaults.set(atom, { promise, resolve })
         return promise
     } else if (typeof atom.defaultValue === "function") {
         // @ts-ignore @ts-todo

--- a/packages/valdres/src/lib/setAtom.test.ts
+++ b/packages/valdres/src/lib/setAtom.test.ts
@@ -195,7 +195,7 @@ describe("setAtom", () => {
         expect(onSetMock).toHaveBeenCalledWith("updated", store1.data)
     })
 
-    test("async updater resolves __isEmptyAtomPromise__", async () => {
+    test("async updater resolves pending-default suspense promise", async () => {
         const store1 = store()
         const emptyAtom = atom<string>()
 
@@ -254,6 +254,41 @@ describe("setAtom", () => {
         const suspenseResult = await suspensePromise
         expect(suspenseResult).toBe("second")
         expect(store1.get(emptyAtom)).toBe("second")
+    })
+
+    test("sync set after in-flight async set on empty atom resolves suspense promise", async () => {
+        const store1 = store()
+        const emptyAtom = atom<string>()
+
+        // Reading gives us the suspense placeholder
+        const suspensePromise = store1.get(emptyAtom) as Promise<string>
+
+        // In-flight async set overwrites the placeholder in values with a
+        // user-supplied promise that never resolves.
+        const pending = new Promise<string>(() => {})
+        setAtom(emptyAtom, () => pending, store1.data)
+
+        // Sync set lands a real value. The placeholder must still resolve,
+        // even though currentValue is now the user promise, not the placeholder.
+        setAtom(emptyAtom, "done", store1.data)
+
+        const suspenseResult = await suspensePromise
+        expect(suspenseResult).toBe("done")
+        expect(store1.get(emptyAtom)).toBe("done")
+    })
+
+    test("set in scoped store resolves suspense promise inited in root", async () => {
+        const root = store()
+        const scoped = root.scope("s1")
+        const emptyAtom = atom<string>()
+
+        // Reading from the scope falls through to root, where the
+        // pending-default placeholder is registered.
+        const suspense = scoped.get(emptyAtom) as Promise<string>
+        scoped.set(emptyAtom, "hello")
+
+        const resolved = await suspense
+        expect(resolved).toBe("hello")
     })
 
     test("async updater onSet throwing does not escape as unhandled rejection", async () => {

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -7,6 +7,28 @@ import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { setValueInData } from "./setValueInData"
 
+/** Resolve any outstanding pending-default suspense placeholder for `atom`
+ *  and remove it. The placeholder may have been registered in a parent
+ *  store (atoms with no `defaultValue` init in whichever scope first reads
+ *  them, which `getState` resolves by walking up to root), so we walk the
+ *  scope chain rather than only checking `data`. */
+const resolvePendingDefault = <Value>(
+    atom: Atom<Value>,
+    data: StoreData,
+    value: Value,
+) => {
+    let cur: StoreData | undefined = data
+    while (cur) {
+        const entry = cur.pendingDefaults.get(atom)
+        if (entry) {
+            entry.resolve(value)
+            cur.pendingDefaults.delete(atom)
+            return
+        }
+        cur = "parent" in cur ? cur.parent : undefined
+    }
+}
+
 const handlePromise = <Value>(
     atom: Atom<Value>,
     promise: Promise<Value>,
@@ -14,15 +36,6 @@ const handlePromise = <Value>(
     data: StoreData,
     skipOnSet: boolean,
 ) => {
-    // @ts-ignore
-    const emptyAtomPromise = currentValue?.__isEmptyAtomPromise__
-        ? currentValue
-        // @ts-ignore
-        : currentValue?.__emptyAtomPromiseOrigin__ ?? null
-    if (emptyAtomPromise) {
-        // @ts-ignore
-        promise.__emptyAtomPromiseOrigin__ = emptyAtomPromise
-    }
     setValueInData(atom, promise as Value, data)
     promise
         .then(resolvedValue => {
@@ -30,10 +43,7 @@ const handlePromise = <Value>(
             if (data.values.get(atom) !== promise) return
             setValueInData(atom, resolvedValue, data)
             if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
-            if (emptyAtomPromise) {
-                // @ts-ignore
-                emptyAtomPromise.__resolveEmptyAtomPromise__(resolvedValue)
-            }
+            resolvePendingDefault(atom, data, resolvedValue)
             propagateAtomUpdate([atom], data)
         })
         // Chained .catch so errors thrown inside the fulfilled handler
@@ -91,11 +101,7 @@ export const setAtom = <Value = any>(
     if (areEqual) return syncValue
     syncValue = setValueInData(atom, syncValue, data)
     if (atom.onSet && !skipOnSet) atom.onSet(syncValue, data)
-    // @ts-ignore
-    if (currentValue?.__isEmptyAtomPromise__) {
-        // @ts-ignore
-        currentValue.__resolveEmptyAtomPromise__(syncValue)
-    }
+    resolvePendingDefault(atom, data, syncValue)
     if (initializedAtomsSet && initializedAtomsSet.size > 0) {
         initializedAtomsSet.add(atom)
         propagateAtomUpdate([...initializedAtomsSet], data)

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -19,6 +19,13 @@ export type RootStoreData = {
      *  maxAge revalidation when the atom is unmounted (no active timer
      *  to keep the cache fresh). Only populated for atoms with `maxAge`. */
     lastValueWriteAt: WeakMap<WeakKey, number>
+    /** Per-atom suspense placeholder for atoms declared with no
+     *  `defaultValue`. The first read creates an unresolved promise that
+     *  external readers (Suspense, `await store.get(atom)`) hold; the
+     *  next `setAtom` resolves it with the eventual value. Keyed by atom
+     *  identity so the lifecycle is independent of the promise stored in
+     *  `values` (which may be replaced by user-supplied async sets). */
+    pendingDefaults: WeakMap<WeakKey, { promise: Promise<any>; resolve: (value: any) => void }>
     storeRef?: Store
     scopes: Map<string, ScopedStoreData>
     batchUpdates?: boolean


### PR DESCRIPTION
## Summary
- Replace `__isEmptyAtomPromise__` / `__resolveEmptyAtomPromise__` / `__emptyAtomPromiseOrigin__` Promise monkey-patching with a `WeakMap<Atom, { promise, resolve }>` on `StoreData`. The Promise returned from `get()` is now plain.
- Drops 6 `@ts-ignore`s and the entire "origin chain" concept (per-atom keying makes per-promise back-pointers unnecessary).
- Fixes a latent leak: the prior implementation mutated *user-supplied* promises (`promise.__emptyAtomPromiseOrigin__ = ...`), which user code can observe via `get()` and which would throw under SES/Hardened JS.

## Bugs fixed along the way (each with a regression test)
- **Sync `set()` after in-flight async `set()` on empty atom** — the suspense placeholder hung forever because the sync branch only checked `currentValue.__isEmptyAtomPromise__`, which was false once an async set had overwritten `values` with a user promise. New code looks up by atom identity, so it always finds the entry. Regression test in `setAtom.test.ts` ("sync set after in-flight async set on empty atom resolves suspense promise").
- **`set()` in a scoped store on an empty atom inited in the parent** — `getState` walks up to root to init empty atoms, so the placeholder lives in root's `pendingDefaults`. The resolver now walks the scope chain to find it. Regression test in `setAtom.test.ts` ("set in scoped store resolves suspense promise inited in root").

## Test plan
- [x] `bun test` in `packages/valdres` — 293 pass, 0 fail (was 291; +2 regression tests)
- [x] Adapter suites green: `valdres-react` (47), `valdres-vue` (31), `valdres-solid` (27), `valdres-svelte` (16), `valdres-angular` (44)
- [x] `bunx tsc --noEmit` in `packages/valdres` — clean
- [x] Both new tests verified red on the pre-refactor code, green after