### PR TITLE
Fix stale selectors after dynamic-dependency changes (beta.4 regression)

### DIFF
--- a/.changeset/stale-selector-dynamic-deps.md
+++ b/.changeset/stale-selector-dynamic-deps.md
@@ -1,0 +1,22 @@
+---
+"valdres": patch
+---
+
+Fix stale selectors after dynamic-dependency changes (regression in 1.0.0-beta.4).
+
+The topological selector-update propagation introduced in beta.4 builds a static
+closure and per-node `pending` counts before the walk, assuming the dependency
+graph is fixed for its duration. A selector re-evaluated out-of-band during the
+walk — most commonly lazily re-initialized via `get` when another selector reads
+it after its value was dropped by orphan-invalidation/unsubscribe — mutates the
+graph mid-walk. That left two classes of node permanently stale: nodes
+materialized after the closure was built ("escaped"), and nodes that dropped a
+snapshotted dependency so their `pending` never drained ("stranded").
+
+This surfaced in apps with conditional ("dragging" vs "settled") selector
+branches that swap dependencies on interaction: after toggling a branch and
+back, derived selectors could return values computed from inputs that no longer
+applied. `advance()` now pulls escaped dependents into the closure, and a
+fixpoint settle pass re-evaluates stranded nodes (and their dependents). The
+steady-state fast path is unaffected — the settle only runs when a stall is
+actually detected.

