### PR TITLE
docs: embed live Bencher perf plot in README (option A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,8 @@ valdres is benchmarked against [Jotai](https://github.com/pmndrs/jotai) (and a r
 
 **→ [bencher.dev/perf/valdres](https://bencher.dev/perf/valdres)**
 
+[![store.get(atom) latency — valdres vs Jotai vs raw Map (Bun + Node)](https://api.bencher.dev/v0/projects/valdres/perf/img?branches=ca02205d-e4c5-4f8e-a227-9790cc6d7f7d&testbeds=6ed7a83d-343c-43c1-b270-225a1688718e%2C0c5502c7-6901-4334-a06c-110e7468d6bb&benchmarks=cc14bb7a-a64d-4e0c-a277-abde4e2f8449%2C7406c2e2-a4cc-4327-935a-2f7fbc9c41b7%2C741adc2f-32e7-47d6-9759-42cf16fc5c8a&measures=34bb7b72-22ec-45bd-bb99-0768d0e0319e&title=store.get%28atom%29+latency%3A+valdres+vs+jotai+vs+map)](https://bencher.dev/perf/valdres?branches=ca02205d-e4c5-4f8e-a227-9790cc6d7f7d&testbeds=6ed7a83d-343c-43c1-b270-225a1688718e%2C0c5502c7-6901-4334-a06c-110e7468d6bb&benchmarks=cc14bb7a-a64d-4e0c-a277-abde4e2f8449%2C7406c2e2-a4cc-4327-935a-2f7fbc9c41b7%2C741adc2f-32e7-47d6-9759-42cf16fc5c8a&measures=34bb7b72-22ec-45bd-bb99-0768d0e0319e&tab=plots&x_axis=date_time)
+
+<sub>Live plot — `store.get(atom)` latency, valdres vs Jotai vs a raw `Map` floor, on both runtimes. Auto-updates from `main`; click through to filter/zoom. (Sparse until `main` accumulates a few runs.)</sub>
+
 Every PR from the repo gets a comment flagging any latency regression vs `main` (fork PRs are skipped — they can't read the upload key).


### PR DESCRIPTION
One of two README-stats options to test (the other is PR for the generated numbers table).

Adds an **auto-updating Bencher perf image** to the README Benchmarks section: `store.get(atom)` latency — valdres vs Jotai vs a raw `Map` floor — across Bun + Node, linked to the interactive perf page.

- Rendered server-side by `api.bencher.dev/.../perf/img` and re-fetched by GitHub's image proxy (`Cache-Control: no-cache`), so it **stays current with zero maintenance** — no generator, no CI, no commits.
- Public project → no auth. Verified the URL returns `200 image/jpeg`.
- Rolling URL (no head pin), so it won't go stale as `main` advances.

**Tradeoffs:** it's a time-series *trend chart*, not a numbers table (no exact "N× faster" on its face — that's the other PR), capped at 8 series/image, and looks sparse until `main` accumulates a few runs.