### PR TITLE
docs: generate a Bencher-sourced benchmark table in README (option B)

### DIFF
--- a/.github/workflows/bench-table.yml
+++ b/.github/workflows/bench-table.yml
@@ -1,13 +1,18 @@
-# Refreshes the README's benchmark table from Bencher's public API.
-# Runs nightly (and on demand) rather than on every main push, to avoid commit
-# churn — the live, always-current view is bencher.dev/perf/valdres; this is a
-# committed snapshot. The generator only READS the public API, so no token /
-# Bencher.dev environment is needed.
+# Refreshes the README's benchmark table from Bencher's public API after each
+# push/merge to main re-benchmarks. Triggered by the "Bencher (base)" workflow
+# completing (rather than on: push) so the base lane has finished uploading the
+# new numbers first — the table then reflects the just-merged commit instead of
+# lagging one behind. Also runnable on demand.
+#
+# The live, always-current view is bencher.dev/perf/valdres; this is a committed
+# snapshot. The generator only READS the public API, so no token / Bencher.dev
+# environment is needed.
 name: Refresh benchmark table
 
 on:
-    schedule:
-        - cron: "17 6 * * *" # daily, off-peak UTC
+    workflow_run:
+        workflows: ["Bencher (base)"]
+        types: [completed]
     workflow_dispatch:
 
 permissions:
@@ -19,9 +24,14 @@ concurrency:
 
 jobs:
     refresh:
+        # Manual runs always proceed; workflow_run only after a successful base
+        # run (don't refresh off a failed/partial upload).
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v6
+              with:
+                  ref: main
             - uses: oven-sh/setup-bun@v2
               with:
                   bun-version: 1.3.13
@@ -36,5 +46,5 @@ jobs:
                       git config user.email "github-actions[bot]@users.noreply.github.com"
                       git add README.md
                       git commit -m "docs: refresh Bencher benchmark table [skip ci]"
-                      git push
+                      git push origin HEAD:main
                   fi

--- a/.github/workflows/bench-table.yml
+++ b/.github/workflows/bench-table.yml
@@ -1,0 +1,40 @@
+# Refreshes the README's benchmark table from Bencher's public API.
+# Runs nightly (and on demand) rather than on every main push, to avoid commit
+# churn — the live, always-current view is bencher.dev/perf/valdres; this is a
+# committed snapshot. The generator only READS the public API, so no token /
+# Bencher.dev environment is needed.
+name: Refresh benchmark table
+
+on:
+    schedule:
+        - cron: "17 6 * * *" # daily, off-peak UTC
+    workflow_dispatch:
+
+permissions:
+    contents: write
+
+concurrency:
+    group: bench-table
+    cancel-in-progress: false
+
+jobs:
+    refresh:
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v6
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: 1.3.13
+            - name: Regenerate README benchmark table
+              run: bun run scripts/gen-bench-table.ts
+            - name: Commit if changed
+              run: |
+                  if git diff --quiet README.md; then
+                      echo "Benchmark table unchanged."
+                  else
+                      git config user.name "github-actions[bot]"
+                      git config user.email "github-actions[bot]@users.noreply.github.com"
+                      git add README.md
+                      git commit -m "docs: refresh Bencher benchmark table [skip ci]"
+                      git push
+                  fi

