### PR TITLE
de-flake the maxAge/scope timing tests

### DIFF
--- a/.changeset/strong-maps-attack.md
+++ b/.changeset/strong-maps-attack.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: de-flake the maxAge/scope timing test. No published behavior change.

--- a/packages/valdres/src/lib/scope.test.ts
+++ b/packages/valdres/src/lib/scope.test.ts
@@ -394,7 +394,20 @@ describe("maxAge interaction with scopes", () => {
         await wait(100)
         aUnsub()
 
-        expect(B.get(a)).toBe(A.get(a))
+        // Settle the root read FIRST. With no subscriber the timer is stopped,
+        // so reading A runs the lazy TTL revalidation (isCachedValueStale) and
+        // pins A's freshest value. The scope then walks up and must observe
+        // that exact value. Reading A first avoids an evaluation-order race:
+        // if `B.get(a)` were evaluated before `A.get(a)`, the scope would read
+        // A's still-cached value while the subsequent root read straddled a
+        // revalidation tick — an off-by-one that has nothing to do with the
+        // inherited-read invariant this test asserts.
+        const rootValue = A.get(a)
+        const countAfterRoot = count
+        expect(B.get(a)).toBe(rootValue)
+        // The scope read inherited the parent's value — it did NOT re-evaluate
+        // the default in its own context (that would bump count and diverge).
+        expect(count).toBe(countAfterRoot)
         expect(count).toBeGreaterThan(1)
     })
 })


### PR DESCRIPTION
## The flake

`packages/valdres/src/lib/scope.test.ts` — *"non-shadowed scope read of a maxAge atom inherits root's revalidated value"* intermittently failed CI with an off-by-one (`Expected: 6, Received: 5`) and passed on re-run.

## Root cause — test artifact, not a code bug

The test asserted `expect(B.get(a)).toBe(A.get(a))`. Argument evaluation order makes this racy at the TTL boundary:

1. `B.get(a)` is evaluated **first**. The scope has no shadow, so `getState` walks up to the root and reads `A.data.values` directly (`getState.ts:59`) — A's *currently cached* value (e.g. 5).
2. `A.get(a)` is evaluated **second**. With no subscriber the maxAge timer is stopped, so `getDefault` runs `isCachedValueStale` (`storeFromStoreData.ts:45`). Past the TTL it evicts the cache, re-runs the `++count` default, and returns a fresher value (6).

→ `Expected: 6 (A), Received: 5 (B)`. The `wait(100)` made it worse by assuming an exact tick count under a loaded runner.

This is **working as designed**, not a user-facing bug:
- `isCachedValueStale` deliberately exempts scoped stores (`if (data.parent) return false`).
- Scopes deliberately run no maxAge timer of their own (`subscribe.ts:343`, `!data.parent`).
- The parent store owns revalidation; the scope is a transparent passthrough that reads whatever the parent currently holds.

## Fix

Read the **root first** to settle/revalidate it, then assert the scope inherits that exact value — which is exactly the invariant the test name claims (*"inherits root's **revalidated** value"*). The `count > 1` invariant is kept. No production code changed.

## Sibling tests reviewed

The other maxAge/scope test (shadowed-pin, `wait(40)`) asserts a pinned shadow / `count === 1` independent of tick count, and the globalAtom maxAge timing tests use relative `toBeGreaterThan` assertions with comfortable margins (e.g. 75ms wait vs 50ms TTL). No exact-tick-count-over-wall-clock flake remains. Left untouched to avoid colliding with the in-flight `fix-maxage-leak` / `global-atom-maxage-dedup` branches.

## Verification

`bun test src/lib/scope.test.ts` run 50× in a tight loop — 50/50 clean (21 tests, 85 assertions each run).

Test-only change to a publishable package, so an empty changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)