### PR TITLE
Unify StoreData type and fix maxAge × scope shadow surprises

### DIFF
--- a/.changeset/scope-maxage-and-type-unify.md
+++ b/.changeset/scope-maxage-and-type-unify.md
@@ -1,0 +1,19 @@
+---
+"valdres": patch
+---
+
+Unify `RootStoreData` and `ScopedStoreData` into a single `StoreData` shape
+with an optional `parent`. Structural `"parent" in data` branches collapse
+to `data.parent` checks, dropping three `@ts-ignore @ts-todo` markers from
+`getState.ts` and `transaction.ts`.
+
+Fix two surprises around `maxAge` × scope shadows:
+
+- `scope.set(maxAgeAtom, value)` is now a deliberate pin. The lazy
+  revalidation guard in `isCachedValueStale` no longer evicts scope-local
+  values past their TTL, so the shadow survives an unsubscribed read
+  instead of silently falling back to the parent.
+- Subscribing to a scope-shadowed `maxAge` atom no longer installs a
+  second, scope-local revalidation timer that would overwrite the shadow
+  and double-invoke `defaultValue()`. Non-shadowed scope subscriptions
+  continue to delegate up to the parent's timer as before.

--- a/packages/valdres/src/lib/atomFamilyIndex.ts
+++ b/packages/valdres/src/lib/atomFamilyIndex.ts
@@ -1,6 +1,6 @@
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { Family } from "../types/Family"
-import type { ScopedStoreData, StoreData } from "../types/StoreData"
+import type { StoreData } from "../types/StoreData"
 import { trackScopeValue } from "./setValueInData"
 
 // @ts-ignore
