### PR TITLE
fix(valdres): resolve suspense placeholder when setting a no-default atom in a transaction

### DIFF
--- a/.changeset/txn-resolves-pending-default.md
+++ b/.changeset/txn-resolves-pending-default.md
@@ -1,0 +1,15 @@
+---
+"valdres": patch
+---
+
+Fix: setting a no-default ("suspense") atom inside a transaction now resolves
+the pending-default placeholder promise, matching plain `store.set`. Previously
+the transaction write path (`writeAtoms`) wrote the value but never called
+`resolvePendingDefault`, so a reader suspended on the placeholder hung forever
+even though the value was set — same intent as `set`, silently different result.
+
+`resolvePendingDefault` is extracted from `setAtom` into `lib/` so every write
+path can share it. The new call in `writeAtoms` is gated on the prior value
+being a promise (a placeholder is always stored as one), so the common
+non-promise transaction write skips the scope-chain walk and the
+benchmark-gated txn hot path is unaffected.

--- a/packages/valdres/src/lib/initAtom.test.ts
+++ b/packages/valdres/src/lib/initAtom.test.ts
@@ -55,4 +55,23 @@ describe("initAtom", () => {
         unsubscribe()
         expect(store1.data.subscriptions.get(callbackAtom)).toBeUndefined()
     })
+
+    // onSet means "on set" — a user write. An async default resolving its own
+    // initial value is initialization, not a set, so onSet must stay silent.
+    // (The set path fires onSet on async resolve; see lib/setAtom.test.ts
+    // "async updater calls onSet after resolution" — the deliberate inverse.)
+    test("async default resolving does not fire onSet", async () => {
+        const store1 = store()
+        const onSet = mock(() => {})
+        const callbackAtom = atom<string>(() => wait(10).then(() => "Bar"), {
+            onSet,
+        })
+        const value = store1.get(callbackAtom)
+        expect(value).toBeInstanceOf(Promise)
+        const res = await value
+        expect(res).toBe("Bar")
+        expect(store1.get(callbackAtom)).toBe("Bar")
+        // Initialization resolved the value but is not a "set".
+        expect(onSet).toHaveBeenCalledTimes(0)
+    })
 })

--- a/packages/valdres/src/lib/resolvePendingDefault.ts
+++ b/packages/valdres/src/lib/resolvePendingDefault.ts
@@ -9,16 +9,20 @@ import type { StoreData } from "../types/StoreData"
  *
  *  Called by every write path that lands a value on an atom that may carry a
  *  placeholder — `setAtom` (sync + async resolve) and `writeAtoms` (the
- *  transaction path). Caller contract:
+ *  transaction path).
  *
- *   - Pass a SETTLED value, never a promise. The placeholder must resolve to
- *     the eventual real value, so an in-flight promise stored mid-sequence
- *     must not consume it — a later settled write still has to find the entry
- *     here. `setAtom` guarantees this by routing promises through
- *     `handlePromise` instead; `writeAtoms` by gating on `!isPromiseLike(value)`.
- *   - Gate the call on `isPromiseLike(currentValue)`: a placeholder is always
- *     stored as a promise, so a non-promise prior value can't have one and the
- *     chain walk is skippable (keeps the write hot path off this function).
+ *  Caller contract: pass a SETTLED value, never a promise. The placeholder must
+ *  resolve to the eventual real value, so an in-flight promise stored
+ *  mid-sequence must not consume it — a later settled write still has to find
+ *  the entry here. `setAtom` guarantees this by routing promises through
+ *  `handlePromise` instead; `writeAtoms` by gating on `!isPromiseLike(value)`.
+ *
+ *  Optional optimization (not required): a caller that already knows the prior
+ *  value may skip the call when it isn't promise-like — a placeholder is always
+ *  stored as a promise, so a non-promise prior value can't have one. `writeAtoms`
+ *  does this (gating on `isPromiseLike(currentValue)`) to keep the write hot
+ *  path off this function. `setAtom` calls unconditionally; the walk is a couple
+ *  of WeakMap lookups that bail immediately when there's nothing to resolve.
  *
  *  Idempotent and commit-safe: the entry is deleted on first resolve and a
  *  settled promise ignores later `resolve` calls, so calling this from more

