### PR TITLE
Make benchmark regression report easier to read

### DIFF
--- a/scripts/check-bench-regression.ts
+++ b/scripts/check-bench-regression.ts
@@ -131,13 +131,13 @@ function fmtRatio(ratio: number): string {
         : `${ratio.toFixed(1)}x slower`
 }
 
-function fmtChange(ratioChange: number | null): string {
-    if (ratioChange == null) return "—"
-    const pct = Math.abs((ratioChange - 1) * 100)
+function fmtChange(change: number | null): string {
+    if (change == null) return "—"
+    const pct = Math.abs((change - 1) * 100)
     if (pct < 1) return "~same"
-    return ratioChange >= 1
-        ? `+${pct.toFixed(0)}%`
-        : `-${pct.toFixed(0)}%`
+    return change < 1
+        ? `🟢 ${pct.toFixed(0)}% faster`
+        : `🔴 ${pct.toFixed(0)}% slower`
 }
 
 function median(values: number[]): number {
@@ -476,22 +476,27 @@ function formatTable(
         )
     }
 
+    lines.push(
+        "",
+        `<sub>**How to read this:** _Valdres_ and _Jotai_ are this run's median timings. _vs Jotai_ is their ratio. _Δ_ columns compare this run against the median of the last ${windowUsed} runs on \`main\` — 🟢 faster, 🔴 slower.</sub>`,
+    )
+
     // ── Show flagged benchmarks inline (if any) ──
     if (noteworthy.length > 0) {
         lines.push(
             "",
-            "| | Benchmark | vs Jotai | Baseline | Δ Ratio | Δ Absolute |",
-            "|:-|:----------|--------:|---------:|-------:|-----------:|",
+            "| | Benchmark | Valdres | Jotai | vs Jotai | Δ vs Jotai | Δ Valdres |",
+            "|:-|:----------|--------:|------:|--------:|:----------|:---------|",
         )
         for (const r of noteworthy) {
             const icon = STATUS_ICON[r.status]
+            const valdres = fmtNs(r.valdres)
+            const jotai = fmtNs(r.jotai)
             const vsJotai = fmtRatio(r.currentRatio)
-            const baseline =
-                r.medianRatio != null ? fmtRatio(r.medianRatio) : "—"
             const ratioChg = fmtChange(r.ratioChange)
             const absChg = fmtChange(r.absChange)
             lines.push(
-                `| ${icon} | ${r.name} | ${vsJotai} | ${baseline} | ${ratioChg} | ${absChg} |`,
+                `| ${icon} | ${r.name} | ${valdres} | ${jotai} | ${vsJotai} | ${ratioChg} | ${absChg} |`,
             )
         }
     }
@@ -511,20 +516,19 @@ function formatTable(
         lines.push(
             `**${cat}**`,
             "",
-            "| | Benchmark | Valdres | vs Jotai | Baseline | Δ Ratio | Δ Absolute |",
-            "|:-|:----------|--------:|--------:|---------:|-------:|-----------:|",
+            "| | Benchmark | Valdres | Jotai | vs Jotai | Δ vs Jotai | Δ Valdres |",
+            "|:-|:----------|--------:|------:|--------:|:----------|:---------|",
         )
 
         for (const r of benchmarks) {
             const icon = STATUS_ICON[r.status]
             const valdres = fmtNs(r.valdres)
+            const jotai = fmtNs(r.jotai)
             const vsJotai = fmtRatio(r.currentRatio)
-            const baseline =
-                r.medianRatio != null ? fmtRatio(r.medianRatio) : "—"
             const ratioChg = fmtChange(r.ratioChange)
             const absChg = fmtChange(r.absChange)
             lines.push(
-                `| ${icon} | ${r.name} | ${valdres} | ${vsJotai} | ${baseline} | ${ratioChg} | ${absChg} |`,
+                `| ${icon} | ${r.name} | ${valdres} | ${jotai} | ${vsJotai} | ${ratioChg} | ${absChg} |`,
             )
         }
 


### PR DESCRIPTION
## Summary

The PR comment posted by `check-bench-regression.ts` had a few rough edges (raised in #129 discussion):

- **Ambiguous sign convention.** "Δ Absolute −40%" read as "40% worse" to a reviewer, when it actually meant valdres got 40% *faster* vs its historical median.
- **No Jotai timing.** Every benchmark measures Jotai, but only valdres' absolute time appeared in the table.
- **Opaque column names.** "Δ Ratio" and "Δ Absolute" don't say *what* the ratio is of or what "absolute" refers to.

This PR rewrites the table format:

- Rename `Δ Ratio` → **`Δ vs Jotai`** and `Δ Absolute` → **`Δ Valdres`** so the referent lives in the column name.
- Replace `+X%` / `-X%` with **`🟢 X% faster`** / **`🔴 X% slower`** so direction is self-documenting; no mental sign-flipping needed.
- Add a **Jotai** absolute-time column so reviewers can see both raw numbers, not just the ratio.
- Drop the **Baseline** (historical-ratio-as-text) column — the Δ column already tells the trend story, freeing room for the Jotai column without making the table wider.
- Add a one-line **"How to read this"** preamble above the tables.

Before:

| | Benchmark | vs Jotai | Baseline | Δ Ratio | Δ Absolute |
|:-|:----------|--------:|---------:|-------:|-----------:|
| ✅ | atom basic get | 2.0x faster | 2.1x faster | -5% | -40% |

After:

| | Benchmark | Valdres | Jotai | vs Jotai | Δ vs Jotai | Δ Valdres |
|:-|:----------|--------:|------:|--------:|:----------|:---------|
| ✅ | atom basic get | 420ns | 850ns | 2.0x faster | 🟢 5% faster | 🟢 40% faster |

## Test plan

- [ ] CI's benchmark workflow posts a comment on this PR — eyeball the rendered markdown there
- [ ] Confirm the table renders on both narrow (mobile) and wide PR views
- [ ] Sign of the deltas is correct (faster = 🟢, slower = 🔴) on real run data
- [ ] Collapsible "Full results" section still groups by category

🤖 Generated with [Claude Code](https://claude.com/claude-code)