--- a/packages/valdres/src/lib/propagateDynamicDeps.test.ts
+++ b/packages/valdres/src/lib/propagateDynamicDeps.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+// Regression tests for a selector-invalidation bug introduced when selector
+// update propagation moved to a static topological closure (1.0.0-beta.4).
+//
+// The closure + per-node `pending` counts are a snapshot of the dependency
+// graph taken before propagation runs. They assume the graph is fixed for the
+// duration of the walk. But a selector can be re-evaluated OUT OF BAND during
+// the walk — most commonly lazily re-initialized via `get` when another
+// selector reads it after its value was dropped by orphan-invalidation /
+// unsubscribe. That re-eval mutates the dependency graph mid-walk, which left
+// two classes of node permanently stale:
+//
+//  1. ESCAPED: a node materialized after the closure was built is absent from
+//     the closure, so `advance()` skipped it when one of its dependencies
+//     settled to a new value.
+//  2. STRANDED: a node in the closure that drops a dependency it was
+//     snapshotted with — the dropped parent's reverse edge is gone, so it never
+//     decrements the node's `pending`, which stalls above 0 so the node is
+//     never processed.
+//
+// Both surface as "a selector whose dependency changed value was never
+// re-evaluated", which is exactly what broke dynamic ("dragging" vs "settled")
+// branch toggles in consuming apps.
+
+describe("dynamic-dependency propagation", () => {
+    // Mirrors the minimal failing graph: an orphaned selector (s7) is lazily
+    // re-initialized when a live selector (s8) reads it across a branch toggle,
+    // reading a still-mid-flight dependency (s4), then is dropped from the
+    // static closure so the later settle of s4 never reaches it.
+    test("escaped node: orphan re-read across branch toggle stays fresh", () => {
+        const defs = [
+            { deps: [1, 2], selDeps: [], altSelDeps: [], ctrl: { atom: 0 }, mode: 0 },
+            { deps: [4, 1, 4], selDeps: [0], altSelDeps: [], ctrl: { sel: 0 }, mode: 1 },
+            { deps: [2, 0], selDeps: [1, 0], altSelDeps: [1, 1], ctrl: { atom: 4 }, mode: 2 },
+            { deps: [1, 2, 1], selDeps: [], altSelDeps: [], ctrl: { atom: 2 }, mode: 1 },
+            { deps: [4, 2], selDeps: [2, 2], altSelDeps: [], ctrl: { atom: 4 }, mode: 0 },
+            { deps: [1, 3], selDeps: [], altSelDeps: [], ctrl: { sel: 1 }, mode: 0 },
+            { deps: [1], selDeps: [], altSelDeps: [0], ctrl: { atom: 2 }, mode: 0 },
+            { deps: [2, 0], selDeps: [4], altSelDeps: [], ctrl: { sel: 6 }, mode: 0 },
+            { deps: [2], selDeps: [5, 7], altSelDeps: [], ctrl: { sel: 3 }, mode: 2 },
+            { deps: [0], selDeps: [0, 0], altSelDeps: [2], ctrl: { atom: 2 }, mode: 2 },
+        ] as const
+        const build = () => {
+            const atoms = Array.from({ length: 5 }, (_, i) => atom(i, { name: `a${i}` }))
+            const sels: any[] = []
+            defs.forEach((def, idx) => {
+                sels.push(selector(get => {
+                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
+                    let acc = def.mode + (ctrl % 3)
+                    if (ctrl % 2 === 0) {
+                        for (const di of def.deps) acc += get(atoms[di])
+                        for (const si of def.selDeps) acc += get(sels[si])
+                    } else {
+                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
+                    }
+                    return acc
+                }, { name: `s${idx}` }))
+            })
+            return { atoms, sels }
+        }
+
+        const { atoms, sels } = build()
+        const s = store()
+        const subs: (null | (() => void))[] = sels.map(sel => s.sub(sel, () => {}))
+        // orphan s7 and s0 (s7's only would-be live consumer s8 is on its other
+        // branch, so s7's value is dropped)
+        subs[7]!(); subs[7] = null
+        subs[0]!(); subs[0] = null
+        s.set(atoms[0], 18)
+        s.set(atoms[2], 16)
+
+        const o = build()
+        const os = store()
+        os.set(o.atoms[0], 18)
+        os.set(o.atoms[2], 16)
+
+        for (let i = 0; i < sels.length; i++) {
+            if (!subs[i]) continue
+            expect(s.get(sels[i])).toBe(os.get(o.sels[i]))
+        }
+    })
+
+    // Random dynamic-dependency graphs (branch keyed on a derived selector,
+    // dropping/re-adding selector deps) with subscribe/unsubscribe churn, in
+    // both a root store and a scope. Each step is checked against a fresh store
+    // replaying the identical op sequence — any divergence is a stale selector.
+    test("fuzz: incremental store matches fresh-replay oracle", () => {
+        const mulberry32 = (seed: number) => () => {
+            seed |= 0
+            seed = (seed + 0x6d2b79f5) | 0
+            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        }
+        const buildGraph = (rnd: () => number, nAtoms: number, nSelectors: number) => {
+            const selDefs: any[] = []
+            for (let i = 0; i < nSelectors; i++) {
+                const pick = (n: number, max: number) => {
+                    const out: number[] = []
+                    for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
+                    return out
+                }
+                selDefs.push({
+                    deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
+                    selDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                    altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                    ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
+                    mode: Math.floor(rnd() * 3),
+                })
+            }
+            return { nAtoms, selDefs }
+        }
+        const inst = (g: any) => {
+            const atoms = Array.from({ length: g.nAtoms }, (_, i) => atom(i, { name: `a${i}` }))
+            const sels: any[] = []
+            g.selDefs.forEach((def: any, idx: number) => {
+                sels.push(selector(get => {
+                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
+                    let acc = def.mode + (ctrl % 3)
+                    if (ctrl % 2 === 0) {
+                        for (const di of def.deps) acc += get(atoms[di])
+                        for (const si of def.selDeps) acc += get(sels[si])
+                    } else {
+                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
+                    }
+                    return acc
+                }, { name: `s${idx}` }))
+            })
+            return { atoms, sels }
+        }
+
+        for (let seed = 1; seed <= 200; seed++) {
+            const rnd = mulberry32(seed)
+            const nAtoms = 3 + Math.floor(rnd() * 4)
+            const nSelectors = 10 + Math.floor(rnd() * 12)
+            const g = buildGraph(rnd, nAtoms, nSelectors)
+            const I = inst(g)
+            const root = store()
+            const useScope = rnd() < 0.5
+            const child: any = useScope ? root.scope("child") : root
+
+            const ops: { target: "r" | "c"; ai: number; v: number }[] = []
+            const doOp = (op: { target: "r" | "c"; ai: number; v: number }) => {
+                ops.push(op)
+                if (op.target === "r") root.set(I.atoms[op.ai], op.v)
+                else child.set(I.atoms[op.ai], op.v)
+            }
+            if (useScope) {
+                for (let ai = 0; ai < nAtoms; ai++) if (rnd() < 0.4) doOp({ target: "c", ai, v: Math.floor(rnd() * 20) })
+            }
+            const subbed: (null | (() => void))[] = new Array(nSelectors).fill(null)
+            const toggle = (si: number) => {
+                if (subbed[si]) { subbed[si]!(); subbed[si] = null }
+                else subbed[si] = child.sub(I.sels[si], () => {})
+            }
+            for (let si = 0; si < nSelectors; si++) if (rnd() < 0.6) toggle(si)
+
+            for (let step = 0; step < 40; step++) {
+                const churn = Math.floor(rnd() * 3)
+                for (let c = 0; c < churn; c++) toggle(Math.floor(rnd() * nSelectors))
+                const m = 1 + Math.floor(rnd() * 3)
+                for (let j = 0; j < m; j++) {
+                    const ai = Math.floor(rnd() * nAtoms)
+                    const v = Math.floor(rnd() * 20)
+                    doOp({ target: useScope && rnd() < 0.5 ? "c" : "r", ai, v })
+                }
+
+                const oI = inst(g)
+                const oRoot = store()
+                const oChild: any = useScope ? oRoot.scope("child") : oRoot
+                for (const op of ops) {
+                    if (op.target === "r") oRoot.set(oI.atoms[op.ai], op.v)
+                    else oChild.set(oI.atoms[op.ai], op.v)
+                }
+                for (let si = 0; si < nSelectors; si++) {
+                    if (!subbed[si]) continue
+                    expect(child.get(I.sels[si])).toBe(oChild.get(oI.sels[si]))
+                }
+            }
+            subbed.forEach(u => u && u())
+        }
+    })
+})

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -483,66 +483,12 @@ const propagateDownstreamTopo = (
         }
     }
 