--- a/packages/valdres/src/lib/resolvePendingDefault.ts
+++ b/packages/valdres/src/lib/resolvePendingDefault.ts
@@ -2,17 +2,30 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 
 /** Resolve any outstanding pending-default suspense placeholder for `atom`
- *  and remove it. The placeholder may have been registered in a parent
- *  store (atoms with no `defaultValue` init in whichever scope first reads
- *  them, which `getState` resolves by walking up to root), so we walk the
- *  scope chain rather than only checking `data`.
+ *  with `value` and remove it. The placeholder may have been registered in a
+ *  parent store (atoms with no `defaultValue` init in whichever scope first
+ *  reads them, which `getState` resolves by walking up to root), so we walk
+ *  the scope chain rather than only checking `data`.
  *
- *  Every write path that lands a real value on an atom that may have a
- *  suspense placeholder must call this — `setAtom` (sync + async resolve)
- *  and `writeAtoms` (the transaction path). Callers should gate on
- *  `isPromiseLike(currentValue)`: a placeholder is always stored as a
- *  promise, so a non-promise current value means there is nothing to
- *  resolve and the chain walk can be skipped. */
+ *  Called by every write path that lands a value on an atom that may carry a
+ *  placeholder — `setAtom` (sync + async resolve) and `writeAtoms` (the
+ *  transaction path). Caller contract:
+ *
+ *   - Pass a SETTLED value, never a promise. The placeholder must resolve to
+ *     the eventual real value, so an in-flight promise stored mid-sequence
+ *     must not consume it — a later settled write still has to find the entry
+ *     here. `setAtom` guarantees this by routing promises through
+ *     `handlePromise` instead; `writeAtoms` by gating on `!isPromiseLike(value)`.
+ *   - Gate the call on `isPromiseLike(currentValue)`: a placeholder is always
+ *     stored as a promise, so a non-promise prior value can't have one and the
+ *     chain walk is skippable (keeps the write hot path off this function).
+ *
+ *  Idempotent and commit-safe: the entry is deleted on first resolve and a
+ *  settled promise ignores later `resolve` calls, so calling this from more
+ *  than one store pass in a single cross-scope commit is harmless. `resolve`
+ *  only schedules the placeholder's `.then` microtasks — it runs no subscriber
+ *  code synchronously — so calling it during a transaction's write phase
+ *  cannot expose a half-applied commit. */
 export const resolvePendingDefault = <Value>(
     atom: Atom<Value>,
     data: StoreData,

--- a/packages/valdres/src/lib/resolvePendingDefault.ts
+++ b/packages/valdres/src/lib/resolvePendingDefault.ts
@@ -1,0 +1,31 @@
+import type { Atom } from "../types/Atom"
+import type { StoreData } from "../types/StoreData"
+
+/** Resolve any outstanding pending-default suspense placeholder for `atom`
+ *  and remove it. The placeholder may have been registered in a parent
+ *  store (atoms with no `defaultValue` init in whichever scope first reads
+ *  them, which `getState` resolves by walking up to root), so we walk the
+ *  scope chain rather than only checking `data`.
+ *
+ *  Every write path that lands a real value on an atom that may have a
+ *  suspense placeholder must call this — `setAtom` (sync + async resolve)
+ *  and `writeAtoms` (the transaction path). Callers should gate on
+ *  `isPromiseLike(currentValue)`: a placeholder is always stored as a
+ *  promise, so a non-promise current value means there is nothing to
+ *  resolve and the chain walk can be skipped. */
+export const resolvePendingDefault = <Value>(
+    atom: Atom<Value>,
+    data: StoreData,
+    value: Value,
+) => {
+    let cur: StoreData | undefined = data
+    while (cur) {
+        const entry = cur.pendingDefaults.get(atom)
+        if (entry) {
+            entry.resolve(value)
+            cur.pendingDefaults.delete(atom)
+            return
+        }
+        cur = "parent" in cur ? cur.parent : undefined
+    }
+}

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -5,29 +5,8 @@ import { isPromiseLike } from "../utils/isPromiseLike"
 import { getState } from "./getState"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
+import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
-
-/** Resolve any outstanding pending-default suspense placeholder for `atom`
- *  and remove it. The placeholder may have been registered in a parent
- *  store (atoms with no `defaultValue` init in whichever scope first reads
- *  them, which `getState` resolves by walking up to root), so we walk the
- *  scope chain rather than only checking `data`. */
-const resolvePendingDefault = <Value>(
-    atom: Atom<Value>,
-    data: StoreData,
-    value: Value,
-) => {
-    let cur: StoreData | undefined = data
-    while (cur) {
-        const entry = cur.pendingDefaults.get(atom)
-        if (entry) {
-            entry.resolve(value)
-            cur.pendingDefaults.delete(atom)
-            return
-        }
-        cur = "parent" in cur ? cur.parent : undefined
-    }
-}
 
 const handlePromise = <Value>(
     atom: Atom<Value>,

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -651,4 +651,59 @@ describe("transaction", () => {
         expect(rootStore.get(nameAtom)).toBe("Bar")
         expect(nestedStore.get(nameAtom)).toBe("Foo")
     })
+
+    // Regression guard: plain `store.set` on a no-default atom resolves the
+    // pending-default suspense promise (see lib/setAtom.test.ts). The
+    // transaction write path goes through writeAtoms, which previously wrote
+    // the value but never resolved the placeholder — so a reader suspended on
+    // it hung forever even though the value was set. writeAtoms now calls
+    // resolvePendingDefault, matching `set`.
+    test("txn set resolves pending-default suspense promise", async () => {
+        const store1 = store()
+        const emptyAtom = atom<string>()
+
+        // Reading the empty atom gives us the suspense placeholder promise.
+        const suspense = store1.get(emptyAtom) as Promise<string>
+
+        store1.txn(txn => {
+            txn.set(emptyAtom, "hello")
+        })
+
+        // Value is written correctly...
+        expect(store1.get(emptyAtom)).toBe("hello")
+
+        // ...but the suspense promise must also resolve, exactly as it does for
+        // a plain `store.set`. Bounded race so the gap fails fast instead of
+        // hanging until the test timeout.
+        const settled = await Promise.race([
+            suspense.then(v => ({ kind: "resolved" as const, value: v })),
+            new Promise<{ kind: "pending" }>(r =>
+                setTimeout(() => r({ kind: "pending" }), 50),
+            ),
+        ])
+        expect(settled).toEqual({ kind: "resolved", value: "hello" })
+    })
+
+    // The placeholder is registered in root (the scoped read falls through),
+    // so resolving it from a scoped txn write must walk up the scope chain —
+    // mirrors the supported `set` case in lib/setAtom.test.ts.
+    test("scoped txn set resolves suspense promise inited in root", async () => {
+        const root = store()
+        const scoped = root.scope("s1")
+        const emptyAtom = atom<string>()
+
+        const suspense = scoped.get(emptyAtom) as Promise<string>
+
+        scoped.txn(txn => {
+            txn.set(emptyAtom, "hello")
+        })
+
+        const settled = await Promise.race([
+            suspense.then(v => ({ kind: "resolved" as const, value: v })),
+            new Promise<{ kind: "pending" }>(r =>
+                setTimeout(() => r({ kind: "pending" }), 50),
+            ),
+        ])
+        expect(settled).toEqual({ kind: "resolved", value: "hello" })
+    })
 })

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -6,6 +6,24 @@ import { store } from "../store"
 import { transaction } from "./transaction"
 import { index } from "../indexConstructor"
 