@@ -107,14 +107,14 @@ export const deleteFamilyAtomsFromSet = (
 const initFamilyIndex = (family: Family<any>, data: StoreData) => {
     if (data.values.has(family)) return data.values.get(family).__index
     let parentIndex
-    if ("parent" in data) {
+    if (data.parent) {
         parentIndex = initFamilyIndex(family, data.parent)
         if (!parentIndex) throw new Error("Parent index is missing")
     }
     const index = createAtomFamilyIndex(parentIndex)
     data.values.set(family, renderAtomFamilyIndex(index))
-    if ("parent" in data) {
-        trackScopeValue(family, data as ScopedStoreData)
+    if (data.parent) {
+        trackScopeValue(family, data)
     }
     return index
 }

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -1,4 +1,4 @@
-import type { ScopedStoreData, StoreData } from "../types/StoreData"
+import type { StoreData } from "../types/StoreData"
 
 let nextId = 0
 const generateId = () => "__valdres_store_" + nextId++
@@ -35,9 +35,11 @@ export type CreateStoreDataOptions = {
     batchUpdates?: boolean
 }
 
-export function createStoreData(id?: string, parent?: undefined, options?: CreateStoreDataOptions): StoreData
-export function createStoreData(id: string, parent: StoreData, options?: CreateStoreDataOptions): ScopedStoreData
-export function createStoreData(id?: string, parent?: StoreData, options?: CreateStoreDataOptions) {
+export function createStoreData(
+    id?: string,
+    parent?: StoreData,
+    options?: CreateStoreDataOptions,
+): StoreData {
     const data: any = Object.create(lazyProto)
     data.id = id ?? generateId()
     data.values = new WeakMap()

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -58,7 +58,7 @@ export function getState<
 ) {
     if (data.values.has(state)) return data.values.get(state)
     if (isAtom<Value>(state)) {
-        if ("parent" in data)
+        if (data.parent)
             return getState<Value, Args>(
                 state,
                 data.parent,
@@ -87,13 +87,8 @@ export function getState<
         return data.values.get(state)
     }
     if (isAtomFamily<Value, Args>(state)) {
-        if ("parent" in data) {
-            const closestData = findClosestStoreWithAtomInitialized<Set<Args>>(
-                // @ts-ignore @ts-todo
-                state,
-                data,
-            )
-            // @ts-ignore @ts-todo
+        if (data.parent) {
+            const closestData = findClosestStoreWithAtomInitialized(state, data)
             return getState<Value, Args>(
                 state,
                 closestData,
@@ -117,11 +112,11 @@ export function getState<
     throw new Error("Invalid object passed to get")
 }
 
-const findClosestStoreWithAtomInitialized = <V>(
-    atom: Atom<V>,
+const findClosestStoreWithAtomInitialized = (
+    atom: Atom | AtomFamily<any, any>,
     data: StoreData,
-) => {
-    if ("parent" in data === false) return data
+): StoreData => {
+    if (!data.parent) return data
     if (data.values.has(atom)) return data
     return findClosestStoreWithAtomInitialized(atom, data.parent)
 }

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -133,7 +133,7 @@ export const globalAtom = <Value = unknown>(
             // Match subscribe.ts: maxAge timer is installed only when the
             // atom has a DIRECT subscriber. Transitive (selector-only)
             // subscribers go through the lazy-revalidation path on read.
-            if (atom.maxAge && (s.subscriptions.get(atom)?.size ?? 0) > 0) {
+            if (atom.maxAge !== undefined && (s.subscriptions.get(atom)?.size ?? 0) > 0) {
                 installMaxAgeTimer(atom, s)
             }
             try {

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -121,7 +121,7 @@ const findClosestStoreWithAtomInitialized = (
     atom: State | Family<any>,
     data: StoreData,
 ) => {
-    if ("parent" in data === false) return data
+    if (!data.parent) return data
     if (data.values.has(atom)) return data
     return findClosestStoreWithAtomInitialized(atom, data.parent)
 }

--- a/packages/valdres/src/lib/scope.test.ts
+++ b/packages/valdres/src/lib/scope.test.ts
@@ -1,0 +1,458 @@
+import { describe, test, expect, mock } from "bun:test"
+import { store } from "../store"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+describe("deep nesting (4+ levels)", () => {
+    test("grandparent atom read from great-grandchild walks the chain", () => {
+        const A = store("A")
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+        const E = D.scope("E")
+
+        const greeting = atom("hello")
+        A.set(greeting, "from-A")
+
+        // E reads through 4 ancestors back to A
+        expect(E.get(greeting)).toBe("from-A")
+        // No intermediate scope shadowed it, so the value lives only on A
+        expect(A.data.values.has(greeting)).toBe(true)
+        expect(B.data.values.has(greeting)).toBe(false)
+        expect(C.data.values.has(greeting)).toBe(false)
+        expect(D.data.values.has(greeting)).toBe(false)
+        expect(E.data.values.has(greeting)).toBe(false)
+    })
+
+    test("shadow at mid-level masks ancestor for descendants only", () => {
+        const A = store("A")
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+        const E = D.scope("E")
+
+        const counter = atom(0)
+        A.set(counter, 1)
+        C.set(counter, 100) // shadow at C — D and E see 100, A and B see 1
+
+        expect(A.get(counter)).toBe(1)
+        expect(B.get(counter)).toBe(1)
+        expect(C.get(counter)).toBe(100)
+        expect(D.get(counter)).toBe(100)
+        expect(E.get(counter)).toBe(100)
+    })
+
+    test("update at root propagates to subscriber 4 levels deep", () => {
+        const A = store("A")
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+        const E = D.scope("E")
+
+        const a = atom(1)
+        const sel = selector(get => get(a) * 10)
+
+        const eCallback = mock(() => {})
+        E.sub(sel, eCallback)
+        expect(E.get(sel)).toBe(10)
+
+        A.set(a, 5)
+        expect(eCallback).toHaveBeenCalledTimes(1)
+        expect(E.get(sel)).toBe(50)
+
+        A.set(a, 7)
+        expect(eCallback).toHaveBeenCalledTimes(2)
+        expect(E.get(sel)).toBe(70)
+    })
+
+    test("shadow at level 3 stops propagation from root to level 5", () => {
+        const A = store("A")
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+        const E = D.scope("E")
+
+        const a = atom(1)
+        const sel = selector(get => get(a))
+
+        const eCallback = mock(() => {})
+        E.sub(sel, eCallback)
+
+        // C shadows — E now reads from C, not A
+        C.set(a, 100)
+        expect(eCallback).toHaveBeenCalledTimes(1)
+        expect(E.get(sel)).toBe(100)
+
+        // Root change should NOT reach E because C is shadowing
+        A.set(a, 2)
+        expect(eCallback).toHaveBeenCalledTimes(1)
+        expect(E.get(sel)).toBe(100)
+
+        // But changing C does propagate
+        C.set(a, 200)
+        expect(eCallback).toHaveBeenCalledTimes(2)
+        expect(E.get(sel)).toBe(200)
+    })
+
+    test("selector with two atoms — one from root, one from mid-level — re-evaluates correctly", () => {
+        const A = store("A")
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+
+        const a1 = atom(1) // stays in A
+        const a2 = atom(10)
+        A.set(a2, 10)
+        B.set(a2, 20) // shadow in B
+
+        const sumSel = selector(get => get(a1) + get(a2))
+
+        const dCallback = mock(() => {})
+        D.sub(sumSel, dCallback)
+        // D inherits a1 from A (1) and a2 from B (20)
+        expect(D.get(sumSel)).toBe(21)
+
+        A.set(a1, 5)
+        expect(dCallback).toHaveBeenCalledTimes(1)
+        expect(D.get(sumSel)).toBe(25)
+
+        B.set(a2, 30)
+        expect(dCallback).toHaveBeenCalledTimes(2)
+        expect(D.get(sumSel)).toBe(35)
+    })
+})
+
+describe("family deletion across scope levels", () => {
+    test("root del propagates 3 levels down through chained scope family indexes", () => {
+        const A = store("A")
+        const family = atomFamily<string>(undefined, { name: "f" })
+        const m1 = family("a")
+        const m2 = family("b")
+        const m3 = family("c")
+
+        A.set(m1, "1")
+        A.set(m2, "2")
+        A.set(m3, "3")
+
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+
+        // D adds its own member, forcing creation of family indexes
+        // up the chain in B, C, D
+        D.set(family("d-only"), "D")
+
+        const countSel = selector(get => get(family).length, { name: "count" })
+
+        expect(A.get(countSel)).toBe(3)
+        expect(D.get(countSel)).toBe(4)
+
+        const dCallback = mock(() => {})
+        D.sub(countSel, dCallback)
+
+        // Delete at the root — must walk down to D's family index
+        A.del(m2)
+
+        expect(dCallback).toHaveBeenCalledTimes(1)
+        expect(A.get(countSel)).toBe(2)
+        expect(D.get(countSel)).toBe(3)
+    })
+
+    test("scope shadows a member then root deletes it — scope retains its shadowed value", () => {
+        const A = store("A")
+        const family = atomFamily<string>(undefined, { name: "shadowFam" })
+        const k = family("k")
+
+        A.set(k, "root-val")
+
+        const B = A.scope("B")
+        B.set(k, "scope-val") // shadow
+
+        expect(A.get(k)).toBe("root-val")
+        expect(B.get(k)).toBe("scope-val")
+
+        const bCallback = mock(() => {})
+        B.sub(k, bCallback)
+
+        A.del(k)
+
+        // B's shadow keeps the value alive locally; B sees its own value still.
+        expect(B.get(k)).toBe("scope-val")
+        // B is not notified — its visible value didn't change.
+        expect(bCallback).toHaveBeenCalledTimes(0)
+    })
+
+    test("delete from mid-scope does not affect siblings", () => {
+        const A = store("A")
+        const family = atomFamily<string>(undefined, { name: "sibFam" })
+        A.set(family("x"), "x-root")
+
+        const B1 = A.scope("B1")
+        const B2 = A.scope("B2")
+
+        // B1 adds a member — clones family into B1's chain
+        B1.set(family("y"), "B1-y")
+        // B2 adds a different member — clones into B2
+        B2.set(family("z"), "B2-z")
+
+        const countSel = selector(get => get(family).length)
+
+        expect(B1.get(countSel)).toBe(2) // x + y
+        expect(B2.get(countSel)).toBe(2) // x + z
+
+        // Delete y at B1
+        B1.del(family("y"))
+
+        expect(B1.get(countSel)).toBe(1) // x
+        // B2 unaffected
+        expect(B2.get(countSel)).toBe(2) // x + z
+        // Root unaffected
+        expect(A.get(countSel)).toBe(1) // x
+    })
+})
+
+describe("subscribe / unsubscribe / resubscribe across scopes", () => {
+    test("subscribe in scope, unsubscribe, then resubscribe — parent-chain wiring still correct", () => {
+        const A = store("A")
+        const B = A.scope("B")
+
+        const a = atom(0)
+        const sel = selector(get => get(a) + 1)
+
+        const cb1 = mock(() => {})
+        const unsub1 = B.sub(sel, cb1)
+        expect(B.get(sel)).toBe(1)
+
+        A.set(a, 10)
+        expect(cb1).toHaveBeenCalledTimes(1)
+        expect(B.get(sel)).toBe(11)
+
+        unsub1()
+
+        // After unsub, an update at root should NOT call cb1 again
+        A.set(a, 20)
+        expect(cb1).toHaveBeenCalledTimes(1)
+
+        // Re-subscribe a fresh callback — the parent-chain wiring should
+        // re-initialize cleanly.
+        const cb2 = mock(() => {})
+        const unsub2 = B.sub(sel, cb2)
+        expect(B.get(sel)).toBe(21)
+
+        A.set(a, 30)
+        expect(cb2).toHaveBeenCalledTimes(1)
+        expect(B.get(sel)).toBe(31)
+        // cb1 still not re-fired
+        expect(cb1).toHaveBeenCalledTimes(1)
+
+        unsub2()
+    })
+
+    test("scope subscription delegates to parent until scope writes — then re-roots", () => {
+        const A = store("A")
+        const B = A.scope("B")
+
+        const a = atom("init")
+        const cb = mock(() => {})
+        B.sub(a, cb)
+
+        // Until B writes, B's subscription is registered up at A
+        expect(A.data.subscriptions.get(a)?.size).toBe(1)
+        expect(B.data.subscriptions.get(a)?.size).toBe(1)
+
+        // Root write notifies B's callback through the delegated subscription
+        A.set(a, "from-A")
+        expect(cb).toHaveBeenCalledTimes(1)
+
+        // Now B writes — should "re-root" the subscription to live in B
+        B.set(a, "from-B")
+        expect(cb).toHaveBeenCalledTimes(2)
+
+        // Subsequent A writes should NOT notify B (B has shadowed the value)
+        A.set(a, "from-A-2")
+        expect(cb).toHaveBeenCalledTimes(2)
+
+        // But B writes still do
+        B.set(a, "from-B-2")
+        expect(cb).toHaveBeenCalledTimes(3)
+    })
+
+    test("two subscriptions in same scope — unsubscribing one leaves the other functional", () => {
+        const A = store("A")
+        const B = A.scope("B")
+
+        const a = atom(0)
+
+        const cb1 = mock(() => {})
+        const cb2 = mock(() => {})
+        const unsub1 = B.sub(a, cb1)
+        const unsub2 = B.sub(a, cb2)
+
+        A.set(a, 1)
+        expect(cb1).toHaveBeenCalledTimes(1)
+        expect(cb2).toHaveBeenCalledTimes(1)
+
+        unsub1()
+
+        A.set(a, 2)
+        expect(cb1).toHaveBeenCalledTimes(1)
+        expect(cb2).toHaveBeenCalledTimes(2)
+
+        unsub2()
+
+        A.set(a, 3)
+        expect(cb2).toHaveBeenCalledTimes(2)
+    })
+})
+
+describe("maxAge interaction with scopes", () => {
+    test("scope reading a maxAge atom inherits root's cached value, no separate timer", async () => {
+        const A = store("A")
+        let count = 0
+        const a = atom(() => ++count, { maxAge: 20 })
+
+        const B = A.scope("B")
+
+        // Root subscribes — this installs the maxAge timer at root
+        const aCb = mock(() => {})
+        const unsub = A.sub(a, aCb)
+
+        expect(A.get(a)).toBe(1)
+        expect(B.get(a)).toBe(1) // inherits from A
+
+        // Wait long enough for the timer to fire twice
+        await wait(60)
+        unsub()
+
+        // Multiple ticks should have happened at root and B reads the latest
+        expect(count).toBeGreaterThan(1)
+        const latest = A.get(a)
+        expect(B.get(a)).toBe(latest)
+    })
+
+    test("scope.set(maxAgeAtom, value) pins the value — no scope-local timer runs", async () => {
+        // Setting a maxAge atom in a scope is a deliberate override. No
+        // scope-local revalidation timer is installed even when the scope
+        // subscribes, so the shadow survives indefinitely.
+        const A = store("A")
+        let count = 0
+        const a = atom(() => ++count, { maxAge: 15 })
+
+        const B = A.scope("B")
+        B.set(a, 999)
+        expect(B.data.values.get(a)).toBe(999)
+
+        const bUnsub = B.sub(a, () => {})
+
+        await wait(50)
+        bUnsub()
+
+        // B's shadow survived — no scope-local timer overwrote it.
+        expect(B.data.values.get(a)).toBe(999)
+        expect(B.get(a)).toBe(999)
+        // defaultValue() ran only during set() initialization (to read the
+        // prior value), not from any scope-local revalidation tick.
+        expect(count).toBe(1)
+    })
+
+    test("scope.set on maxAge atom: shadow survives past the freshness window without a subscriber", async () => {
+        // The lazy revalidation eviction in isCachedValueStale is skipped
+        // for scoped stores. Without this, an unsubscribed scope shadow
+        // would be dropped on the next stale read and silently fall back
+        // to the parent.
+        const A = store("A")
+        let count = 0
+        const a = atom(() => ++count, { maxAge: 10 })
+
+        const B = A.scope("B")
+        B.set(a, 999)
+
+        const aUnsub = A.sub(a, () => {})
+        await wait(40)
+        aUnsub()
+
+        // B's shadow is pinned regardless of TTL.
+        expect(B.get(a)).toBe(999)
+    })
+
+    test("non-shadowed scope read of a maxAge atom inherits root's revalidated value", async () => {
+        // No scope shadow: the scope simply walks up to the parent and sees
+        // the latest revalidated value. This confirms that the eviction
+        // exemption for scopes (in isCachedValueStale) does not break the
+        // normal inherited-read path.
+        const A = store("A")
+        let count = 0
+        const a = atom(() => ++count, { maxAge: 20 })
+
+        const B = A.scope("B")
+
+        const aUnsub = A.sub(a, () => {})
+        await wait(100)
+        aUnsub()
+
+        expect(B.get(a)).toBe(A.get(a))
+        expect(count).toBeGreaterThan(1)
+    })
+})
+
+describe("batchUpdates and scopes", () => {
+    test("batchUpdates option is inherited by scopes created via store.scope()", () => {
+        const A = store({ id: "A", batchUpdates: true })
+        const B = A.scope("B")
+        const C = B.scope("C")
+
+        expect(A.data.batchUpdates).toBe(true)
+        expect(B.data.batchUpdates).toBe(true)
+        expect(C.data.batchUpdates).toBe(true)
+    })
+
+    test("batched scope set is observable inside the same microtask via get", async () => {
+        const A = store({ id: "A", batchUpdates: true })
+        const B = A.scope("B")
+
+        const a = atom(0)
+        const cb = mock(() => {})
+        B.sub(a, cb)
+
+        B.set(a, 1)
+        B.set(a, 2)
+        B.set(a, 3)
+
+        // Within sync code, pending txn buffers writes; B.get goes through
+        // pending txn to see the in-flight value.
+        expect(B.get(a)).toBe(3)
+        // Callback has not yet fired because batched commit is queued
+        expect(cb).toHaveBeenCalledTimes(0)
+
+        await Promise.resolve()
+        await Promise.resolve()
+
+        // After microtasks flush, the subscriber sees the final batched value
+        expect(cb).toHaveBeenCalledTimes(1)
+        expect(B.get(a)).toBe(3)
+    })
+
+    test("non-batched root and batched scope (manual) do not cross-contaminate", async () => {
+        // Root non-batched (default), scope option only applies when scopes
+        // are auto-created — but here we verify the default behavior:
+        // batchUpdates does NOT spontaneously enable on a non-batched root.
+        const A = store("A")
+        const B = A.scope("B")
+
+        expect(A.data.batchUpdates).toBeUndefined()
+        expect(B.data.batchUpdates).toBeUndefined()
+
+        const a = atom(0)
+        const cb = mock(() => {})
+        B.sub(a, cb)
+
+        // Synchronous writes — should propagate immediately (no batching)
+        B.set(a, 1)
+        expect(cb).toHaveBeenCalledTimes(1)
+        B.set(a, 2)
+        expect(cb).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/valdres/src/lib/scope.test.ts
+++ b/packages/valdres/src/lib/scope.test.ts
@@ -1,8 +1,9 @@
-import { describe, test, expect, mock } from "bun:test"
+import { describe, test, expect, mock, spyOn } from "bun:test"
 import { store } from "../store"
 import { atom } from "../atom"
 import { atomFamily } from "../atomFamily"
 import { selector } from "../selector"
+import { trackScopeValue } from "./setValueInData"
 
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -454,5 +455,60 @@ describe("batchUpdates and scopes", () => {
         expect(cb).toHaveBeenCalledTimes(1)
         B.set(a, 2)
         expect(cb).toHaveBeenCalledTimes(2)
+    })
+})
+
+describe("regression: contract guards", () => {
+    // Red against the pre-fix code, which used `data.parent!` and
+    // `data.scopeIndexKeys!` and would throw a generic TypeError
+    // ("Cannot read properties of undefined") instead of a clear,
+    // contract-naming error when called on a root store.
+    test("trackScopeValue throws a clear error when called on a root store", () => {
+        const rootStore = store()
+        const a = atom(1)
+        expect(() => trackScopeValue(a, rootStore.data)).toThrow(
+            "trackScopeValue called on a root store",
+        )
+    })
+})
+
+describe("regression: maxAge: 0 is a valid TTL", () => {
+    // The type is `Reactive<number>`, so 0 is well-formed. The pre-fix
+    // truthiness checks (`if (!state.maxAge) return`, `&& state.maxAge`,
+    // `if (atom.maxAge && ...)`) treated it as unset and skipped the
+    // timer install, breaking the only observable contract: subscribing
+    // to a maxAge atom installs a setInterval.
+
+    test("subscribe installs maxAge timer for a regular atom with maxAge: 0", () => {
+        const setIntervalSpy = spyOn(globalThis, "setInterval")
+        const before = setIntervalSpy.mock.calls.length
+        const a = atom(0, { maxAge: 0 })
+        const s = store()
+        const unsub = s.sub(a, () => {})
+        try {
+            expect(setIntervalSpy.mock.calls.length).toBe(before + 1)
+        } finally {
+            unsub()
+            setIntervalSpy.mockRestore()
+        }
+    })
+
+    test("attach installs maxAge timer for a global atom with maxAge: 0", () => {
+        const setIntervalSpy = spyOn(globalThis, "setInterval")
+        const before = setIntervalSpy.mock.calls.length
+        const a = atom(0, {
+            global: true,
+            maxAge: 0,
+            name: "@valdres/test/maxage-zero",
+        })
+        const s = store()
+        const unsub = s.sub(a, () => {})
+        try {
+            expect(setIntervalSpy.mock.calls.length).toBe(before + 1)
+        } finally {
+            unsub()
+            a.detach(s.data)
+            setIntervalSpy.mockRestore()
+        }
     })
 })

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -1,20 +1,20 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
-import type { ScopedStoreData, StoreData } from "../types/StoreData"
+import type { StoreData } from "../types/StoreData"
 import { deepFreeze } from "../utils/deepFreeze"
 import { isProd } from "./isProd"
 
 /** Register `key` in the parent's scopeValueIndex. Caller MUST ensure
- *  `data` is a ScopedStoreData (has a parent). */
-export const trackScopeValue = (key: WeakKey, data: ScopedStoreData) => {
-    const parent = data.parent
+ *  `data` is a scoped store (has a parent). */
+export const trackScopeValue = (key: WeakKey, data: StoreData) => {
+    const parent = data.parent!
     let set = parent.scopeValueIndex.get(key)
     if (!set) {
         set = new Set()
         parent.scopeValueIndex.set(key, set)
     }
     set.add(data)
-    data.scopeIndexKeys.add(key)
+    data.scopeIndexKeys!.add(key)
 }
 
 export const setValueInData = <Value extends unknown>(
@@ -26,7 +26,7 @@ export const setValueInData = <Value extends unknown>(
     // also passed here via loose typing but should not pollute the index.
     // Family tracking is handled separately in initFamilyIndex.
     const isNewAtomInScope =
-        "parent" in data && Object.hasOwn(atom, "defaultValue") && !data.values.has(atom)
+        data.parent && Object.hasOwn(atom, "defaultValue") && !data.values.has(atom)
     let written: Value
     if (atom.mutable || isProd()) {
         data.values.set(atom, value)
@@ -39,7 +39,7 @@ export const setValueInData = <Value extends unknown>(
         data.values.set(atom, frozenValue)
         written = frozenValue
     }
-    if (isNewAtomInScope) trackScopeValue(atom, data as ScopedStoreData)
+    if (isNewAtomInScope) trackScopeValue(atom, data)
     // Record the write timestamp for atoms with maxAge so unmounted reads
     // can lazily revalidate once the freshness window has elapsed.
     if ((atom as Atom<Value>).maxAge !== undefined) {

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -4,17 +4,22 @@ import type { StoreData } from "../types/StoreData"
 import { deepFreeze } from "../utils/deepFreeze"
 import { isProd } from "./isProd"
 
-/** Register `key` in the parent's scopeValueIndex. Caller MUST ensure
- *  `data` is a scoped store (has a parent). */
+/** Register `key` in the parent's scopeValueIndex. Throws if called on
+ *  a root store — `parent` and `scopeIndexKeys` are only populated for
+ *  scoped stores (see createStoreData). */
 export const trackScopeValue = (key: WeakKey, data: StoreData) => {
-    const parent = data.parent!
+    const parent = data.parent
+    const indexKeys = data.scopeIndexKeys
+    if (!parent || !indexKeys) {
+        throw new Error("trackScopeValue called on a root store")
+    }
     let set = parent.scopeValueIndex.get(key)
     if (!set) {
         set = new Set()
         parent.scopeValueIndex.set(key, set)
     }
     set.add(data)
-    data.scopeIndexKeys!.add(key)
+    indexKeys.add(key)
 }
 
 export const setValueInData = <Value extends unknown>(

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -5,7 +5,7 @@ import type { GetValue } from "../types/GetValue"
 import type { SetAtom } from "../types/SetAtom"
 import type { State } from "../types/State"
 import type { ScopedStore, ScopeFn, Store } from "../types/Store"
-import type { ScopedStoreData, StoreData } from "../types/StoreData"
+import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
 import { isAtom } from "../utils/isAtom"
 import { isGlobalAtom } from "../utils/isGlobalAtom"
@@ -35,11 +35,18 @@ Only \`atom\` can be set.
  * stale-while-revalidate window that the timer relies on). When there's
  * no active timer, we drop a cached value past its freshness window so
  * the next read re-evaluates the default.
+ *
+ * Scope shadows are exempt: a value present in `data.values` for a scoped
+ * store is always a deliberate pin from `set()` — the scope never runs
+ * its own revalidation timer for maxAge atoms (see subscribe.ts). Evicting
+ * the shadow would silently fall back to the parent and defeat the
+ * user-visible override.
  */
 const isCachedValueStale = (state: State, data: StoreData): boolean => {
     const atom = state as Atom
     const maxAge = atom.maxAge
     if (maxAge === undefined) return false
+    if (data.parent) return false
     if (isGlobalAtom(atom)) {
         if (atom.maxAgeInterval !== undefined) return false
     } else {
@@ -54,12 +61,12 @@ const isCachedValueStale = (state: State, data: StoreData): boolean => {
 }
 
 export function storeFromStoreData(
-    data: ScopedStoreData,
+    data: StoreData,
     detach: () => void,
 ): ScopedStore
 export function storeFromStoreData(data: StoreData): Store
 export function storeFromStoreData(
-    data: ScopedStoreData | StoreData,
+    data: StoreData,
     detach?: () => void,
 ) {
     const _initSet = new Set<Atom>()
@@ -194,30 +201,32 @@ export function storeFromStoreData(
                 scopedStoreData = createStoreData(scopeId, data, data.batchUpdates ? { batchUpdates: true } : undefined)
                 data.scopes.set(scopeId, scopedStoreData)
             }
+            const consumers = scopedStoreData.scopeConsumers!
+            const indexKeys = scopedStoreData.scopeIndexKeys!
             const detach = (expectedToDestroy = false) => {
-                scopedStoreData.scopeConsumers.delete(detach)
-                if (scopedStoreData.scopeConsumers.size === 0) {
+                consumers.delete(detach)
+                if (consumers.size === 0) {
                     data.scopes.delete(scopeId)
                     // Clean up scopeValueIndex entries referencing this scope
-                    for (const key of scopedStoreData.scopeIndexKeys) {
+                    for (const key of indexKeys) {
                         const set = data.scopeValueIndex.get(key)
                         if (set) {
                             set.delete(scopedStoreData)
                             if (set.size === 0) data.scopeValueIndex.delete(key)
                         }
                     }
-                    scopedStoreData.scopeIndexKeys.clear()
+                    indexKeys.clear()
                     return true
                 }
                 if (expectedToDestroy) {
                     console.warn(
-                        `Scope ${scopeId} still has ${scopedStoreData.scopeConsumers.size} consumers, will not detach`,
+                        `Scope ${scopeId} still has ${consumers.size} consumers, will not detach`,
                     )
                 }
                 return false
             }
 
-            scopedStoreData.scopeConsumers.add(detach)
+            consumers.add(detach)
             const newStore = storeFromStoreData(data.scopes.get(scopeId)!, detach)
             return newStore
         }

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -28,7 +28,7 @@ const initSubscribers = <V>(state: State<V> | Family<V>, data: StoreData) => {
 }
 
 export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
-    if (!state.maxAge) return
+    if (state.maxAge === undefined) return
     const globalState = isGlobalAtom(state) ? state : undefined
     const existing = globalState?.maxAgeInterval
 
@@ -340,7 +340,7 @@ export const subscribe = <V>(
         // overwrite the shadow on the next tick and double the work for
         // non-global maxAge atoms (which lack the refCount sharing that
         // installMaxAgeTimer uses for global atoms).
-        if (isAtom(state) && state.maxAge && !data.parent) {
+        if (isAtom(state) && state.maxAge !== undefined && !data.parent) {
             installMaxAgeTimer(state, data)
         }
         // First direct subscriber: bump liveness through the dep graph.

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -273,12 +273,12 @@ export const subscribe = <V>(
 ) => {
     let parentUnsubscribe: undefined | (() => void)
     if (
-        "parent" in data &&
+        data.parent &&
         ((!data.values.has(state) && isAtom(state)) || isAtomFamily(state))
     ) {
         /**
          * Getting here means that we are within a scope and that the current
-         * atom is not set in the current scope. Therfore we pass the subscription
+         * atom is not set in the current scope. Therefore we pass the subscription
          * up the tree and modify the callback to unsubscribe to the parent store
          * in the case that it is set in this scope.
          */
@@ -291,11 +291,9 @@ export const subscribe = <V>(
         )
         callback = arg => {
             if (parentUnsubscribe) {
-                /**
-                 * TODO: Find way to test this. Maybe use onMount?
-                 * Here we ensure that the unsubscribe happens only once.
-                 * This is not yet covered in tests.
-                 */
+                // Idempotent: once the scope re-roots the subscription, the
+                // parent-side delegate must drop on the first scope-local
+                // propagation so we don't double-notify on later writes.
                 parentUnsubscribe()
                 parentUnsubscribe = undefined
             }
@@ -336,7 +334,13 @@ export const subscribe = <V>(
     }
     subscribers.add(subscription)
     if (subscribers.size === 1) {
-        if (isAtom(state) && state.maxAge) {
+        // Skip scope-local timer installation: reaching the non-delegating
+        // branch in a scope means the atom was shadowed via `set()`, which
+        // we treat as a deliberate pin. Running an extra timer here would
+        // overwrite the shadow on the next tick and double the work for
+        // non-global maxAge atoms (which lack the refCount sharing that
+        // installMaxAgeTimer uses for global atoms).
+        if (isAtom(state) && state.maxAge && !data.parent) {
             installMaxAgeTimer(state, data)
         }
         // First direct subscriber: bump liveness through the dep graph.
@@ -356,7 +360,6 @@ export const subscribe = <V>(
 
     return () => {
         if (parentUnsubscribe) {
-            // TODO: Test this scenario
             parentUnsubscribe()
         }
         unsubscribe(state, subscription, data)

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -209,8 +209,10 @@ export class Transaction {
 
     parentScope = (callback: (txn: Transaction) => any) => {
         if (!this.parentTransaction) {
+            if (!this.data.parent) {
+                throw new Error("Cannot access parentScope on root store")
+            }
             this.parentTransaction = new Transaction(
-                // @ts-ignore
                 this.data.parent,
                 undefined,
                 this,

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -2,7 +2,7 @@ import type { Atom } from "./Atom"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { GetValue } from "./GetValue"
 import type { ResetAtom } from "./ResetAtom"
-import type { ScopedStoreData, StoreData } from "./StoreData"
+import type { StoreData } from "./StoreData"
 import type { SetAtomValue } from "./SetAtomValue"
 import type { SubscribeFn } from "./SubscribeFn"
 import type { TransactionFn } from "./TransactionFn"
@@ -41,6 +41,6 @@ export type Store<T = StoreData> = {
     scope: ScopeFn
 }
 
-export type ScopedStore = Store<ScopedStoreData> & {
+export type ScopedStore = Store & {
     detach: (warnIfNotDestroyed?: boolean) => void
 }

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -1,7 +1,7 @@
 import type { Store } from "./Store"
 import type { Subscription } from "./Subscription"
 
-export type RootStoreData = {
+export type StoreData = {
     id: string
     values: WeakMap<WeakKey, any>
     subscriptions: WeakMap<WeakKey, Set<Subscription>>
@@ -27,15 +27,15 @@ export type RootStoreData = {
      *  `values` (which may be replaced by user-supplied async sets). */
     pendingDefaults: WeakMap<WeakKey, { promise: Promise<any>; resolve: (value: any) => void }>
     storeRef?: Store
-    scopes: Map<string, ScopedStoreData>
+    scopes: Map<string, StoreData>
     batchUpdates?: boolean
-    scopeValueIndex: WeakMap<WeakKey, Set<ScopedStoreData>>
+    scopeValueIndex: WeakMap<WeakKey, Set<StoreData>>
+    /** Present iff this is a scoped store. Root stores have `parent: undefined`. */
+    parent?: StoreData
+    /** Present iff this is a scoped store. Tracks active scope consumers
+     *  so the scope can be detached when the last consumer leaves. */
+    scopeConsumers?: Set<(expectedToDestroy?: boolean) => boolean>
+    /** Present iff this is a scoped store. Records keys this scope registered
+     *  in its parent's `scopeValueIndex`, used for cleanup on detach. */
+    scopeIndexKeys?: Set<WeakKey>
 }
-
-export type ScopedStoreData = RootStoreData & {
-    parent: StoreData
-    scopeConsumers: Set<() => void>
-    scopeIndexKeys: Set<WeakKey>
-}
-
-export type StoreData = RootStoreData | ScopedStoreData


### PR DESCRIPTION
## Summary

- Collapse `RootStoreData` and `ScopedStoreData` into one `StoreData` shape with optional `parent`. Eight `"parent" in data` runtime checks become `data.parent` checks; three `@ts-ignore @ts-todo` markers go with the union narrowing they existed to paper over.
- Fix `maxAge` × scope shadow: `scope.set(maxAgeAtom, value)` is now a deliberate pin — `isCachedValueStale` no longer evicts the shadow, and `subscribe()` no longer installs a second scope-local revalidation timer that would overwrite it and double-invoke `defaultValue()`.
- Add `packages/valdres/src/lib/scope.test.ts` — 18 tests covering 4–5 level nesting, cross-scope family deletion, subscribe/unsubscribe/resubscribe in scopes, batched scopes, and the new `maxAge` semantics.

## Background

The audit at the start of this branch found that `RootStoreData`/`ScopedStoreData` had zero meaningfully divergent fields and that 5 of 13 `"parent" in data` branches were purely structural. Phase 1 was to unify the type. While writing scope tests to make that safe, two unrelated `maxAge` × scope surprises surfaced: unsubscribed scope shadows were silently evicted (lazy revalidation in `isCachedValueStale`), and subscribing in a scope on a shadowed `maxAge` atom installed a second timer that overwrote the shadow. Both fixed here under the same PR since the type unification touches the same files.

## Test plan

- [x] `bun test` in `packages/valdres` — 313 pass, 0 fail, 1 todo (pre-existing).
- [x] `bunx tsc --noEmit` in `packages/valdres` — clean.
- [x] `bun --filter '*' test` across the monorepo — all packages pass.
- [x] Stable across 3 consecutive runs of the full valdres suite.