### PR TITLE
Make the Bencher latency gate noise-tolerant on shared runners

### DIFF
--- a/.github/workflows/bencher-base.yml
+++ b/.github/workflows/bencher-base.yml
@@ -55,12 +55,15 @@ jobs:
               run: bun run scripts/bench-to-bmf.ts
 
             # Gate the built-in `latency` measure with a t-test against main's
-            # history (auto-scales tolerance to each benchmark's own variance —
-            # noisy benchmarks get a wider band). NOTE: a Bencher threshold is
-            # per-measure, so the jotai/map reference benchmarks are gated too;
-            # they're stable enough to usually self-pass (upper-boundary only),
-            # but a jotai bump or a noise spike on a reference can trip a PR.
-            # Move references to their own measure if that proves flaky.
+            # history (auto-scales tolerance to each benchmark's own variance).
+            # Tuned for noisy shared runners: min-sample-size 6 means a benchmark
+            # isn't gated until it has enough history (kills early-life false
+            # alerts on a thin baseline), and a wide 0.9999 upper boundary
+            # tolerates the ~1.5x wobble heavy/allocation benches show on a loaded
+            # runner while still catching genuine large regressions. NOTE:
+            # thresholds are per-measure, so the jotai/map reference benches are
+            # gated too — stable enough to self-pass; move them to their own
+            # measure if that ever flakes.
             - name: Track Bun baseline
               run: |
                   bencher run \
@@ -68,8 +71,9 @@ jobs:
                     --testbed ubuntu-2204-bun \
                     --threshold-measure latency \
                     --threshold-test t_test \
+                    --threshold-min-sample-size 6 \
                     --threshold-max-sample-size 64 \
-                    --threshold-upper-boundary 0.99 \
+                    --threshold-upper-boundary 0.9999 \
                     --thresholds-reset \
                     --adapter json \
                     --github-actions '${{ secrets.GITHUB_TOKEN }}' \
@@ -82,8 +86,9 @@ jobs:
                     --testbed ubuntu-2204-node \
                     --threshold-measure latency \
                     --threshold-test t_test \
+                    --threshold-min-sample-size 6 \
                     --threshold-max-sample-size 64 \
-                    --threshold-upper-boundary 0.99 \
+                    --threshold-upper-boundary 0.9999 \
                     --thresholds-reset \
                     --adapter json \
                     --github-actions '${{ secrets.GITHUB_TOKEN }}' \


### PR DESCRIPTION
Fixes the false-positive benchmark alerts PRs are hitting during bootstrap (e.g. #159 failed on `set + read 100 selectorFamily entries / valdres` at 116.7µs vs an 84.6µs boundary — a ~1.5× noise wobble on a docs-only PR, not a regression).

**Cause:** with only a few `main` data points, the t-test's variance estimate is tiny, so the upper boundary sits right on the mean and ordinary shared-runner noise trips it. Heavy/allocation benches (selectorFamily, scope, txn) wobble most; one even alerted at just 1.1% over its limit.

**Change** (both Bun + Node base lanes):
- `--threshold-min-sample-size 6` — a benchmark isn't gated until it has ≥6 historical points (kills early-life false alerts on a thin baseline).
- `--threshold-upper-boundary 0.99 → 0.9999` — wider CI; tolerates run-to-run wobble while still catching genuine *large* regressions. (Bencher's own repo uses 0.9999 for shared-runner measures.)

`--thresholds-reset` re-seeds the thresholds when this lands on `main`; PRs then clone the looser model. After merge, re-running #159's Bencher check should pass.

Optional companion: flip on Bencher's "informational on failure" in the console during bootstrap so any residual noise alert doesn't *block* merges.