### PR TITLE
Allow user-provided onSet on global atoms

### DIFF
--- a/.changeset/global-atom-on-set.md
+++ b/.changeset/global-atom-on-set.md
@@ -1,0 +1,10 @@
+---
+"valdres": minor
+---
+
+Allow user-provided `onSet` on global atoms. Previously, passing `onSet` to
+`atom(value, { global: true, onSet })` threw at construction because the
+field was reserved for the internal cross-store sync mechanism. The factory
+now composes both: cross-store sync runs first (peers receive the update
+with `skipOnSet=true`, so the user hook does not double-fire), then the
+user hook is invoked once, in the originating store.

--- a/packages/valdres/src/lib/globalAtom.test.ts
+++ b/packages/valdres/src/lib/globalAtom.test.ts
@@ -744,4 +744,44 @@ describe("globalAtom", () => {
 
         expect(callCount).toBe(countAfterReset)
     })
+
+    test("user-provided onSet fires alongside cross-store sync", () => {
+        const store1 = store()
+        const store2 = store()
+        const onSet = mock(() => {})
+        const numberAtom = atom(0, { global: true, onSet })
+
+        store1.set(numberAtom, 1)
+
+        // Cross-store sync still works
+        expect(store1.get(numberAtom)).toBe(1)
+        expect(store2.get(numberAtom)).toBe(1)
+
+        // User hook fires once, in the originating store, with the new value
+        expect(onSet).toHaveBeenCalledTimes(1)
+        expect(onSet).toHaveBeenCalledWith(1, store1.data)
+
+        store2.set(numberAtom, 2)
+        expect(onSet).toHaveBeenCalledTimes(2)
+        expect(onSet).toHaveBeenLastCalledWith(2, store2.data)
+    })
+
+    test("user-provided onSet fires once on setSelf with globalStore as originator", async () => {
+        const { globalStore } = await import("../globalStore")
+        const store1 = store()
+        const store2 = store()
+        const onSet = mock(() => {})
+        const numberAtom = atom(0, { global: true, onSet })
+
+        // Touch the atom from peer stores so they're registered for sync.
+        store1.get(numberAtom)
+        store2.get(numberAtom)
+
+        numberAtom.setSelf(7)
+
+        expect(store1.get(numberAtom)).toBe(7)
+        expect(store2.get(numberAtom)).toBe(7)
+        expect(onSet).toHaveBeenCalledTimes(1)
+        expect(onSet).toHaveBeenCalledWith(7, globalStore.data)
+    })
 })

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -18,8 +18,7 @@ export const globalAtom = <Value = unknown>(
     options: AtomOptions<Value>,
 ) => {
     const stores = new Set<StoreData>()
-    if (options.onSet)
-        throw new Error("onSet on globalAtom is currently not supported")
+    const userOnSet = options.onSet
 
     // Sync the atom's current value into a store on first access. Called by
     // initAtom whenever a store touches this atom for the first time.
@@ -28,6 +27,8 @@ export const globalAtom = <Value = unknown>(
         stores.add(data)
     }
 
+    // Cross-store sync propagates to peers with skipOnSet=true, so the user
+    // hook fires exactly once per set — in the originating store.
     const onSet: AtomOnSet<Value> = (newValue, currentStore) => {
         if (stores.size > 1) {
             for (const store of stores) {
@@ -36,6 +37,7 @@ export const globalAtom = <Value = unknown>(
                 }
             }
         }
+        userOnSet?.(newValue, currentStore)
     }
 
     // For global atoms, options.onMount fires when the FIRST subscriber across


### PR DESCRIPTION
## Summary

`globalAtom` previously threw at construction if you passed `options.onSet`, because the `onSet` field was reserved for the internal cross-store sync mechanism. This lifts that restriction by composing both behaviors in the factory.

- Cross-store sync still runs first; peers receive the update via `setAtom(..., skipOnSet=true)`, so the user hook does not double-fire.
- The user `onSet` fires exactly once per logical set, in the originating store. For `setSelf` the originator is `globalStore.data`.
- No type changes. `AtomOptions.onSet` was already typed — this just makes it honored on global atoms.

## Test plan

- [x] New: `user-provided onSet fires alongside cross-store sync` — confirms one call per set in the originating store, sync still propagates to peers.
- [x] New: `user-provided onSet fires once on setSelf with globalStore as originator` — pins down the originator contract for `setSelf`.
- [x] All 293 existing valdres core tests pass.

## Notes

Latent fragility I noticed but did not change: `setAtoms.ts:22` does not honor `skipOnSet`. Today it's not exercised by cross-store sync (which uses `setAtom` singular), but a future change routing sync through `setAtoms` would loop. Worth a follow-up but out of scope here.