-    const depsChange: DepsChange = {}
-
-    // Re-evaluate one selector and reconcile its side effects: orphan-invalidate
-    // when it has no live consumer, otherwise re-evaluate, mount/unmount any
-    // changed dependencies, and collect its subscribers. Returns whether the
-    // value actually changed. Shared by the topo walk and the settle pass below.
-    const evaluateNode = (selector: Selector, currentValue: unknown): boolean => {
-        const dependents = data.stateDependents.get(selector)
-        const subscribers = data.subscriptions.get(selector)
-        if (
-            !isPromiseLike(currentValue) &&
-            (!dependents || dependents.size === 0) &&
-            (!subscribers || subscribers.size === 0)
-        ) {
-            // No live consumer — invalidate for lazy re-eval on next read.
-            data.values.delete(selector)
-            return false
-        }
-        depsChange.added = undefined
-        depsChange.removed = undefined
-        const wasValueUpdated = reEvaluateSelector(
-            selector,
-            data,
-            updatedInitializedAtoms,
-            depsChange,
-            currentValue,
-        )
-        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
-        // Casts work around a tsgo control-flow narrowing quirk where
-        // property accesses lose their narrowing after a function call.
-        const added = depsChange.added as Set<State> | undefined
-        const removed = depsChange.removed as Set<State> | undefined
-        if (added || removed) {
-            graphMutated = true
-            if (isLive(selector, data)) {
-                if (added) {
-                    for (const dep of added) {
-                        onLiveDependencyAdded(dep, data)
-                        mountTransitiveDeps(dep, data)
-                    }
-                }
-                if (removed) {
-                    for (const dep of removed) {
-                        onLiveDependencyRemoved(dep, data)
-                        unmountOrphanedDeps(dep, data)
-                    }
-                }
-            }
-        }
-        if (wasValueUpdated && subscribers) {
-            addSetToSet(subscribers, collectedSubscribers)
-        }
-        return wasValueUpdated
-    }
-
     // FIFO head pointer preserves the original BFS sibling order — nested
     // writes that side-effect into peer selectors during eval depend on it.
     // Reused across every re-evaluated selector. evaluateSelector only
     // allocates the inner Sets when deps actually changed, so steady-state
     // settling does zero allocation here.
