### PR TITLE
Make cross-scope transactions atomically observable

### DIFF
--- a/.changeset/atomic-cross-scope-txn.md
+++ b/.changeset/atomic-cross-scope-txn.md
@@ -1,0 +1,36 @@
+---
+"valdres": patch
+---
+
+Make `store.txn()` atomically observable across scopes. A single transaction
+that writes to the root and to one or more scopes (via `t.scope(...)` /
+`t.parentScope(...)`) is now committed as write-everything-then-notify-everything:
+all values across the whole store tree are applied first, then a single
+notification pass runs. Previously each store committed and propagated in
+sequence, so a root subscriber, `onSet` hook, or a selector spanning root + scope
+could observe a half-applied transaction (root = new while a scope was still old,
+or scope A applied before scope B's writes landed). The final committed state was
+always consistent — only the observation was non-atomic.
+
+`atom.onSet` now fires in the notify phase (after all writes) for the cross-scope
+path, so a hook reading any atom sees the fully-applied transaction; it still
+fires before subscribers, preserving the prior relative ordering. The
+single-store / non-scoped-txn fast path is unchanged in both behavior (onSet
+fires inline during the write loop) and performance.
+
+Two related fixes fall out of the coordinated commit:
+
+- A direct subscription created in a scope before the scope shadows an atom is
+  now correctly re-rooted when one transaction both writes that atom at the root
+  and shadows it in the scope — the subscriber fires once (it previously fired
+  twice), matching the non-transaction `set()` path.
+- A selector reachable by more than one store's propagation pass in a single
+  cross-scope commit (one spanning an ancestor atom and a scope atom, or an
+  updated atom and a deleted family) is now evaluated exactly once per commit
+  instead of once per reaching pass.
+- Adding or deleting a family member at the root inside a transaction now
+  cascades into scopes that already shadow that family (their dependent
+  selectors and subscribers see the change). Previously the transaction cloned a
+  new root family index and the shadowing scope kept pointing at the old one, so
+  it never observed the add/delete — the non-transaction `del`/`set` path was
+  already correct.

--- a/packages/valdres/src/lib/atomFamilyIndex.ts
+++ b/packages/valdres/src/lib/atomFamilyIndex.ts
@@ -131,11 +131,23 @@ const findFamilyIndex = (family: Family<any>, data: StoreData) => {
     return value.__index
 }
 
-const recursivelyUpdateIndexes = (data: StoreData, family: Family<any>) => {
+export const recursivelyUpdateIndexes = (
+    data: StoreData,
+    family: Family<any>,
+) => {
     const childScopesWithFamily = data.scopeValueIndex.get(family)
     if (!childScopesWithFamily || childScopesWithFamily.size === 0) return
+    // The parent's family index object can be REPLACED, not just mutated: `del`
+    // and `set` inside a transaction clone the family index, and the clone
+    // becomes the parent's committed index. A child scope that shadows the
+    // family still points its `parentIndex` at the old object, so its rendered
+    // members would reflect the pre-transaction parent. Re-link to the parent's
+    // current index before re-rendering. Outside a txn the parent index is
+    // mutated in place, so `parentIndex` is already correct and this is a no-op.
+    const parentIndex = data.values.get(family).__index
     for (const scopedData of childScopesWithFamily) {
         const index = scopedData.values.get(family).__index
+        index.parentIndex = parentIndex
         index.rendered = null
         index.renderedArray = null
         scopedData.values.set(family, renderAtomFamilyIndex(index))

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -12,6 +12,7 @@ import { isPromiseLike } from "../utils/isPromiseLike"
 import {
     addFamilyAtomsToSet,
     deleteFamilyAtomsFromSet,
+    recursivelyUpdateIndexes,
 } from "./atomFamilyIndex"
 import type { DepsChange } from "./initSelector"
 import {
@@ -136,6 +137,7 @@ export const propagateDeletedAtoms = (
     subscriptions: Set<Subscription> = new Set(),
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>> = new Map(),
     timestamp = performance.now(),
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     const selectors = new Set<Selector>()
     for (const atom of atoms) {
@@ -160,7 +162,7 @@ export const propagateDeletedAtoms = (
             deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
         }
     }
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families)
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, false, evaluatedSelectors)
     // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
     // already updated each scope's family index via recursivelyUpdateIndexes;
     // selectors in those scopes that depend on the family still need to be
@@ -181,17 +183,26 @@ export const propagateDeletedAtoms = (
             }
         }
         for (const [scope, familiesInScope] of scopeFamilies) {
-            propagateInScope(familiesInScope, scope)
+            propagateInScope(familiesInScope, scope, false, evaluatedSelectors)
         }
     }
 }
 
 // Top-level entry: notify direct atom subscribers, walk dependent selectors,
 // then cross-propagate into scopes.
+//
+// `evaluatedSelectors` (cross-scope commit only): a per-commit guard set. A
+// selector lives in one store but can be reached twice in a single cross-scope
+// commit — once via an ancestor's propagateToScopes, once via its own store's
+// pass. Since every value is written before any propagation runs, whichever
+// pass reaches a selector first computes its final value; the guard skips the
+// redundant second evaluation. Left undefined on the single-store / non-scoped
+// hot path, so that path is unchanged.
 export const propagateAtomUpdate = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     // Fast path: single non-family atom with no dependent selectors and no
     // scopes can skip the full graph walk entirely and just notify subscribers.
@@ -239,10 +250,25 @@ export const propagateAtomUpdate = (
         }
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly)
+    // A family OBJECT in `atoms` whose value changed without a corresponding
+    // family-atom update (the txn delete case: the rendered list shrank but the
+    // deleted member flows through propagateDeletedAtoms, not `families`) means
+    // the parent's committed family index may be a freshly cloned object. Re-link
+    // shadowing child scopes so their dependent selectors read the new index
+    // before they are evaluated below. Family-atom adds already did this via
+    // addFamilyAtomsToSet, so skip families handled there.
+    if (data.scopes && data.scopes.size > 0) {
+        for (const atom of atoms) {
+            if (isAtomFamily(atom) && !families.has(atom)) {
+                recursivelyUpdateIndexes(data, atom)
+            }
+        }
+    }
+
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, evaluatedSelectors)
 
     if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly)
+        propagateToScopes(atoms, data, isInitOnly, evaluatedSelectors)
     }
 }
 
@@ -254,6 +280,7 @@ export const propagateInScope = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     const subscriptions = new Set<Subscription>()
     const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
@@ -263,10 +290,10 @@ export const propagateInScope = (
         addSetToSet(data.stateDependents.get(atom), selectors)
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly)
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, evaluatedSelectors)
 
     if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly)
+        propagateToScopes(atoms, data, isInitOnly, evaluatedSelectors)
     }
 }
 