--- a/README.md
+++ b/README.md
@@ -43,3 +43,76 @@ valdres is benchmarked against [Jotai](https://github.com/pmndrs/jotai) (and a r
 **→ [bencher.dev/perf/valdres](https://bencher.dev/perf/valdres)**
 
 Every PR from the repo gets a comment flagging any latency regression vs `main` (fork PRs are skipped — they can't read the upload key).
+
+<!-- BENCH:START -->
+### Performance vs Jotai
+
+Latest `main` latency per operation (live, always-current numbers: [bencher.dev/perf/valdres](https://bencher.dev/perf/valdres)). Auto-generated from Bencher — do not hand-edit.
+
+#### Bun (JavaScriptCore)
+
+| Operation | valdres | Jotai | |
+|:----------|--------:|------:|:--|
+| `atom lifecycle (create+100get+100set)` | 12.0µs | 267.0µs | 🟢 22.2× faster |
+| `atom(1)` | 2ns | 55ns | 🟢 22.0× faster |
+| `atomFamily(id)` | 245ns | 457ns | 🟢 1.9× faster |
+| `atomFamily(id) cache hit` | 29ns | 12ns | 🔴 2.5× slower |
+| `createStore` | 259ns | 5.4µs | 🟢 21.0× faster |
+| `get 1000 atoms` | 9.4µs | 632.4µs | 🟢 66.9× faster |
+| `selector(fn)` | 4ns | 58ns | 🟢 13.4× faster |
+| `selectorFamily(id)` | 186ns | 439ns | 🟢 2.4× faster |
+| `set + read 10 selectors` | 6.7µs | 37.2µs | 🟢 5.6× faster |
+| `set + read 100 selectorFamily entries` | 71.3µs | 274.8µs | 🟢 3.9× faster |
+| `set + read 100 selectors` | 55.6µs | 355.5µs | 🟢 6.4× faster |
+| `set + read through 5 chained selectors` | 5.7µs | 18.5µs | 🟢 3.2× faster |
+| `set 1000 atoms` | 107.2µs | 964.2µs | 🟢 9.0× faster |
+| `set(atom, curr => curr+1)` | 97ns | 3.1µs | 🟢 32.5× faster |
+| `set(atom, value)` | 114ns | 2.4µs | 🟢 21.3× faster |
+| `set(atom) with 10 subs` | 142ns | 3.9µs | 🟢 27.5× faster |
+| `store.get(atom)` | 40ns | 371ns | 🟢 9.3× faster |
+| `sub + unsub` | 450ns | 3.3µs | 🟢 7.3× faster |
+| `sub+unsub on chain of 100 unsubscribed derived deps` | 104.7µs | 139.8µs | 🟢 1.3× faster |
+| `sub+unsub on chain of 50 unsubscribed derived deps` | 64.4µs | 98.0µs | 🟢 1.5× faster |
+| `sub+unsub on chain of 500 unsubscribed derived deps` | 474.7µs | 654.9µs | 🟢 1.4× faster |
+| `txn: 10 atoms × 10 selectors, set + read` | 67.2µs | 292.6µs | 🟢 4.4× faster |
+| `txn: 10 atoms × 10 selectors, with subs` | 108.8µs | 603.0µs | 🟢 5.5× faster |
+| `txn: 10 atoms × 100 selectors, set + read` | 663.4µs | 2.77ms | 🟢 4.2× faster |
+| `txn: asymmetric DAG shared sink` | 26.2µs | 155.6µs | 🟢 5.9× faster |
+| `txn: cross-atom 1000 selectors, set + read` | 745.9µs | 5.32ms | 🟢 7.1× faster |
+| `txn: cross-atom 1000 selectors, with subs` | 1.27ms | 23.18ms | 🟢 18.3× faster |
+| `txn: large asymmetric DAG (1000 leaves × 50 chain)` | 4.32ms | 20.99ms | 🟢 4.9× faster |
+
+#### Node.js (V8)
+
+| Operation | valdres | Jotai | |
+|:----------|--------:|------:|:--|
+| `atom lifecycle (create+100get+100set)` | 27.1µs | 145.4µs | 🟢 5.4× faster |
+| `atom(1)` | 25ns | 49ns | 🟢 1.9× faster |
+| `atomFamily(id)` | 242ns | 406ns | 🟢 1.7× faster |
+| `atomFamily(id) cache hit` | 28ns | 27ns | 🔴 1.1× slower |
+| `createStore` | 175ns | 1.7µs | 🟢 9.9× faster |
+| `get 1000 atoms` | 15.0µs | 206.1µs | 🟢 13.8× faster |
+| `selector(fn)` | 42ns | 54ns | 🟢 1.3× faster |
+| `selectorFamily(id)` | 183ns | 258ns | 🟢 1.4× faster |
+| `set + read 10 selectors` | 8.3µs | 21.4µs | 🟢 2.6× faster |
+| `set + read 100 selectorFamily entries` | 74.4µs | 131.1µs | 🟢 1.8× faster |
+| `set + read 100 selectors` | 71.3µs | 131.2µs | 🟢 1.8× faster |
+| `set + read through 5 chained selectors` | 5.4µs | 10.0µs | 🟢 1.9× faster |
+| `set 1000 atoms` | 81.6µs | 447.5µs | 🟢 5.5× faster |
+| `set(atom, curr => curr+1)` | 236ns | 1.5µs | 🟢 6.5× faster |
+| `set(atom, value)` | 221ns | 1.3µs | 🟢 5.8× faster |
+| `set(atom) with 10 subs` | 261ns | 1.7µs | 🟢 6.7× faster |
+| `store.get(atom)` | 14ns | 160ns | 🟢 11.8× faster |
+| `sub + unsub` | 880ns | 2.1µs | 🟢 2.4× faster |
+| `sub+unsub on chain of 100 unsubscribed derived deps` | 167.8µs | 107.8µs | 🔴 1.6× slower |
+| `sub+unsub on chain of 50 unsubscribed derived deps` | 91.5µs | 56.6µs | 🔴 1.6× slower |
+| `sub+unsub on chain of 500 unsubscribed derived deps` | 766.0µs | 534.2µs | 🔴 1.4× slower |
+| `txn: 10 atoms × 10 selectors, set + read` | 74.2µs | 151.9µs | 🟢 2.0× faster |
+| `txn: 10 atoms × 10 selectors, with subs` | 80.6µs | 248.4µs | 🟢 3.1× faster |
+| `txn: 10 atoms × 100 selectors, set + read` | 823.1µs | 1.35ms | 🟢 1.6× faster |
+| `txn: asymmetric DAG shared sink` | 24.0µs | 55.3µs | 🟢 2.3× faster |
+| `txn: cross-atom 1000 selectors, set + read` | 1.03ms | 1.81ms | 🟢 1.8× faster |
+| `txn: cross-atom 1000 selectors, with subs` | 1.05ms | 13.20ms | 🟢 12.5× faster |
+| `txn: large asymmetric DAG (1000 leaves × 50 chain)` | 3.89ms | 9.40ms | 🟢 2.4× faster |
+
+<!-- BENCH:END -->

--- a/scripts/gen-bench-table.ts
+++ b/scripts/gen-bench-table.ts
@@ -1,0 +1,116 @@
+/**
+ * Regenerates the README benchmark table from Bencher's PUBLIC API (no token).
+ *
+ * Pulls the latest `main` report for each testbed, pairs each "<op> / valdres"
+ * with its "<op> / jotai" sibling, computes the speedup, and rewrites the table
+ * between the <!-- BENCH:START --> / <!-- BENCH:END --> markers in README.md.
+ *
+ *   bun run scripts/gen-bench-table.ts
+ *
+ * The live, always-current view is bencher.dev/perf/valdres; this table is a
+ * committed snapshot refreshed by .github/workflows/bench-table.yml.
+ */
+import { readFileSync, writeFileSync } from "fs"
+import { join } from "path"
+
+const API = "https://api.bencher.dev/v0"
+const PROJECT = "valdres"
+const TESTBEDS = [
+    { slug: "ubuntu-2204-bun", label: "Bun (JavaScriptCore)" },
+    { slug: "ubuntu-2204-node", label: "Node.js (V8)" },
+]
+const README = join(import.meta.dir, "..", "README.md")
+const START = "<!-- BENCH:START -->"
+const END = "<!-- BENCH:END -->"
+
+function fmtNs(ns: number): string {
+    if (ns < 1_000) return `${ns.toFixed(0)}ns`
+    if (ns < 1_000_000) return `${(ns / 1_000).toFixed(1)}µs`
+    return `${(ns / 1_000_000).toFixed(2)}ms`
+}
+
+function speedup(valdres: number, jotai: number): string {
+    const ratio = jotai / valdres
+    return ratio >= 1
+        ? `🟢 ${ratio.toFixed(1)}× faster`
+        : `🔴 ${(1 / ratio).toFixed(1)}× slower`
+}
+
+// Latest `main` report for a testbed → { "<op> / <impl>": latency_ns }.
+async function latestLatencies(testbed: string): Promise<Map<string, number>> {
+    const url = `${API}/projects/${PROJECT}/reports?branch=main&testbed=${testbed}&per_page=1&direction=desc`
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`Bencher reports (${testbed}): HTTP ${res.status}`)
+    const reports = await res.json()
+    const out = new Map<string, number>()
+    if (!Array.isArray(reports) || reports.length === 0) return out
+    for (const arm of reports[0].results ?? []) {
+        for (const item of arm) {
+            const lat = item.measures?.find(
+                (m: { measure: { slug: string } }) => m.measure.slug === "latency",
+            )
+            if (lat) out.set(item.benchmark.name, lat.metric.value)
+        }
+    }
+    return out
+}
+
+// Pair "<op> / valdres" with "<op> / jotai" (ignores map floor + valdres-only benches).
+function pairByOp(
+    lat: Map<string, number>,
+): Map<string, { valdres?: number; jotai?: number }> {
+    const ops = new Map<string, { valdres?: number; jotai?: number }>()
+    for (const [name, value] of lat) {
+        const m = name.match(/^(.*) \/ (valdres|jotai)$/)
+        if (!m) continue
+        const entry = ops.get(m[1]) ?? {}
+        entry[m[2] as "valdres" | "jotai"] = value
+        ops.set(m[1], entry)
+    }
+    return ops
+}
+
+async function renderTestbed(tb: {
+    slug: string
+    label: string
+}): Promise<string> {
+    const ops = pairByOp(await latestLatencies(tb.slug))
+    const rows: string[] = []
+    for (const [op, { valdres, jotai }] of [...ops].sort((a, b) =>
+        a[0].localeCompare(b[0]),
+    )) {
+        if (valdres == null || jotai == null) continue
+        rows.push(
+            `| \`${op}\` | ${fmtNs(valdres)} | ${fmtNs(jotai)} | ${speedup(valdres, jotai)} |`,
+        )
+    }
+    if (rows.length === 0) return `#### ${tb.label}\n\n_No data yet._`
+    return [
+        `#### ${tb.label}`,
+        "",
+        "| Operation | valdres | Jotai | |",
+        "|:----------|--------:|------:|:--|",
+        ...rows,
+    ].join("\n")
+}
+
+const sections = await Promise.all(TESTBEDS.map(renderTestbed))
+
+const block = [
+    START,
+    "### Performance vs Jotai",
+    "",
+    "Latest `main` latency per operation (live, always-current numbers: [bencher.dev/perf/valdres](https://bencher.dev/perf/valdres)). Auto-generated from Bencher — do not hand-edit.",
+    "",
+    ...sections.flatMap(s => [s, ""]),
+    END,
+].join("\n")
+
+const md = readFileSync(README, "utf8")
+const i = md.indexOf(START)
+const j = md.indexOf(END)
+if (i === -1 || j === -1) {
+    throw new Error(`README is missing ${START} / ${END} markers`)
+}
+writeFileSync(README, md.slice(0, i) + block + md.slice(j + END.length))
+console.log(`README benchmark table refreshed (${sections.length} testbeds)`)


### PR DESCRIPTION
The other README-stats option to test (alongside the embedded perf plot PR).

Adds a **generated "valdres vs Jotai" numbers table** to the README, sourced from Bencher's **public API** (the system of record now) — replacing the old local-NDJSON generator we deleted in the migration.

- `scripts/gen-bench-table.ts` — fetches the latest `main` report per testbed (`reports?branch=main&testbed=…&per_page=1&direction=desc`, no token needed for a public project), pairs `<op> / valdres` with `<op> / jotai`, computes the speedup, and rewrites the table between `<!-- BENCH:START -->` / `<!-- BENCH:END -->`. Populated here for both runtimes from live data.
- `.github/workflows/bench-table.yml` — **nightly + on-demand** refresh (regenerate → commit with `[skip ci]`). Nightly rather than per-`main`-push to avoid commit churn; can be switched to on-push-after-base-lane if you want it tighter.

**Tradeoffs vs the embed PR:** crisp "N× faster" numbers a reader sees at a glance (this is the marketing artifact), but it's a *committed snapshot* needing a refresh cadence, and it faithfully shows the current losses (`atomFamily(id) cache hit` slower; `sub+unsub` chains slower on Node).

Notes:
- If this is the chosen approach, CLAUDE.md's "the README links to it, not a generated table" line should be tweaked back.
- Overlaps the README Benchmarks section with the embed PR — expect a trivial conflict when merging the second of the two.