+    const depsChange: DepsChange = {}
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
@@ -567,7 +513,57 @@ const propagateDownstreamTopo = (
             continue
         }
 
-        advance(selector, evaluateNode(selector, currentValue))
+        const dependents = data.stateDependents.get(selector)
+        const subscribers = data.subscriptions.get(selector)
+
+        if (
+            !isPromiseLike(currentValue) &&
+            (!dependents || dependents.size === 0) &&
+            (!subscribers || subscribers.size === 0)
+        ) {
+            // No live consumer — invalidate for lazy re-eval on next read.
+            data.values.delete(selector)
+            advance(selector, false)
+            continue
+        }
+
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluateSelector(
+            selector,
+            data,
+            updatedInitializedAtoms,
+            depsChange,
+            currentValue,
+        )
+        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
+        // Casts work around a tsgo control-flow narrowing quirk where
+        // property accesses lose their narrowing after a function call.
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if (added || removed) {
+            // The graph changed under the walk — a node may now be stranded.
+            graphMutated = true
+            if (isLive(selector, data)) {
+                if (added) {
+                    for (const dep of added) {
+                        onLiveDependencyAdded(dep, data)
+                        mountTransitiveDeps(dep, data)
+                    }
+                }
+                if (removed) {
+                    for (const dep of removed) {
+                        onLiveDependencyRemoved(dep, data)
+                        unmountOrphanedDeps(dep, data)
+                    }
+                }
+            }
+        }
+
+        advance(selector, wasValueUpdated)
+        if (wasValueUpdated && subscribers) {
+            addSetToSet(subscribers, collectedSubscribers)
+        }
     }
 
     // Settle stranded nodes. The `pending` counts are a snapshot taken before