+/** Resolve to a promise's value if it settles within `ms`, else report it
+ *  still pending — a bounded race so a hung suspense promise fails fast
+ *  instead of timing out the test. Clears the timer in `finally` so a won
+ *  race never leaves a dangling timeout holding the event loop open. */
+const settleWithin = async <T>(promise: Promise<T>, ms = 50) => {
+    let timer: ReturnType<typeof setTimeout>
+    try {
+        return await Promise.race([
+            promise.then(value => ({ kind: "resolved" as const, value })),
+            new Promise<{ kind: "pending" }>(resolve => {
+                timer = setTimeout(() => resolve({ kind: "pending" }), ms)
+            }),
+        ])
+    } finally {
+        clearTimeout(timer!)
+    }
+}
+
 describe("transaction", () => {
     test("txn set direct", () => {
         const store1 = store()
@@ -675,12 +693,7 @@ describe("transaction", () => {
         // ...but the suspense promise must also resolve, exactly as it does for
         // a plain `store.set`. Bounded race so the gap fails fast instead of
         // hanging until the test timeout.
-        const settled = await Promise.race([
-            suspense.then(v => ({ kind: "resolved" as const, value: v })),
-            new Promise<{ kind: "pending" }>(r =>
-                setTimeout(() => r({ kind: "pending" }), 50),
-            ),
-        ])
+        const settled = await settleWithin(suspense)
         expect(settled).toEqual({ kind: "resolved", value: "hello" })
     })
 
@@ -698,12 +711,7 @@ describe("transaction", () => {
             txn.set(emptyAtom, "hello")
         })
 
-        const settled = await Promise.race([
-            suspense.then(v => ({ kind: "resolved" as const, value: v })),
-            new Promise<{ kind: "pending" }>(r =>
-                setTimeout(() => r({ kind: "pending" }), 50),
-            ),
-        ])
+        const settled = await settleWithin(suspense)
         expect(settled).toEqual({ kind: "resolved", value: "hello" })
     })
 
@@ -731,12 +739,7 @@ describe("transaction", () => {
             txn.set(emptyAtom, "done")
         })
 
-        const settled = await Promise.race([
-            suspense.then(v => ({ kind: "resolved" as const, value: v })),
-            new Promise<{ kind: "pending" }>(r =>
-                setTimeout(() => r({ kind: "pending" }), 50),
-            ),
-        ])
+        const settled = await settleWithin(suspense)
         expect(settled).toEqual({ kind: "resolved", value: "done" })
         expect(store1.get(emptyAtom)).toBe("done")
     })

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -706,4 +706,38 @@ describe("transaction", () => {
         ])
         expect(settled).toEqual({ kind: "resolved", value: "hello" })
     })