@@ -274,6 +301,7 @@ const propagateToScopes = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly: boolean,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     if (atoms.length === 1) {
         // Fast path for single-atom updates (most common case)
@@ -283,7 +311,7 @@ const propagateToScopes = (
             : data.scopeValueIndex.get(atom)
         for (const [, scope] of data.scopes) {
             if (!shadowingScopes || !shadowingScopes.has(scope)) {
-                propagateInScope(atoms, scope, isInitOnly)
+                propagateInScope(atoms, scope, isInitOnly, evaluatedSelectors)
             }
         }
         return
@@ -305,7 +333,7 @@ const propagateToScopes = (
 
     if (!anyShadowed) {
         for (const [, scope] of data.scopes) {
-            propagateInScope(atoms, scope, isInitOnly)
+            propagateInScope(atoms, scope, isInitOnly, evaluatedSelectors)
         }
         return
     }
@@ -328,7 +356,7 @@ const propagateToScopes = (
             }
         }
         if (atomsToUpdateInScope.length > 0) {
-            propagateInScope(atomsToUpdateInScope, scope, isInitOnly)
+            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, evaluatedSelectors)
         }
     }
 }
@@ -340,6 +368,7 @@ export const propagateDirtySelectors = (
     subscriptions: Set<Subscription>,
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
     isInitOnly = false,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     const updatedInitializedAtoms = new Set<Atom>(updatedAtoms)
     if (selectors.size > 0) {
@@ -352,6 +381,7 @@ export const propagateDirtySelectors = (
             subscriptions,
             updatedInitializedAtoms,
             isInitOnly,
+            evaluatedSelectors,
         )
     }
     if (subscriptions.size > 0) {
@@ -373,6 +403,7 @@ const propagateDownstreamTopo = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     const closure = new Set<Selector>(seeds)
     {
@@ -436,6 +467,15 @@ const propagateDownstreamTopo = (
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
+
+        // Cross-scope commit dedup: already evaluated (with final values) by an
+        // earlier store-pass this commit. Its value won't change here, so drain
+        // its pending edges without re-evaluating or re-propagating change.
+        if (evaluatedSelectors !== undefined && evaluatedSelectors.has(selector)) {
+            advance(selector, false)
+            continue
+        }
+
         const currentValue = data.values.get(selector)
 
         if (isPromiseLike(currentValue) && isInitOnly) {
@@ -471,6 +511,7 @@ const propagateDownstreamTopo = (
             depsChange,
             currentValue,
         )
+        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
@@ -522,6 +563,7 @@ const propagateSelectorUpdates = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly = false,
+    evaluatedSelectors?: Set<Selector>,
 ) => {
     if (selectors.size === 0) return
 
@@ -530,6 +572,12 @@ const propagateSelectorUpdates = (
     // Reused across every re-evaluated selector — see propagateDownstreamTopo.
     const depsChange: DepsChange = {}
     for (const selector of selectors) {
+        // Cross-scope commit dedup: an earlier store-pass this commit already
+        // evaluated this selector with final values, fired its subscribers, and
+        // walked its downstream. Skip it entirely.
+        if (evaluatedSelectors !== undefined && evaluatedSelectors.has(selector)) {
+            continue
+        }
         const currentValue = data.values.get(selector)
         if (isPromiseLike(currentValue) && isInitOnly) continue
         const dependents = data.stateDependents.get(selector)
@@ -552,6 +600,7 @@ const propagateSelectorUpdates = (
             depsChange,
             currentValue,
         )
+        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
@@ -587,6 +636,7 @@ const propagateSelectorUpdates = (
             collectedSubscribers,
             updatedInitializedAtoms,
             isInitOnly,
+            evaluatedSelectors,
         )
     }
 }

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -1,9 +1,7 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
-import { isPromiseLike } from "../utils/isPromiseLike"
-import { getState } from "./getState"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
-import { setValueInData } from "./setValueInData"
+import { writeAtoms } from "./writeAtoms"
 
 export const setAtoms = (
     pairs: Map<Atom<any>, any>,
@@ -11,27 +9,7 @@ export const setAtoms = (
     initializedAtomsSet: Set<Atom>,
     skipOnSet = false,
 ) => {
-    const updatedAtoms: Atom[] = []
-    for (let [atom, value] of pairs) {
-        const currentValue = getState(atom, data, initializedAtomsSet)
-        const areEqual = isPromiseLike(currentValue) || isPromiseLike(value)
-            ? currentValue === value
-            : atom.equal(currentValue, value)
-        if (!areEqual) {
-            updatedAtoms.push(atom)
-            value = setValueInData(atom, value, data)
-            if (atom.onSet && !skipOnSet) atom.onSet(value, data)
-        } else {
-            // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope
-            setValueInData(atom, value, data)
-        }
-    }
-    // Merge updatedAtoms and initializedAtomsSet without extra Set+spread
-    if (initializedAtomsSet.size > 0) {
-        for (const atom of initializedAtomsSet) {
-            updatedAtoms.push(atom)
-        }
-    }
+    const updatedAtoms = writeAtoms(pairs, data, initializedAtomsSet, skipOnSet)
     if (updatedAtoms.length > 0) {
         propagateAtomUpdate(updatedAtoms, data)
     }

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -44,7 +44,21 @@ export const setValueInData = <Value extends unknown>(
         data.values.set(atom, frozenValue)
         written = frozenValue
     }
-    if (isNewAtomInScope) trackScopeValue(atom, data)
+    if (isNewAtomInScope) {
+        trackScopeValue(atom, data)
+        // This scope now shadows `atom`, so any subscription here that was
+        // delegating to an ancestor must stop delegating now — otherwise an
+        // ancestor write in the same transaction commit would notify it in
+        // addition to this scope's own notification. subscribe() also drops the
+        // delegate lazily on the first scope-local callback, but in a single
+        // cross-scope commit the ancestor's notify pass can run first; dropping
+        // it here (during the write phase, before any notification) keeps the
+        // subscriber single-fire. Idempotent with the lazy path.
+        const subs = data.subscriptions.get(atom)
+        if (subs) {
+            for (const sub of subs) sub.reRoot?.()
+        }
+    }
     // Record the write timestamp for atoms with maxAge so unmounted reads
     // can lazily revalidate once the freshness window has elapsed.
     if ((atom as Atom<Value>).maxAge !== undefined) {

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -272,6 +272,7 @@ export const subscribe = <V>(
     data: StoreData,
 ) => {
     let parentUnsubscribe: undefined | (() => void)
+    let dropDelegate: undefined | (() => void)
     if (
         data.parent &&
         ((!data.values.has(state) && isAtom(state)) || isAtomFamily(state))
@@ -289,14 +290,19 @@ export const subscribe = <V>(
             requireDeepEqualCheckBeforeCallback,
             data.parent,
         )
-        callback = arg => {
+        // Idempotent: once the scope re-roots the subscription, the parent-side
+        // delegate must drop so we don't double-notify on later writes. This
+        // fires either lazily (first scope-local propagation, below) or eagerly
+        // (when the scope shadows the state — see setValueInData), whichever
+        // comes first.
+        dropDelegate = () => {
             if (parentUnsubscribe) {
-                // Idempotent: once the scope re-roots the subscription, the
-                // parent-side delegate must drop on the first scope-local
-                // propagation so we don't double-notify on later writes.
                 parentUnsubscribe()
                 parentUnsubscribe = undefined
             }
+        }
+        callback = arg => {
+            dropDelegate!()
             originalCallback(arg)
         }
     } else if (!data.values.has(state) && isAtom(state)) {
@@ -325,11 +331,13 @@ export const subscribe = <V>(
             callback,
             state,
             requireDeepEqualCheckBeforeCallback,
+            reRoot: dropDelegate,
         }
     } else {
         subscription = {
             callback,
             requireDeepEqualCheckBeforeCallback,
+            reRoot: dropDelegate,
         }
     }
     subscribers.add(subscription)

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -1,0 +1,845 @@
+import { describe, test, expect, mock } from "bun:test"
+import { store } from "../store"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
+
+// A single store.txn() that writes to the root and to one or more scopes must
+// be observed atomically: no subscriber, onSet hook, or selector should ever
+// see a state where part of the transaction (one store/scope) is applied but
+// another isn't. The final committed state was always consistent; what these
+// tests pin is that every *observation point* (subscriber, selector recompute,
+// onSet hook) sees the fully-applied transaction.
+
+describe("cross-scope transactions are atomically observable", () => {
+    describe("single scope", () => {
+        test("root subscriber never sees root=new while scope=old", () => {
+            const root = store()
+            const S = root.scope("S")
+
+            const r = atom(1, { name: "r" })
+            const s = atom(10, { name: "s" })
+
+            // Establish a scope-local shadow for `s` before the txn.
+            S.set(s, 10)
+
+            const observed: Array<[number, number]> = []
+            root.sub(r, () => {
+                observed.push([root.get(r), S.get(s)])
+            })
+
+            root.txn(t => {
+                t.set(r, 2)
+                t.scope("S", st => st.set(s, 20))
+            })
+
+            // The subscriber must only ever observe the fully-applied state.
+            expect(observed).toEqual([[2, 20]])
+        })
+
+        test("selector spanning root + scope is notified once with final values", () => {
+            const root = store()
+            const S = root.scope("S")
+
+            const r = atom(1, { name: "r2" })
+            const s = atom(10, { name: "s2" })
+            S.set(s, 10)
+
+            const sum = selector(get => get(r) + get(s), { name: "sum" })
+
+            const observed: number[] = []
+            const cb = mock(() => {
+                observed.push(S.get(sum))
+            })
+            S.sub(sum, cb)
+            expect(S.get(sum)).toBe(11)
+
+            root.txn(t => {
+                t.set(r, 2)
+                t.scope("S", st => st.set(s, 20))
+            })
+
+            // Final value is 22. The intermediate half-applied value
+            // (2 + 10 = 12) must never be observed.
+            expect(observed).not.toContain(12)
+            expect(observed).toEqual([22])
+            expect(S.get(sum)).toBe(22)
+        })
+
+        test("scope newly shadows a root atom with the same value root is set to", () => {
+            // Regression for the leaf-first write order. The scope creates its
+            // first shadow of X *in this txn*, set to the exact value the root
+            // is simultaneously setting X to. The scope's selector was reading
+            // the inherited value (0) and must recompute to 5 — even though the
+            // scope's shadow numerically equals the root's new value. Writing
+            // parent-first would mask this (getState would already return 5) and
+            // the root's propagateToScopes would skip the now-shadowing scope.
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(0, { name: "ns-x" })
+
+            const sel = selector(get => get(X), { name: "ns-sel" })
+            const cb = mock(() => {})
+            S.sub(sel, cb)
+            expect(S.get(sel)).toBe(0)
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("S", st => st.set(X, 5))
+            })
+
+            expect(S.get(sel)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(1)
+            // Root side is unaffected.
+            expect(root.get(X)).toBe(5)
+        })
+
+        test("scope shadow + root write in one txn: each side sees its own final value", () => {
+            const root = store()
+            const S = root.scope("S")
+            const x = atom(0, { name: "shadow-x" })
+            // Establish the shadow (and re-root S's subscription) before the txn.
+            S.set(x, 50)
+
+            const rootSeen: Array<[number, number]> = []
+            const scopeSeen: Array<[number, number]> = []
+            root.sub(x, () => rootSeen.push([root.get(x), S.get(x)]))
+            S.sub(x, () => scopeSeen.push([root.get(x), S.get(x)]))
+
+            root.txn(t => {
+                t.set(x, 1)
+                t.scope("S", st => st.set(x, 100))
+            })
+
+            expect(root.get(x)).toBe(1)
+            expect(S.get(x)).toBe(100)
+            // Both observers see the same fully-applied snapshot.
+            expect(rootSeen).toEqual([[1, 100]])
+            expect(scopeSeen).toEqual([[1, 100]])
+        })
+    })
+
+    describe("multiple scopes", () => {
+        test("every observer sees all scopes applied, each fires once", () => {
+            const root = store()
+            const A = root.scope("A")
+            const B = root.scope("B")
+
+            const r = atom(0, { name: "m-r" })
+            const a = atom(0, { name: "m-a" })
+            const b = atom(0, { name: "m-b" })
+            A.set(a, 0)
+            B.set(b, 0)
+
+            const snapshots: Array<[string, number, number, number]> = []
+            root.sub(r, () =>
+                snapshots.push(["root", root.get(r), A.get(a), B.get(b)]),
+            )
+            A.sub(a, () =>
+                snapshots.push(["A", root.get(r), A.get(a), B.get(b)]),
+            )
+            B.sub(b, () =>
+                snapshots.push(["B", root.get(r), A.get(a), B.get(b)]),
+            )
+
+            root.txn(t => {
+                t.set(r, 1)
+                t.scope("A", st => st.set(a, 2))
+                t.scope("B", st => st.set(b, 3))
+            })
+
+            // Regardless of which store is being notified, the full final
+            // state [1, 2, 3] is visible.
+            for (const [, rv, av, bv] of snapshots) {
+                expect([rv, av, bv]).toEqual([1, 2, 3])
+            }
+            expect(snapshots.length).toBe(3)
+        })
+
+        test("scope A's subscriber sees scope B's write in the same txn", () => {
+            const root = store()
+            const A = root.scope("A")
+            const B = root.scope("B")
+            const a = atom(0, { name: "ab-a" })
+            const b = atom(0, { name: "ab-b" })
+            A.set(a, 0)
+            B.set(b, 0)
+
+            const seen: number[] = []
+            A.sub(a, () => seen.push(B.get(b)))
+
+            root.txn(t => {
+                t.scope("A", st => st.set(a, 1))
+                t.scope("B", st => st.set(b, 2))
+            })
+
+            expect(seen).toEqual([2])
+        })
+    })
+
+    describe("nested scopes", () => {
+        test("deep observer sees every level applied, in one notification", () => {
+            const root = store()
+            const S = root.scope("S")
+            const N = S.scope("N")
+
+            const r = atom(0, { name: "n-r" })
+            const s = atom(0, { name: "n-s" })
+            const n = atom(0, { name: "n-n" })
+            S.set(s, 0)
+            N.set(n, 0)
+
+            const span = selector(
+                get => `${get(r)}-${get(s)}-${get(n)}`,
+                { name: "n-span" },
+            )
+            const seen: string[] = []
+            N.sub(span, () => seen.push(N.get(span)))
+            expect(N.get(span)).toBe("0-0-0")
+
+            root.txn(t => {
+                t.set(r, 1)
+                t.scope("S", st => {
+                    st.set(s, 2)
+                    st.scope("N", nt => nt.set(n, 3))
+                })
+            })
+
+            expect(seen).toEqual(["1-2-3"])
+            expect(N.get(span)).toBe("1-2-3")
+        })
+
+        test("newly shadow same-as-root value at an INTERMEDIATE scope", () => {
+            // Same hazard as the single-scope newly-shadow regression, but the
+            // shadow is created at an intermediate level (A) of root → A → B.
+            // A's own selector must recompute even though A's shadow equals the
+            // root's new value. Exercises leaf-first ordering at depth.
+            const root = store()
+            const A = root.scope("A")
+            A.scope("B")
+            const X = atom(0, { name: "i-x" })
+
+            const sel = selector(get => get(X), { name: "i-sel" })
+            const cb = mock(() => {})
+            A.sub(sel, cb)
+            expect(A.get(sel)).toBe(0)
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("A", st => st.set(X, 5))
+            })
+
+            expect(A.get(sel)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("shadow at intermediate scope, observed through a leaf selector", () => {
+            // The shadow is pinned at A; the observer is a selector in the leaf
+            // B (which inherits X from A). When root and A both set X=5, B must
+            // recompute to 5 and be notified exactly once — the root→A→B
+            // cross-propagation has to reach B through the shadowing intermediate.
+            const root = store()
+            const A = root.scope("A")
+            const B = A.scope("B")
+            const X = atom(0, { name: "i2-x" })
+
+            const sel = selector(get => get(X), { name: "i2-sel" })
+            const cb = mock(() => {})
+            B.sub(sel, cb)
+            expect(B.get(sel)).toBe(0)
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("A", st => st.set(X, 5))
+            })
+
+            expect(B.get(sel)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe("parentScope", () => {
+        test("root subscriber sees a child write reached via parentScope", () => {
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(0, { name: "ps-r" })
+            const c = atom(0, { name: "ps-c" })
+            child.set(c, 0)
+
+            const seen: Array<[number, number]> = []
+            root.sub(r, () => seen.push([root.get(r), child.get(c)]))
+
+            child.txn(t => {
+                t.set(c, 5)
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            expect(seen).toEqual([[9, 5]])
+        })
+    })
+
+    describe("onSet timing", () => {
+        test("onSet on a root atom sees the scope write and fires before subscribers", () => {
+            const root = store()
+            const S = root.scope("S")
+            const s = atom(0, { name: "ot-s" })
+            S.set(s, 0)
+
+            const order: Array<[string, number]> = []
+            const r = atom(0, {
+                name: "ot-r",
+                onSet: () => order.push(["onSet:r", S.get(s)]),
+            })
+            root.sub(r, () => order.push(["sub:r", S.get(s)]))
+
+            root.txn(t => {
+                t.set(r, 1)
+                t.scope("S", st => st.set(s, 7))
+            })
+
+            // onSet observes the fully-applied scope value (7), and fires
+            // before the subscriber — preserving the legacy relative order.
+            expect(order).toEqual([
+                ["onSet:r", 7],
+                ["sub:r", 7],
+            ])
+        })
+
+        test("onSet in scope A sees scope B's write in the same txn", () => {
+            const root = store()
+            const A = root.scope("A")
+            const B = root.scope("B")
+            const b = atom(0, { name: "ob-b" })
+            const seen: number[] = []
+            const a = atom(0, {
+                name: "ob-a",
+                onSet: () => seen.push(B.get(b)),
+            })
+            A.set(a, 0)
+            B.set(b, 0)
+
+            root.txn(t => {
+                t.scope("A", st => st.set(a, 1))
+                t.scope("B", st => st.set(b, 2))
+            })
+
+            expect(seen).toEqual([2])
+        })
+
+        test("onSet on a scope atom is deferred until the root write also lands", () => {
+            // The distinguishing test for deferral: writes run leaf-first, so the
+            // scope atom is written BEFORE the root atom. If onSet fired inline
+            // during the write loop it would observe the not-yet-written root
+            // value (0). Deferring every onSet to the notify phase — after all
+            // writes — guarantees it sees the fully-applied root value.
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(0, { name: "od-r" })
+            const seen: number[] = []
+            const a = atom(0, {
+                name: "od-a",
+                onSet: () => seen.push(root.get(r)),
+            })
+            S.set(a, 0) // S shadows `a` so the scope (written first) sets it
+
+            root.txn(t => {
+                t.set(r, 7) // root written last (leaf-first)
+                t.scope("S", st => st.set(a, 1))
+            })
+
+            expect(seen).toEqual([7]) // never the inline-observed 0
+        })
+
+        test("onSet still fires inline (mid-write-loop) for a non-scoped txn", () => {
+            // The single-store fast path is unchanged: onSet fires during the
+            // write loop, before subscribers, exactly as before.
+            const root = store()
+            const order: string[] = []
+            const a = atom(0, {
+                name: "inline-a",
+                onSet: () => order.push("onSet:a"),
+            })
+            const b = atom(0, {
+                name: "inline-b",
+                onSet: () => order.push("onSet:b"),
+            })
+            root.sub(a, () => order.push("sub:a"))
+            root.sub(b, () => order.push("sub:b"))
+
+            root.txn(t => {
+                t.set(a, 1)
+                t.set(b, 1)
+            })
+
+            // Both onSets fire during the write loop, then subscribers.
+            expect(order).toEqual(["onSet:a", "onSet:b", "sub:a", "sub:b"])
+        })
+    })
+
+    describe("deletes within a cross-scope txn", () => {
+        test("family delete at root + scope write observed atomically", () => {
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "del-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+
+            const S = root.scope("S")
+            const s = atom(0, { name: "del-s" })
+            S.set(s, 0)
+
+            const count = selector(get => get(fam).length, {
+                name: "del-count",
+            })
+            const seen: Array<[number, number]> = []
+            root.sub(count, () => seen.push([root.get(count), S.get(s)]))
+            expect(root.get(count)).toBe(2)
+
+            root.txn(t => {
+                t.del(m2)
+                t.scope("S", st => st.set(s, 9))
+            })
+
+            // The count subscriber observes the deletion AND the scope write
+            // together — never count=1 while the scope is still old.
+            expect(seen).toEqual([[1, 9]])
+            expect(root.get(count)).toBe(1)
+        })
+
+        test("cross-scope delete removes the member value and notifies its direct subscriber", () => {
+            // A family-index write alone makes a `length` selector look right, so
+            // assert the parts that ONLY the delete pass provides: the member's
+            // value is actually evicted from the store, and a subscriber on the
+            // deleted member is notified. (Guards against the cross-scope commit
+            // silently dropping deleteAtomFamilyAtoms / propagateDeletedAtoms.)
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "cd-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const S = root.scope("S")
+            const sAtom = atom(0, { name: "cd-s" })
+            const m2cb = mock(() => {})
+            root.sub(m2, m2cb)
+            expect(root.data.values.has(m2)).toBe(true)
+
+            root.txn(t => {
+                t.del(m2)
+                t.scope("S", st => st.set(sAtom, 9))
+            })
+
+            expect(root.data.values.has(m2)).toBe(false) // value evicted
+            expect(m2cb).toHaveBeenCalledTimes(1) // deletion notified
+        })
+
+        test("delete at root + scope NEWLY shadows another atom, spanning selector", () => {
+            // Combines the delete path with the newly-shadow hazard: a selector
+            // spanning the family count and a scope atom that S shadows for the
+            // first time in this txn. The selector must end at the fully-applied
+            // state ("1:9") and fire exactly once — no half-applied "1:0" or
+            // "2:9", and the new shadow must not get masked.
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "dn-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+
+            const S = root.scope("S")
+            const Y = atom(0, { name: "dn-y" })
+
+            const span = selector(get => `${get(fam).length}:${get(Y)}`, {
+                name: "dn-span",
+            })
+            const seen: string[] = []
+            S.sub(span, () => seen.push(S.get(span)))
+            expect(S.get(span)).toBe("2:0")
+
+            root.txn(t => {
+                t.del(m2)
+                t.scope("S", st => st.set(Y, 9)) // first shadow of Y in S
+            })
+
+            expect(S.get(span)).toBe("1:9")
+            expect(seen).toEqual(["1:9"])
+        })
+    })
+
+    describe("family atoms in a scoped txn", () => {
+        test("members added at root + scope are atomically observable", () => {
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "fam-scope" })
+            const S = root.scope("S")
+
+            const count = selector(get => get(fam).length, {
+                name: "fam-count",
+            })
+            const seen: number[] = []
+            S.sub(count, () => seen.push(S.get(count)))
+            expect(S.get(count)).toBe(0)
+
+            root.txn(t => {
+                t.set(fam("r1"), "x")
+                t.scope("S", st => st.set(fam("s1"), "y"))
+            })
+
+            // S sees the root-level member AND its own member in a single
+            // notification — never just the root member (length 1) first.
+            expect(seen).toEqual([2])
+            expect(S.get(count)).toBe(2)
+        })
+    })
+
+    describe("subscription re-rooting on a txn scope-shadow", () => {
+        test("delegated direct subscription fires once when the scope shadows in the same txn", () => {
+            // A direct atom subscription created in a scope before the scope
+            // shadows the atom is registered both at the scope (a wrapped
+            // callback) and, delegated, at root. When one txn both writes X at
+            // root and shadows X in the scope, leaf-first notification runs the
+            // scope's pass first; its wrapped callback drops the root delegate
+            // before root's pass would fire it — so the subscriber fires once,
+            // matching how the non-txn set() path re-roots.
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(0, { name: "rr-x" })
+            const cb = mock(() => {})
+            S.sub(X, cb) // delegated to root (S has not shadowed X yet)
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("S", st => st.set(X, 5)) // S newly shadows X
+            })
+
+            expect(S.get(X)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(1)
+
+            // And the delegate is gone: a later root write must NOT notify S.
+            root.set(X, 6)
+            expect(cb).toHaveBeenCalledTimes(1)
+            expect(S.get(X)).toBe(5) // S keeps its shadow
+        })
+
+        test("scope shadows with a value different from root's", () => {
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(0, { name: "rr-x2" })
+            const cb = mock(() => {})
+            S.sub(X, cb)
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("S", st => st.set(X, 9))
+            })
+
+            expect(root.get(X)).toBe(5)
+            expect(S.get(X)).toBe(9)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("scope subscription still delegates when the scope does NOT shadow in the txn", () => {
+            // If the scope never shadows X, the delegate must remain: a root
+            // write in the txn still notifies the scope subscriber.
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(0, { name: "rr-x3" })
+            const cb = mock(() => {})
+            S.sub(X, cb)
+
+            root.txn(t => {
+                t.set(X, 5)
+            })
+
+            expect(S.get(X)).toBe(5) // inherited
+            expect(cb).toHaveBeenCalledTimes(1)
+
+            // Delegate intact — a second root write still notifies S.
+            root.set(X, 6)
+            expect(cb).toHaveBeenCalledTimes(2)
+            expect(S.get(X)).toBe(6)
+        })
+    })
+
+    describe("deduped union-propagation", () => {
+        test("a root+scope spanning selector evaluates its body once per commit", () => {
+            // The selector is reachable both via the root's propagateToScopes
+            // and via the scope's own propagation pass. The per-commit
+            // `evaluatedSelectors` guard makes it evaluate exactly once —
+            // whichever pass reaches it first computes the final value (all
+            // writes are applied before any propagation), and the other is
+            // skipped rather than recomputed-then-discarded.
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dd-r" })
+            const s = atom(10, { name: "dd-s" })
+            S.set(s, 10)
+
+            let evals = 0
+            const sum = selector(
+                get => {
+                    evals++
+                    return get(r) + get(s)
+                },
+                { name: "dd-sum" },
+            )
+            const cb = mock(() => {})
+            S.sub(sum, cb)
+            S.get(sum)
+            const before = evals
+
+            root.txn(t => {
+                t.set(r, 2)
+                t.scope("S", st => st.set(s, 20))
+            })
+
+            expect(S.get(sum)).toBe(22)
+            expect(evals - before).toBe(1) // single body evaluation
+            expect(cb).toHaveBeenCalledTimes(1) // single notification
+        })
+
+        test("deeper spanning chain: each selector body runs once", () => {
+            // r (root) and s (scope) feed a → b. Both a and b span the two
+            // stores; both must evaluate exactly once across the commit's two
+            // store-passes.
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dd2-r" })
+            const s = atom(10, { name: "dd2-s" })
+            S.set(s, 10)
+
+            let aEvals = 0
+            let bEvals = 0
+            const a = selector(
+                get => {
+                    aEvals++
+                    return get(r) + get(s)
+                },
+                { name: "dd2-a" },
+            )
+            const b = selector(
+                get => {
+                    bEvals++
+                    return get(a) + get(s)
+                },
+                { name: "dd2-b" },
+            )
+            S.sub(b, () => {})
+            S.get(b)
+            const aBefore = aEvals
+            const bBefore = bEvals
+
+            root.txn(t => {
+                t.set(r, 2)
+                t.scope("S", st => st.set(s, 20))
+            })
+
+            expect(S.get(a)).toBe(22)
+            expect(S.get(b)).toBe(42)
+            expect(aEvals - aBefore).toBe(1)
+            expect(bEvals - bBefore).toBe(1)
+        })
+
+        test("single-store update + delete: spanning selector body runs once", () => {
+            // A selector depending on both an updated atom AND a deleted family
+            // is reachable by the commit's update pass (propagateAtomUpdate) and
+            // its delete pass (propagateDeletedAtoms). The shared guard makes it
+            // evaluate once. (This double-eval predates the cross-scope work — it
+            // lives in the single-store fast path too.)
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "ud-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const Y = atom(0, { name: "ud-y" })
+
+            let evals = 0
+            const span = selector(
+                get => {
+                    evals++
+                    return `${get(fam).length}:${get(Y)}`
+                },
+                { name: "ud-span" },
+            )
+            const cb = mock(() => {})
+            root.sub(span, cb)
+            root.get(span)
+            const before = evals
+
+            root.txn(t => {
+                t.del(m2)
+                t.set(Y, 9)
+            })
+
+            expect(root.get(span)).toBe("1:9")
+            expect(evals - before).toBe(1)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("cross-scope: scope selector spanning a root atom + a root-deleted family runs once", () => {
+            // A selector in S depends on a root atom (updated) and a root family
+            // (member deleted), with S NOT shadowing the family. Both reach S in
+            // a single propagateToScopes pass, so the selector evaluates once and
+            // ends at the fully-applied state.
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "cud-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const R = atom(0, { name: "cud-r" })
+            const S = root.scope("S")
+
+            let evals = 0
+            const span = selector(
+                get => {
+                    evals++
+                    return `${get(fam).length}:${get(R)}`
+                },
+                { name: "cud-span" },
+            )
+            const cb = mock(() => {})
+            S.sub(span, cb)
+            S.get(span)
+            const before = evals
+
+            root.txn(t => {
+                t.del(m2)
+                t.set(R, 9)
+            })
+
+            expect(S.get(span)).toBe("1:9")
+            expect(evals - before).toBe(1)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    // The dedup guard skips a selector once any pass has evaluated it. That is
+    // only sound if the FIRST pass to reach a selector evaluates it against
+    // final values. For a scope selector that transitively depends on an
+    // ancestor atom THROUGH another scope selector, that requires the ancestor's
+    // pass (which settles the intermediate scope selector via propagateToScopes)
+    // to run before the scope's own pass — i.e. root-first notify. These pin
+    // that ordering invariant directly, with plain selectors (no families), so a
+    // regression to leaf-first notify is caught here rather than incidentally.
+    describe("commit propagation order keeps transitive scope selectors fresh", () => {
+        test("scope selector → scope selector → root atom, plus a scope atom, in one txn", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "ord-r" }) // root atom
+            const Y = atom(0, { name: "ord-y" }) // scope atom
+            S.set(Y, 0)
+
+            // A (in S) depends on the root atom; B (in S) depends on A AND the
+            // scope atom. Under leaf-first notify the scope's Y-pass would
+            // evaluate B against a stale A (r not yet propagated into S) and the
+            // guard would then skip B's correcting re-eval in the root pass.
+            const A = selector(get => get(r), { name: "ord-A" })
+            const B = selector(get => get(A) + get(Y), { name: "ord-B" })
+            const cb = mock(() => {})
+            S.sub(B, cb)
+            expect(S.get(B)).toBe(1) // A=1, Y=0
+
+            root.txn(t => {
+                t.set(r, 5)
+                t.scope("S", st => st.set(Y, 9))
+            })
+
+            expect(S.get(A)).toBe(5)
+            expect(S.get(B)).toBe(14) // 5 + 9, never the stale 1 + 9 = 10
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("three-level transitive chain stays consistent", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "ord3-r" })
+            const Y = atom(0, { name: "ord3-y" })
+            S.set(Y, 0)
+
+            const A = selector(get => get(r), { name: "ord3-A" })
+            const Bsel = selector(get => get(A) * 2, { name: "ord3-B" })
+            const C = selector(get => get(Bsel) + get(Y), { name: "ord3-C" })
+            const cb = mock(() => {})
+            S.sub(C, cb)
+            expect(S.get(C)).toBe(2) // A=1 → B=2 → C=2+0
+
+            root.txn(t => {
+                t.set(r, 10)
+                t.scope("S", st => st.set(Y, 3))
+            })
+
+            // A=10 → B=20 → C=20+3. Never a stale intermediate.
+            expect(S.get(C)).toBe(23)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    // A txn that adds or deletes a root family member must cascade into a scope
+    // that already shadows the family. Inside a txn, del()/set() clone a NEW
+    // root family index that becomes the committed one; the shadowing scope's
+    // index keeps a `parentIndex` pointer to the old object, so it must be
+    // re-linked at commit (see recursivelyUpdateIndexes). Outside a txn the root
+    // index is mutated in place, so this always worked there.
+    describe("family add/delete in a txn cascades into a shadowing scope", () => {
+        const buildShadowedFamily = (famName: string) => {
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: famName })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const S = root.scope("S")
+            S.set(fam("s-only"), "z") // S shadows the family (own index)
+            const count = selector(get => get(fam).length, {
+                name: `${famName}-count`,
+            })
+            const cb = mock(() => {})
+            S.sub(count, cb)
+            expect(S.get(count)).toBe(3) // m1, m2, s-only
+            return { root, fam, m1, m2, S, count, cb }
+        }
+
+        test("txn delete of a root member drops the scope's count", () => {
+            const { root, m2, S, count, cb } = buildShadowedFamily("fd-fam")
+            root.txn(t => t.del(m2))
+            expect(S.get(count)).toBe(2) // {m1, s-only}
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("txn add of a root member raises the scope's count", () => {
+            const { root, fam, S, count, cb } = buildShadowedFamily("fa-fam")
+            root.txn(t => t.set(fam("3"), "c"))
+            expect(S.get(count)).toBe(4) // {m1, m2, s-only, 3}
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("cross-scope txn: root delete + scope write both observed", () => {
+            const { root, m2, S, count, cb } = buildShadowedFamily("fc-fam")
+            const Y = atom(0, { name: "fc-y" })
+            S.set(Y, 0)
+            const spanCb = mock(() => {})
+            const span = selector(get => `${get(count)}:${get(Y)}`, {
+                name: "fc-span",
+            })
+            S.sub(span, spanCb)
+            expect(S.get(span)).toBe("3:0")
+
+            root.txn(t => {
+                t.del(m2)
+                t.scope("S", st => st.set(Y, 9))
+            })
+
+            expect(S.get(count)).toBe(2)
+            expect(S.get(span)).toBe("2:9")
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("non-txn root delete still cascades (unchanged behavior)", () => {
+            const { root, m2, S, count } = buildShadowedFamily("fn-fam")
+            root.del(m2)
+            expect(S.get(count)).toBe(2)
+        })
+    })
+})

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -2,6 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { GetValue } from "../types/GetValue"
+import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
@@ -18,8 +19,22 @@ import {
     cloneAtomFamilyIndex,
     renderAtomFamilyIndex,
 } from "./atomFamilyIndex"
-import { propagateDeletedAtoms } from "./propagateUpdatedAtoms"
+import {
+    propagateAtomUpdate,
+    propagateDeletedAtoms,
+} from "./propagateUpdatedAtoms"
 import { setAtoms } from "./setAtoms"
+import { writeAtoms, type DeferredOnSet } from "./writeAtoms"
+
+/** One store's slot in a cross-scope commit. Collected root-first; written
+ *  leaf-first (see commit) but notified root-first. */
+type CommitWrite = {
+    txn: Transaction
+    data: StoreData
+    updatedAtoms: Atom[]
+    deleted: AtomFamilyAtom<any, any>[] | undefined
+    onSets: DeferredOnSet[]
+}
 
 // const findDependencies = (
 //     state: State,
@@ -246,15 +261,145 @@ export class Transaction {
     }
 
     commit = () => {
-        const initializedAtomsSet = new Set<Atom>()
-        setAtoms(this._atomMap, this.data, initializedAtomsSet)
-        if (this.deleteSet?.size) {
-            deleteAtomFamilyAtoms(this.deleteSet, this.data)
-            propagateDeletedAtoms([...this.deleteSet], this.data)
+        // Single-store fast path: no scoped transactions to coordinate, so
+        // write-and-notify in one pass exactly as before. This keeps the
+        // non-scoped txn hot path (the Bencher-gated one) unchanged in both
+        // behavior and cost — onSet fires inline during the write loop here.
+        if (!this._scopedTransactions) {
+            const initializedAtomsSet = new Set<Atom>()
+            if (this._deleteSet?.size) {
+                // Updates and a delete in one single-store txn: a selector that
+                // depends on both an updated atom and the deleted family is
+                // reachable by the update pass (propagateAtomUpdate) and the
+                // delete pass (propagateDeletedAtoms). Share a guard so it
+                // evaluates once. (Splitting setAtoms into writeAtoms + propagate
+                // lets the same guard span both passes.)
+                const evaluatedSelectors = new Set<Selector>()
+                const updatedAtoms = writeAtoms(
+                    this._atomMap,
+                    this.data,
+                    initializedAtomsSet,
+                )
+                if (updatedAtoms.length > 0) {
+                    propagateAtomUpdate(
+                        updatedAtoms,
+                        this.data,
+                        false,
+                        evaluatedSelectors,
+                    )
+                }
+                deleteAtomFamilyAtoms(this._deleteSet, this.data)
+                propagateDeletedAtoms(
+                    [...this._deleteSet],
+                    this.data,
+                    undefined,
+                    undefined,
+                    undefined,
+                    evaluatedSelectors,
+                )
+            } else {
+                setAtoms(this._atomMap, this.data, initializedAtomsSet)
+            }
+            return
         }
+
+        // Cross-scope path: write the whole tree (root + every nested scope)
+        // first, then run a single notification pass per store. This guarantees
+        // no subscriber, onSet hook, or selector ever observes a half-applied
+        // transaction — root written while a scope isn't, or scope A written
+        // while scope B isn't. The final committed state is identical to the
+        // old sequential model; only the observation point moves.
+        const plan: CommitWrite[] = []
+        this.collectStores(plan)
+
+        // Write leaf-first (descendants before ancestors — the reverse of the
+        // root-first plan). A scope's equality check reads through the chain via
+        // getState; writing the parent first would let the parent's new value
+        // mask a scope's own change. Concretely: a scope that newly shadows a
+        // root atom with the same value the root is simultaneously set to would
+        // see "no change" (its getState already returns the parent's new value)
+        // AND be skipped by the root's propagateToScopes (its shadow is now
+        // tracked), so its selectors would never recompute. Leaf-first makes
+        // each store decide against its genuine pre-transaction value.
+        for (let i = plan.length - 1; i >= 0; i--) {
+            const entry = plan[i]
+            const txn = entry.txn
+            entry.updatedAtoms = writeAtoms(
+                txn._atomMap,
+                entry.data,
+                new Set<Atom>(),
+                false,
+                entry.onSets,
+            )
+            if (txn._deleteSet?.size) {
+                deleteAtomFamilyAtoms(txn._deleteSet, entry.data)
+                entry.deleted = [...txn._deleteSet]
+            }
+        }
+
+        // Every value across the tree is now applied. onSet hooks fire here, in
+        // the notify phase, so a hook reading any atom — root or scope — sees
+        // the fully-applied transaction. Fired root-first (matching the old
+        // model's order) and before any subscriber, preserving the
+        // long-standing onSet-before-subscribers ordering. (Deliberate
+        // placement: in the old model onSet fired mid-write-loop and a
+        // cross-scope hook could read a not-yet-written scope value. Deferring
+        // to here is the only placement consistent with atomicity.)
+        for (const entry of plan) {
+            for (const [atom, value, data] of entry.onSets) {
+                atom.onSet!(value, data)
+            }
+        }
+
+        // One propagation pass per store, root-first (ancestors before
+        // descendants). Order matters for correctness with the dedup guard: an
+        // ancestor's pass cross-propagates its atom changes into descendant
+        // scopes (propagateToScopes), so a scope selector that transitively
+        // depends on an ancestor atom is recomputed with final upstream values
+        // before the scope's own pass runs. Running leaf-first instead could
+        // evaluate such a selector against a still-stale upstream scope selector
+        // and the guard would then skip its correcting re-eval.
+        //
+        // `evaluatedSelectors` is a per-commit guard so a selector reachable by
+        // more than one store-pass (e.g. spanning an ancestor atom and a scope
+        // atom, or an updated atom and a deleted family) evaluates exactly once:
+        // whichever pass reaches it first computes its final value (all writes
+        // are already applied, and root-first guarantees upstream selectors are
+        // settled first), and later passes skip it. Without the guard the result
+        // is still correct — the equality check discards the redundant recompute
+        // — but the body would run once per reaching pass.
+        const evaluatedSelectors = new Set<Selector>()
+        for (const { data, updatedAtoms, deleted } of plan) {
+            if (updatedAtoms.length > 0) {
+                propagateAtomUpdate(updatedAtoms, data, false, evaluatedSelectors)
+            }
+            if (deleted) {
+                propagateDeletedAtoms(
+                    deleted,
+                    data,
+                    undefined,
+                    undefined,
+                    undefined,
+                    evaluatedSelectors,
+                )
+            }
+        }
+    }
+
+    // Depth-first pre-order: this store, then each nested scope. Produces a
+    // root-first plan used directly for the notify pass and reversed for the
+    // write pass (so descendants are written before their ancestors).
+    private collectStores = (plan: CommitWrite[]) => {
+        plan.push({
+            txn: this,
+            data: this.data,
+            updatedAtoms: [],
+            deleted: undefined,
+            onSets: [],
+        })
         if (this._scopedTransactions) {
             for (const [, scopedTxn] of this._scopedTransactions) {
-                scopedTxn.commit()
+                scopedTxn.collectStores(plan)
             }
         }
     }

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -1,0 +1,58 @@
+import type { Atom } from "../types/Atom"
+import type { StoreData } from "../types/StoreData"
+import { isPromiseLike } from "../utils/isPromiseLike"
+import { getState } from "./getState"
+import { setValueInData } from "./setValueInData"
+
+/** A deferred onSet invocation: the hook, the written value, and the store it
+ *  was written to. Collected during the write phase of a cross-scope commit so
+ *  hooks fire only once the whole tree has been written. */
+export type DeferredOnSet = [Atom<any>, any, StoreData]
+
+/**
+ * Write phase for a single store. Applies every value in `pairs` to
+ * `data.values`, returning the atoms whose value actually changed (the
+ * propagation set), merged with any atoms lazily initialized during the
+ * equality checks. This does NOT propagate — see `setAtoms` (single-store
+ * fast path) or `Transaction.commit` (cross-scope path) for the notify pass.
+ *
+ * onSet handling:
+ *  - `skipOnSet` true     → never fire onSet.
+ *  - `onSetQueue` given    → defer onSet by pushing `[atom, value, data]`. The
+ *    cross-scope commit uses this so a hook never observes a half-applied
+ *    transaction — it fires only after every store's writes have landed.
+ *  - otherwise             → fire onSet inline (single-store path, unchanged).
+ */
+export const writeAtoms = (
+    pairs: Map<Atom<any>, any>,
+    data: StoreData,
+    initializedAtomsSet: Set<Atom>,
+    skipOnSet = false,
+    onSetQueue?: DeferredOnSet[],
+): Atom[] => {
+    const updatedAtoms: Atom[] = []
+    for (let [atom, value] of pairs) {
+        const currentValue = getState(atom, data, initializedAtomsSet)
+        const areEqual = isPromiseLike(currentValue) || isPromiseLike(value)
+            ? currentValue === value
+            : atom.equal(currentValue, value)
+        if (!areEqual) {
+            updatedAtoms.push(atom)
+            value = setValueInData(atom, value, data)
+            if (atom.onSet && !skipOnSet) {
+                if (onSetQueue) onSetQueue.push([atom, value, data])
+                else atom.onSet(value, data)
+            }
+        } else {
+            // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope
+            setValueInData(atom, value, data)
+        }
+    }
+    // Merge updatedAtoms and initializedAtomsSet without extra Set+spread
+    if (initializedAtomsSet.size > 0) {
+        for (const atom of initializedAtomsSet) {
+            updatedAtoms.push(atom)
+        }
+    }
+    return updatedAtoms
+}

--- a/packages/valdres/src/types/Subscription.ts
+++ b/packages/valdres/src/types/Subscription.ts
@@ -7,11 +7,18 @@ export type AtomFamilySubscription<
     state: AtomFamily<Value, Args>
     callback: (...args: Args) => void
     requireDeepEqualCheckBeforeCallback: boolean
+    /** Present only on a scope subscription that is delegating to an ancestor.
+     *  Drops the ancestor delegate (idempotent). Called eagerly when the scope
+     *  shadows the state so an ancestor write in the same transaction commit
+     *  does not also notify this subscription. */
+    reRoot?: () => void
 }
 
 export type SimpleSubscription = {
     requireDeepEqualCheckBeforeCallback: boolean
     callback: () => void
+    /** See AtomFamilySubscription.reRoot. */
+    reRoot?: () => void
 }
 
 export type Subscription = SimpleSubscription | AtomFamilySubscription


### PR DESCRIPTION
## Problem

`store.txn()` can write to the root store and to scopes in one transaction (`t.scope(...)`, `t.parentScope(...)`). Previously each store committed **and propagated** in sequence, so a root subscriber, an `onSet` hook, or a selector spanning root + scope could observe a **half-applied** transaction (root = new while a scope was still old, or scope A applied before scope B's writes landed). The final committed state was always consistent — only the *observation* was non-atomic.

## Approach

Two-phase commit for the cross-scope path: **write the whole store tree first, then run a single notification pass.**

- **Write leaf-first** (descendants before ancestors) so a scope's equality check reads its genuine pre-transaction inherited value rather than an ancestor's mid-commit write.
- **Notify root-first** so a scope selector that transitively depends on an ancestor atom is recomputed with final upstream values before the scope's own pass.
- **`onSet` deferred** to the notify phase for the cross-scope path (a hook reading any atom sees the fully-applied txn); still fires before subscribers. The single-store / non-scoped fast path is unchanged — `onSet` inline, hot path untouched.

## Fixes that fall out of the coordinated commit

- **Subscription re-rooting**: a direct subscription created in a scope before it shadows an atom is now re-rooted *eagerly* when the scope first shadows (during the write phase), so an ancestor write in the same txn no longer double-notifies it.
- **Deduped propagation**: a selector reachable by more than one store-pass (spanning an ancestor atom + a scope atom, or an updated atom + a deleted family) is evaluated exactly once per commit.
- **Family add/delete in a txn** now cascades into scopes that already shadow the family (the txn clones a new root family index; the shadowing scope's `parentIndex` is re-linked to it). The non-txn `del`/`set` path was already correct.

## Testing

- New `transaction.atomicScope.test.ts`: single/multi/nested scopes, `parentScope`, notification ordering, `onSet` timing/deferral, spanning selectors, deletes, family atoms, re-rooting, dedup, transitive-selector freshness.
- **Mutation-audited**: every implementation decision (leaf-first write, root-first notify, `onSet` deferral, dedup guard + internals, eager re-rooting, family re-link, delete eviction) was deliberately broken and confirmed to fail a test — **zero survivors**.
- 369 tests pass, deterministic across 3 runs; all monorepo packages green; typecheck clean.
- Benches: non-scoped `set`/`txn` hot paths within noise of `main` (the new work is gated behind cross-scope / `isNewAtomInScope` branches).

Merged latest `main` (dev/test-only freeze change); resolved cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)