@@ -581,34 +577,71 @@ const propagateDownstreamTopo = (
     // even though one of its surviving dependencies changed. Such a node is left
     // stale, and so is anything that read it. Re-settle the stranded set (and
     // whatever depends on it) with a fixpoint that re-fetches dependents each
-    // pass, which is inherently robust to a graph that changed under us. This
-    // only runs when a stall is actually detected, so the steady-state fast path
-    // is unaffected.
+    // pass, which is inherently robust to a graph that changed under us. Guarded
+    // by `graphMutated`, so the steady-state fast path skips it entirely.
+    if (!graphMutated) return
+
     let stranded: Set<Selector> | undefined
-    if (graphMutated) {
-        for (const s of closure) {
-            if (needsEval.has(s) && (pending.get(s) ?? 0) > 0) {
-                if (!stranded) stranded = new Set()
-                stranded.add(s)
-            }
+    for (const s of closure) {
+        if (needsEval.has(s) && (pending.get(s) ?? 0) > 0) {
+            if (!stranded) stranded = new Set()
+            stranded.add(s)
         }
     }
-    if (stranded) {
-        let work = stranded
-        while (work.size > 0) {
-            const next = new Set<Selector>()
-            for (const selector of work) {
-                const currentValue = data.values.get(selector)
-                if (isPromiseLike(currentValue) && isInitOnly) continue
-                if (evaluateNode(selector, currentValue)) {
-                    const downstream = data.stateDependents.get(selector)
-                    if (downstream) {
-                        for (const d of downstream) next.add(d)
+    if (!stranded) return
+
+    let work = stranded
+    while (work.size > 0) {
+        const next = new Set<Selector>()
+        for (const selector of work) {
+            const currentValue = data.values.get(selector)
+            if (isPromiseLike(currentValue) && isInitOnly) continue
+            const dependents = data.stateDependents.get(selector)
+            const subscribers = data.subscriptions.get(selector)
+            if (
+                !isPromiseLike(currentValue) &&
+                (!dependents || dependents.size === 0) &&
+                (!subscribers || subscribers.size === 0)
+            ) {
+                data.values.delete(selector)
+                continue
+            }
+            depsChange.added = undefined
+            depsChange.removed = undefined
+            const wasValueUpdated = reEvaluateSelector(
+                selector,
+                data,
+                updatedInitializedAtoms,
+                depsChange,
+                currentValue,
+            )
+            if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
+            const added = depsChange.added as Set<State> | undefined
+            const removed = depsChange.removed as Set<State> | undefined
+            if ((added || removed) && isLive(selector, data)) {
+                if (added) {
+                    for (const dep of added) {
+                        onLiveDependencyAdded(dep, data)
+                        mountTransitiveDeps(dep, data)
+                    }
+                }
+                if (removed) {
+                    for (const dep of removed) {
+                        onLiveDependencyRemoved(dep, data)
+                        unmountOrphanedDeps(dep, data)
                     }
                 }
             }
-            work = next
+            if (wasValueUpdated) {
+                if (subscribers) addSetToSet(subscribers, collectedSubscribers)
+                // Re-fetch dependents — eval may have changed them.
+                const downstream = data.stateDependents.get(selector)
+                if (downstream) {
+                    for (const d of downstream) next.add(d)
+                }
+            }
         }
+        work = next
     }
 }
 
@@ -674,7 +707,6 @@ const propagateSelectorUpdates = (
             depsChange,
             currentValue,
         )
-        if ((globalThis as any).__TRACE) console.log(`[${data.id}] eval ${(selector as any).name}: ${currentValue} -> ${data.values.get(selector)} changed=${wasValueUpdated} added=[${[...(depsChange.added??[])].map((x:any)=>x.name)}] removed=[${[...(depsChange.removed??[])].map((x:any)=>x.name)}]`)
         if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -446,11 +446,36 @@ const propagateDownstreamTopo = (
     // downstream gets flagged as parents propagate change.
     const needsEval = new Set<Selector>(seeds)
 
+    // Set when the dependency graph changes during the walk (a selector's deps
+    // were added/removed, or an out-of-closure dependent was pulled in). Only
+    // then can a node be left stranded with an undrained `pending`, so the
+    // settle scan below is skipped entirely on the steady-state path.
+    let graphMutated = false
+
     const advance = (selector: Selector, propagateChange: boolean) => {
         const downstream = data.stateDependents.get(selector)
         if (!downstream) return
         for (const d of downstream) {
-            if (!closure.has(d)) continue
+            if (!closure.has(d)) {
+                // `d` is downstream of a just-changed selector but absent from
+                // the static closure, which means it was materialized AFTER the
+                // closure was built — e.g. an orphaned selector whose value was
+                // dropped by unsubscribe GC and then lazily re-initialized when
+                // a closure selector read it mid-propagation. Such a node may
+                // have read a not-yet-settled (stale) value of `selector`, and
+                // because it's untracked, a later change here would never reach
+                // it. Pull it into the closure so the topo walk re-evaluates it
+                // once `selector` settles. (Only when there is an actual change
+                // to propagate; an unchanged parent needs no re-eval.)
+                if (propagateChange) {
+                    graphMutated = true
+                    closure.add(d)
+                    pending.set(d, 0)
+                    needsEval.add(d)
+                    ready.push(d)
+                }
+                continue
+            }
             const c = (pending.get(d) ?? 0) - 1
             pending.set(d, c)
             if (propagateChange) needsEval.add(d)
@@ -458,12 +483,66 @@ const propagateDownstreamTopo = (
         }
     }
 
+    const depsChange: DepsChange = {}
+
+    // Re-evaluate one selector and reconcile its side effects: orphan-invalidate
+    // when it has no live consumer, otherwise re-evaluate, mount/unmount any
+    // changed dependencies, and collect its subscribers. Returns whether the
+    // value actually changed. Shared by the topo walk and the settle pass below.
+    const evaluateNode = (selector: Selector, currentValue: unknown): boolean => {
+        const dependents = data.stateDependents.get(selector)
+        const subscribers = data.subscriptions.get(selector)
+        if (
+            !isPromiseLike(currentValue) &&
+            (!dependents || dependents.size === 0) &&
+            (!subscribers || subscribers.size === 0)
+        ) {
+            // No live consumer — invalidate for lazy re-eval on next read.
+            data.values.delete(selector)
+            return false
+        }
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluateSelector(
+            selector,
+            data,
+            updatedInitializedAtoms,
+            depsChange,
+            currentValue,
+        )
+        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
+        // Casts work around a tsgo control-flow narrowing quirk where
+        // property accesses lose their narrowing after a function call.
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if (added || removed) {
+            graphMutated = true
+            if (isLive(selector, data)) {
+                if (added) {
+                    for (const dep of added) {
+                        onLiveDependencyAdded(dep, data)
+                        mountTransitiveDeps(dep, data)
+                    }
+                }
+                if (removed) {
+                    for (const dep of removed) {
+                        onLiveDependencyRemoved(dep, data)
+                        unmountOrphanedDeps(dep, data)
+                    }
+                }
+            }
+        }
+        if (wasValueUpdated && subscribers) {
+            addSetToSet(subscribers, collectedSubscribers)
+        }
+        return wasValueUpdated
+    }
+
     // FIFO head pointer preserves the original BFS sibling order — nested
     // writes that side-effect into peer selectors during eval depend on it.
     // Reused across every re-evaluated selector. evaluateSelector only
     // allocates the inner Sets when deps actually changed, so steady-state
     // settling does zero allocation here.
-    const depsChange: DepsChange = {}
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
@@ -488,52 +567,47 @@ const propagateDownstreamTopo = (
             continue
         }
 
-        const dependents = data.stateDependents.get(selector)
-        const subscribers = data.subscriptions.get(selector)
+        advance(selector, evaluateNode(selector, currentValue))
+    }
 
-        if (
-            !isPromiseLike(currentValue) &&
-            (!dependents || dependents.size === 0) &&
-            (!subscribers || subscribers.size === 0)
-        ) {
-            // No live consumer — invalidate for lazy re-eval on next read.
-            data.values.delete(selector)
-            advance(selector, false)
-            continue
-        }
-
-        depsChange.added = undefined
-        depsChange.removed = undefined
-        const wasValueUpdated = reEvaluateSelector(
-            selector,
-            data,
-            updatedInitializedAtoms,
-            depsChange,
-            currentValue,
-        )
-        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
-        // Casts work around a tsgo control-flow narrowing quirk where
-        // property accesses lose their narrowing after a function call.
-        const added = depsChange.added as Set<State> | undefined
-        const removed = depsChange.removed as Set<State> | undefined
-        if ((added || removed) && isLive(selector, data)) {
-            if (added) {
-                for (const dep of added) {
-                    onLiveDependencyAdded(dep, data)
-                    mountTransitiveDeps(dep, data)
-                }
-            }
-            if (removed) {
-                for (const dep of removed) {
-                    onLiveDependencyRemoved(dep, data)
-                    unmountOrphanedDeps(dep, data)
-                }
+    // Settle stranded nodes. The `pending` counts are a snapshot taken before
+    // the walk; they assume the dependency graph is fixed for its duration. But
+    // a selector can be re-evaluated out-of-band DURING the walk — most commonly
+    // lazily re-initialized via getState when another selector reads it (after
+    // its value was dropped by an earlier orphan-invalidation/unsubscribe). If
+    // that re-eval drops a dependency it was snapshotted with, the dropped
+    // parent's reverse edge is gone, so it never decrements this node's
+    // `pending`, which then stalls above 0 and the node is never processed —
+    // even though one of its surviving dependencies changed. Such a node is left
+    // stale, and so is anything that read it. Re-settle the stranded set (and
+    // whatever depends on it) with a fixpoint that re-fetches dependents each
+    // pass, which is inherently robust to a graph that changed under us. This
+    // only runs when a stall is actually detected, so the steady-state fast path
+    // is unaffected.
+    let stranded: Set<Selector> | undefined
+    if (graphMutated) {
+        for (const s of closure) {
+            if (needsEval.has(s) && (pending.get(s) ?? 0) > 0) {
+                if (!stranded) stranded = new Set()
+                stranded.add(s)
             }
         }
-
-        advance(selector, wasValueUpdated)
-        if (wasValueUpdated && subscribers) {
-            addSetToSet(subscribers, collectedSubscribers)
+    }
+    if (stranded) {
+        let work = stranded
+        while (work.size > 0) {
+            const next = new Set<Selector>()
+            for (const selector of work) {
+                const currentValue = data.values.get(selector)
+                if (isPromiseLike(currentValue) && isInitOnly) continue
+                if (evaluateNode(selector, currentValue)) {
+                    const downstream = data.stateDependents.get(selector)
+                    if (downstream) {
+                        for (const d of downstream) next.add(d)
+                    }
+                }
+            }
+            work = next
         }
     }
 }
@@ -600,6 +674,7 @@ const propagateSelectorUpdates = (
             depsChange,
             currentValue,
         )
+        if ((globalThis as any).__TRACE) console.log(`[${data.id}] eval ${(selector as any).name}: ${currentValue} -> ${data.values.get(selector)} changed=${wasValueUpdated} added=[${[...(depsChange.added??[])].map((x:any)=>x.name)}] removed=[${[...(depsChange.removed??[])].map((x:any)=>x.name)}]`)
         if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.


### PR DESCRIPTION
## Summary

Fixes a selector-invalidation regression introduced in `1.0.0-beta.4` (the selector-update propagation rewrite). After a conditional selector toggles its dependencies and toggles back (e.g. a "dragging" → "settled" branch swap), derived selectors could return **stale values computed from inputs that no longer apply**, with no re-evaluation and no subscriber notification. Bisects cleanly: `beta.3` correct, `beta.4` first broken.

## Root cause

beta.4's `propagateDownstreamTopo` builds a **static downstream closure** + per-node `pending` counts **once**, before the walk, assuming the dependency graph is fixed for its duration. That breaks when a selector is re-evaluated **out-of-band during the walk** — most commonly **lazily re-initialized via `get`/`getState`** when another selector reads it after its value was dropped by orphan-invalidation/unsubscribe (exactly what a drag interaction does: drop a dep → orphan → re-read on toggle-back).

The mid-walk graph mutation strands two classes of node permanently stale:

1. **Escaped** — materialized after the closure was built, so `advance()` hit `if (!closure.has(d)) continue` and never re-evaluated it when a dependency later settled.
2. **Stranded** — dropped a snapshotted dependency, so the dropped parent's reverse edge is gone and never decrements its `pending`, which stalls above 0 → the node is never processed even though a surviving dependency changed. Anything reading it is stale too.

beta.3's multi-pass cascade re-fetched dependents every pass, so it was immune to both.

## Fix

- `advance()` pulls **escaped** dependents into the closure instead of skipping them.
- A **fixpoint settle pass** after the topo walk re-evaluates **stranded** nodes (and cascades to their dependents) with re-fetched dependents — beta.3-style robustness to a graph that changed under the walk.
- Both gated behind a `graphMutated` flag, so the steady-state fast path is unchanged (no extra scan when no dependency changed mid-walk).

## Verification

- New regression test `propagateDynamicDeps.test.ts`: minimal deterministic repro + a 200-seed replay-oracle fuzzer (branches keyed on derived selectors, dropping/re-adding selector deps, sub/unsub churn, root **and** scoped stores). **Fails on beta.4, passes here** (~64k assertions).
- Stress: 1000 seeds × 70 steps clean.
- Full suite: **371 pass, 0 fail**; `tsgo` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)