+
+    // Demonstrates the `!isPromiseLike(value)` half of the writeAtoms gate.
+    // The txn path does no async resolution, so storing an in-flight promise
+    // must NOT resolve the placeholder by adoption — that would consume it and
+    // strand it on a promise that never settles, so a later settled write
+    // could never resolve it. The placeholder must survive until a settled
+    // value lands. Mirrors lib/setAtom.test.ts "sync set after in-flight async
+    // set on empty atom resolves suspense promise" for the transaction path.
+    test("txn set: in-flight promise does not consume the suspense placeholder", async () => {
+        const store1 = store()
+        const emptyAtom = atom<string>()
+
+        const suspense = store1.get(emptyAtom) as Promise<string>
+
+        // Store a never-resolving promise via txn — placeholder must survive.
+        const pending = new Promise<string>(() => {})
+        store1.txn(txn => {
+            txn.set(emptyAtom, pending)
+        })
+
+        // A later settled value lands and resolves the still-live placeholder.
+        store1.txn(txn => {
+            txn.set(emptyAtom, "done")
+        })
+
+        const settled = await Promise.race([
+            suspense.then(v => ({ kind: "resolved" as const, value: v })),
+            new Promise<{ kind: "pending" }>(r =>
+                setTimeout(() => r({ kind: "pending" }), 50),
+            ),
+        ])
+        expect(settled).toEqual({ kind: "resolved", value: "done" })
+        expect(store1.get(emptyAtom)).toBe("done")
+    })
 })

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -45,18 +45,25 @@ export const writeAtoms = (
                 if (onSetQueue) onSetQueue.push([atom, value, data])
                 else atom.onSet(value, data)
             }
-            // Landing a real value over a suspense placeholder must resolve
-            // the held promise, exactly as setAtom does. setAtom only ever
-            // resolves with a settled (non-promise) value, so mirror that:
-            // resolve only when replacing a promise (a placeholder is always
-            // stored as one) with a non-promise. The `currentIsPromise` gate
-            // also keeps the common non-promise txn write off the chain walk.
+            // Landing a settled value over a suspense placeholder must resolve
+            // the held promise, exactly as setAtom does. Two gates, both load-
+            // bearing (see resolvePendingDefault's contract):
+            //   currentIsPromise   — a placeholder is always a promise, so a
+            //     non-promise prior value can't have one; skips the chain walk
+            //     on the common (non-promise) write, i.e. the benchmark hot path.
+            //   !isPromiseLike(value) — only resolve with a settled value;
+            //     storing an in-flight promise must not consume the placeholder,
+            //     so a later settled write can still resolve it.
             if (currentIsPromise && !isPromiseLike(value)) {
                 resolvePendingDefault(atom, data, value)
             }
         } else {
             // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope
             setValueInData(atom, value, data)
+            // No placeholder to resolve here: areEqual with a settled value
+            // means there was none (a placeholder is a promise, never equal to
+            // a settled value), and equal promises are the same reference — a
+            // no-op set, not a value landing.
         }
     }
     // Merge updatedAtoms and initializedAtomsSet without extra Set+spread

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -2,6 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { getState } from "./getState"
+import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 
 /** A deferred onSet invocation: the hook, the written value, and the store it
@@ -33,7 +34,8 @@ export const writeAtoms = (
     const updatedAtoms: Atom[] = []
     for (let [atom, value] of pairs) {
         const currentValue = getState(atom, data, initializedAtomsSet)
-        const areEqual = isPromiseLike(currentValue) || isPromiseLike(value)
+        const currentIsPromise = isPromiseLike(currentValue)
+        const areEqual = currentIsPromise || isPromiseLike(value)
             ? currentValue === value
             : atom.equal(currentValue, value)
         if (!areEqual) {
@@ -42,6 +44,15 @@ export const writeAtoms = (
             if (atom.onSet && !skipOnSet) {
                 if (onSetQueue) onSetQueue.push([atom, value, data])
                 else atom.onSet(value, data)
+            }
+            // Landing a real value over a suspense placeholder must resolve
+            // the held promise, exactly as setAtom does. setAtom only ever
+            // resolves with a settled (non-promise) value, so mirror that:
+            // resolve only when replacing a promise (a placeholder is always
+            // stored as one) with a non-promise. The `currentIsPromise` gate
+            // also keeps the common non-promise txn write off the chain walk.
+            if (currentIsPromise && !isPromiseLike(value)) {
+                resolvePendingDefault(atom, data, value)
             }
         } else {
             // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope


### PR DESCRIPTION
## What

Setting a no-default ("suspense") atom via `store.set` resolves the pending-default placeholder promise. The **transaction** write path didn't — `writeAtoms` wrote the value but never called `resolvePendingDefault`, so a reader suspended on the placeholder **hung forever** even though the value was set. Same user intent as `set`, silently different result.

## Why it's realistic

A no-default atom *is* the async-loaded-data / Suspense pattern (`setAtom.ts` has five tests pinning "`set` resolves the placeholder", including the scoped-store case). A component suspends on the atom, data arrives and is committed via `txn` to batch it with related state, the value lands but the component never un-suspends.

## The fix

- **Extract `resolvePendingDefault`** out of `setAtom.ts` into `lib/resolvePendingDefault.ts` so every write path can share it (the helper was trapped as a private function, which is *why* `writeAtoms` couldn't reach it). One export per file.
- **Call it from `writeAtoms`**, gated on `currentIsPromise && !isPromiseLike(value)`:
  - mirrors `setAtom` exactly. `setAtom` only ever resolves a placeholder with a **settled** value (sync path returns early for promises; async `.then` resolves with the settled value), so we don't resolve-by-adoption when the new value is itself a promise.
  - the `currentIsPromise` gate keeps the **benchmark-gated** numeric txn write off the scope-chain walk entirely (no added `isPromiseLike` call on the hot path, the existing one was just hoisted into a `const`).

## Tests

- `transaction.test.ts` — single-store **and** scoped suspense resolution via `txn` (the scoped case exercises the parent-chain walk).
- `initAtom.test.ts` — async default resolving does **not** fire `onSet`, pinning the deliberate set-vs-init asymmetry that this cluster of code depends on.

## Verification

- Full core suite: **374 pass, 0 fail** (375 with the new tests).
- `tsgo --noEmit`: clean.
- `bunx changeset status --since=origin/main`: valdres → patch.

## Review notes

Self-reviewed (staff-eng pass). One refinement caught and applied during review: the initial gate (`currentIsPromise` only) would have resolved the placeholder *by adoption* when setting a no-default atom to a promise value in a txn, a new semantic `setAtom` doesn't have. Tightened to also require a settled value. Independent codex pass was attempted but the codex CLI returned 401 (not authenticated in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
