### PR TITLE
Fix stale cross-scope/pass selectors & index() crash; serializable txn observation

### DIFF
--- a/.changeset/fix-cross-pass-stale-selector-and-index.md
+++ b/.changeset/fix-cross-pass-stale-selector-and-index.md
@@ -6,28 +6,29 @@ Fix stale cross-scope/cross-pass selectors and a related `index()` crash
 (regressions exposed by the beta.4 topological propagation and the beta.5
 cross-scope atomic commit).
 
-**Stale selector across commit passes.** A cross-scope transaction (and the
-single-store update+delete transaction) propagates in one pass per store and
-shares a per-commit `evaluatedSelectors` guard so a selector reachable by more
-than one pass evaluates once. Two flaws made selectors (and their whole
-subtrees) go stale — e.g. a node dragged and dropped back outside any dropzone
-settling one row too low, or a connector line rendering stale geometry:
+**Stale selector across commit passes + non-atomic observation.** A cross-scope
+transaction (and the single-store update+delete transaction) propagates in one
+pass per store and shared a per-commit `evaluatedSelectors` dedup guard so a
+selector reachable by more than one pass evaluated once. That guard caused two
+correctness regressions — a selector (and its whole subtree) left stale, e.g. a
+node dragged and dropped back outside any dropzone settling one row too low, or
+a connector line rendering stale geometry:
 
-- The guard was keyed by selector *object*, but the same selector has an
-  independent value in the root and in each scope. A selector subscribed in both
-  the root and a scope was evaluated in the root pass, marked done, and the
-  scope's (differently valued) copy was skipped entirely — left stale. The guard
-  is now keyed **per store**, so each store evaluates its own copy while the
-  intra-store dedup is preserved.
-- Even within one store, the guard assumed the first reaching pass computed the
-  final value — true for atom-only selectors (all writes precede propagation),
-  but false when a selector depends on an intermediate *selector* recomputed in
-  a later pass (e.g. a scope selector reached via a root atom before its sibling
-  scope selector settles). A guarded selector is now recomputed when one of its
-  dependencies actually changed value later in the commit (tracked by the topo
-  `needsEval` set); the redundant pass is still skipped when nothing it depends
-  on moved, so the "evaluate once" fast path is unchanged for atom-only
-  selectors and the single-store / non-scoped hot path is untouched.
+- Keyed by selector *object*, it skipped a scope's copy of a selector that was
+  also live in the root (the same object has a different value per store).
+- It locked in a value an early pass computed from an intermediate *selector*
+  that a later pass corrected (e.g. a scope selector reached via a root atom
+  before its sibling scope selector settled).
+
+The dedup guard is **removed**. Multi-pass commits now (1) write every value
+across every store first, (2) let each store re-derive its own selectors against
+that final state — a selector reachable by two passes is simply recomputed in
+each, and the equality check prunes the redundant result — and (3) **defer all
+subscriber notification to the end of the commit**, firing each subscriber once.
+This makes a transaction *serializable to observe*: no subscriber, and nothing a
+subscriber reads, ever sees a half-applied intermediate. A selector reachable by
+multiple passes now has its body run once per reaching pass (the dropped
+optimization); the single-store / non-scoped hot path is untouched.
 
 **`index()` crash / desync across stores.** `index()` kept a mutable Set + Map
 of current members in closure scope and mutated them from inside a selector

--- a/.changeset/fix-cross-pass-stale-selector-and-index.md
+++ b/.changeset/fix-cross-pass-stale-selector-and-index.md
@@ -23,12 +23,18 @@ a connector line rendering stale geometry:
 The dedup guard is **removed**. Multi-pass commits now (1) write every value
 across every store first, (2) let each store re-derive its own selectors against
 that final state — a selector reachable by two passes is simply recomputed in
-each, and the equality check prunes the redundant result — and (3) **defer all
-subscriber notification to the end of the commit**, firing each subscriber once.
-This makes a transaction *serializable to observe*: no subscriber, and nothing a
-subscriber reads, ever sees a half-applied intermediate. A selector reachable by
-multiple passes now has its body run once per reaching pass (the dropped
-optimization); the single-store / non-scoped hot path is untouched.
+each, and the equality check prunes the redundant result — and (3) **defer
+subscriber notification to the end of the commit**, partitioned **per store**,
+firing each store's subscribers once against the members that changed in that
+store. This makes a transaction *serializable to observe*: no subscriber, and
+nothing a **synchronous** selector a subscriber reads, ever sees a half-applied
+intermediate. (An async/Promise selector still notifies again when its promise
+resolves — a separate, later microtask — so the "exactly once with the final
+value" guarantee is for synchronous selectors.) Per-store partitioning also
+keeps an atomFamily subscriber in one store from firing for members that only
+changed in another store. A selector reachable by multiple passes now has its
+body run once per reaching pass (the dropped optimization); the single-store /
+non-scoped hot path is untouched.
 
 **`index()` crash / desync across stores.** `index()` kept a mutable Set + Map
 of current members in closure scope and mutated them from inside a selector
@@ -39,8 +45,9 @@ filtered selector could iterate a member whose predicate-selector entry had been
 deleted by the other store's evaluation — throwing
 `Cannot convert undefined or null to object`. `index()` now derives membership
 from `get(family)` on every evaluation (correct per store) and caches per-atom
-predicate selectors in a grow-only, store-agnostic map (a lookup is never
-undefined).
+predicate selectors in a store-agnostic `WeakMap` keyed by the family-atom (a
+lookup is never undefined for a live member, and a deleted member's entry
+becomes GC-eligible rather than leaking on create/delete/recreate churn).
 
 `isAtom` and `isGlobalAtom` also gained the `state && …` null-guard the other
 `is*` helpers already have, so a stale read degrades gracefully instead of

--- a/.changeset/fix-cross-pass-stale-selector-and-index.md
+++ b/.changeset/fix-cross-pass-stale-selector-and-index.md
@@ -1,0 +1,46 @@
+---
+"valdres": patch
+---
+
+Fix stale cross-scope/cross-pass selectors and a related `index()` crash
+(regressions exposed by the beta.4 topological propagation and the beta.5
+cross-scope atomic commit).
+
+**Stale selector across commit passes.** A cross-scope transaction (and the
+single-store update+delete transaction) propagates in one pass per store and
+shares a per-commit `evaluatedSelectors` guard so a selector reachable by more
+than one pass evaluates once. Two flaws made selectors (and their whole
+subtrees) go stale — e.g. a node dragged and dropped back outside any dropzone
+settling one row too low, or a connector line rendering stale geometry:
+
+- The guard was keyed by selector *object*, but the same selector has an
+  independent value in the root and in each scope. A selector subscribed in both
+  the root and a scope was evaluated in the root pass, marked done, and the
+  scope's (differently valued) copy was skipped entirely — left stale. The guard
+  is now keyed **per store**, so each store evaluates its own copy while the
+  intra-store dedup is preserved.
+- Even within one store, the guard assumed the first reaching pass computed the
+  final value — true for atom-only selectors (all writes precede propagation),
+  but false when a selector depends on an intermediate *selector* recomputed in
+  a later pass (e.g. a scope selector reached via a root atom before its sibling
+  scope selector settles). A guarded selector is now recomputed when one of its
+  dependencies actually changed value later in the commit (tracked by the topo
+  `needsEval` set); the redundant pass is still skipped when nothing it depends
+  on moved, so the "evaluate once" fast path is unchanged for atom-only
+  selectors and the single-store / non-scoped hot path is untouched.
+
+**`index()` crash / desync across stores.** `index()` kept a mutable Set + Map
+of current members in closure scope and mutated them from inside a selector
+evaluation. Because selectors evaluate independently per store, reading the same
+index in both a root and a scope with divergent family membership (e.g. publish
+moving members between a scope and the root) clobbered the shared state, and the
+filtered selector could iterate a member whose predicate-selector entry had been
+deleted by the other store's evaluation — throwing
+`Cannot convert undefined or null to object`. `index()` now derives membership
+from `get(family)` on every evaluation (correct per store) and caches per-atom
+predicate selectors in a grow-only, store-agnostic map (a lookup is never
+undefined).
+
+`isAtom` and `isGlobalAtom` also gained the `state && …` null-guard the other
+`is*` helpers already have, so a stale read degrades gracefully instead of
+crashing in `Object.hasOwn(undefined, …)`.

--- a/packages/valdres/src/indexConstructor.multiStore.test.ts
+++ b/packages/valdres/src/indexConstructor.multiStore.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test"
+import { atomFamily } from "./atomFamily"
+import { index } from "./indexConstructor"
+import { selector } from "./selector"
+import { store } from "./store"
+
+// Regression for the index() crash on publish (SelectorEvaluationError /
+// "Cannot convert undefined or null to object" inside `...:termSelector`).
+//
+// index() used to keep a mutable Set + Map of "current members" in closure
+// scope and mutate them from inside a `termIndexSelector` evaluation. But that
+// selector — like every selector — is evaluated independently per store. When
+// the same index is read in both the root and a scope with divergent family
+// membership (ShiftX "publish" moves members between a scope and the root), the
+// two evaluations clobbered the shared state, and `termSelector` could iterate
+// a snapshot set holding a member whose predicate-selector map entry had been
+// deleted by the other store's evaluation → get(undefined) → crash.
+//
+// index() now derives membership from get(family) on every evaluation (correct
+// per store) and uses a grow-only predicate cache (a lookup is never
+// undefined). isAtom/isGlobalAtom also gained a null-guard so any future stale
+// read degrades gracefully instead of throwing.
+
+const mulberry32 = (seed: number) => () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+
+const KINDS = ["a", "b", "c"]
+
+describe("index() across root + scope", () => {
+    test("divergent root/scope membership does not desync or crash", () => {
+        const fam = atomFamily<{ kind: string } | null, [string]>(null, {
+            name: "ms-ent",
+        })
+        const byKind = index(
+            fam,
+            (v: any, term: string) => v != null && v.kind === term,
+            { name: "ms" },
+        )
+        const root = store()
+        const S = root.scope("S")
+        // keep both stores' term selectors live
+        for (const k of KINDS) {
+            root.sub(byKind(k), () => {})
+            S.sub(byKind(k), () => {})
+        }
+
+        root.set(fam("1"), { kind: "a" })
+        root.set(fam("2"), { kind: "b" })
+        // scope diverges: shadow "1" as kind c, delete "2", add "3"
+        S.set(fam("1"), { kind: "c" })
+        S.del(fam("2"))
+        S.set(fam("3"), { kind: "a" })
+
+        // root view
+        expect(root.get(byKind("a")).map(a => a.familyArgs[0])).toEqual(["1"])
+        expect(root.get(byKind("b")).map(a => a.familyArgs[0])).toEqual(["2"])
+        expect(root.get(byKind("c"))).toEqual([])
+        // scope view (1->c, 2 deleted, 3->a)
+        expect(S.get(byKind("a")).map(a => a.familyArgs[0])).toEqual(["3"])
+        expect(S.get(byKind("b"))).toEqual([])
+        expect(S.get(byKind("c")).map(a => a.familyArgs[0])).toEqual(["1"])
+    })
+
+    test("fuzz: heavy root+scope family churn under index() never crashes", () => {
+        // The index crash (SelectorEvaluationError inside `...:termSelector`)
+        // reproduced under exactly this shape — the same index read in a root
+        // and a scope with divergent, churning family membership. This is a
+        // pure no-crash regression: reading byKind(k) in both stores after
+        // arbitrary churn must never throw. (Cross-store contamination
+        // correctness is pinned by the deterministic tests above; exact
+        // membership freshness of *subscribed scope selectors* is an orthogonal,
+        // pre-existing scope-family propagation concern not exercised here.)
+        for (let seed = 1; seed <= 1500; seed++) {
+            const rnd = mulberry32(seed)
+            const fam = atomFamily<{ kind: string } | null, [string]>(null, {
+                name: "ms-fz",
+            })
+            const byKind = index(
+                fam,
+                (v: any, term: string) => v != null && v.kind === term,
+                { name: "msfz" },
+            )
+            // a plain selector exposing the store's own family membership
+            const members = selector(get => get(fam) as any[], {
+                name: "ms-members",
+            })
+            const root = store()
+            const S = root.scope("S")
+            const ids = ["1", "2", "3", "4", "5", "6"]
+
+            for (const k of KINDS) {
+                root.sub(byKind(k), () => {})
+                S.sub(byKind(k), () => {})
+            }
+            // Subscribe the plain membership selector too, so the oracle reads
+            // the same propagation state index() does (any orthogonal scope
+            // family staleness then cancels out of the comparison).
+            root.sub(members, () => {})
+            S.sub(members, () => {})
+
+            const apply = (st: any, id: string, del: boolean, kind: string) => {
+                if (del) st.del(fam(id))
+                else st.set(fam(id), { kind })
+            }
+            for (let step = 0; step < 25; step++) {
+                const where = rnd() < 0.5 ? root : S
+                const n = 1 + Math.floor(rnd() * 3)
+                for (let j = 0; j < n; j++) {
+                    apply(
+                        where,
+                        ids[Math.floor(rnd() * ids.length)],
+                        rnd() < 0.35,
+                        KINDS[Math.floor(rnd() * KINDS.length)],
+                    )
+                }
+            }
+
+            // Force evaluation of every filtered selector in both stores; the
+            // old shared-closure desync threw here.
+            for (const k of KINDS) {
+                expect(Array.isArray(root.get(byKind(k)))).toBe(true)
+                expect(Array.isArray(S.get(byKind(k)))).toBe(true)
+            }
+            void members
+        }
+    })
+
+    test("publish-style: move members from scope to root in a cross-scope txn", () => {
+        const fam = atomFamily<{ kind: string } | null, [string]>(null, {
+            name: "pub-ent",
+        })
+        const byKind = index(
+            fam,
+            (v: any, term: string) => v != null && v.kind === term,
+            { name: "pub" },
+        )
+        const agg = selector(
+            get => KINDS.reduce((s, k) => s + get(byKind(k)).length, 0),
+            { name: "pub-agg" },
+        )
+        const root = store()
+        const S = root.scope("S")
+        for (const k of KINDS) {
+            root.sub(byKind(k), () => {})
+            S.sub(byKind(k), () => {})
+        }
+        root.sub(agg, () => {})
+        S.sub(agg, () => {})
+
+        // draft lives in the scope
+        S.set(fam("d1"), { kind: "a" })
+        S.set(fam("d2"), { kind: "b" })
+        expect(S.get(agg)).toBe(2)
+
+        // publish: write the drafts to the root and clear the scope drafts, atomically
+        root.txn(t => {
+            t.set(fam("d1"), { kind: "a" })
+            t.set(fam("d2"), { kind: "b" })
+            t.scope("S", st => {
+                st.del(fam("d1"))
+                st.del(fam("d2"))
+            })
+        })
+
+        // Root now holds the published members.
+        expect(root.get(byKind("a")).map(a => a.familyArgs[0])).toEqual(["d1"])
+        expect(root.get(byKind("b")).map(a => a.familyArgs[0])).toEqual(["d2"])
+        // The scope deleted its drafts: a scope `del` tombstones the member in
+        // the scope's family index (get(fam) excludes it), so the scope's index
+        // is empty — and, crucially, it is recomputed (not left at its stale
+        // pre-publish value, which is what the old cross-store-shared guard did).
+        expect(S.get(byKind("a"))).toEqual([])
+        expect(S.get(byKind("b"))).toEqual([])
+    })
+})

--- a/packages/valdres/src/indexConstructor.ts
+++ b/packages/valdres/src/indexConstructor.ts
@@ -25,21 +25,27 @@ export const index = <
         // Per-atom predicate selectors, cached so we don't recreate them on
         // every membership change.
         //
-        // This cache is GROW-ONLY and store-agnostic on purpose. A selector is
-        // a pure definition that valdres evaluates independently per store, so
-        // the same `termSelector` here runs once in the root and once in every
-        // scope that reads it. The previous design kept a mutable Set + Map of
-        // "current members" in this closure and mutated them from inside a
-        // `termIndexSelector` evaluation. Because that evaluation runs per store
-        // — and a scope can have a different family membership than the root
-        // (publish moves members between a scope and the root) — the two stores
-        // clobbered the shared state: `termSelector` in one store could iterate
-        // a snapshot set that still held a member whose predicate-selector entry
-        // had already been deleted by the other store's evaluation, and
-        // `get(undefined)` threw. Deriving membership from `get(family)` on every
-        // evaluation makes each store read its own correct membership, and never
-        // deleting from the predicate cache means a lookup is never undefined.
-        const predicateSelectors = new Map<
+        // Store-agnostic on purpose: a selector is a pure definition that valdres
+        // evaluates independently per store, so the same predicate selector is
+        // correct in the root and in every scope. The previous index() design
+        // kept a mutable Set + Map of "current members" in this closure and
+        // mutated them from inside a `termIndexSelector` evaluation. Because that
+        // evaluation runs per store — and a scope can have a different family
+        // membership than the root (publish moves members between a scope and the
+        // root) — the two stores clobbered the shared state: `termSelector` in
+        // one store could iterate a snapshot set that still held a member whose
+        // predicate-selector entry had already been deleted by the other store's
+        // evaluation, and `get(undefined)` threw. Deriving membership from
+        // `get(family)` on every evaluation makes each store read its own correct
+        // membership, and the cache lookup is never undefined for a live member.
+        //
+        // A WeakMap (not a Map) keyed by the family-atom object: deleting a
+        // member calls family.release(...), so a deleted-and-recreated key mints
+        // a fresh atom identity; a strong Map would retain one dead entry per
+        // create/delete/recreate cycle (unbounded under churn). The WeakMap lets
+        // a released member's entry (and its predicate selector) become
+        // GC-eligible, bounding the cache by live membership.
+        const predicateSelectors = new WeakMap<
             AtomFamilyAtom<Value, FamilyArgs>,
             Selector<boolean>
         >()

--- a/packages/valdres/src/indexConstructor.ts
+++ b/packages/valdres/src/indexConstructor.ts
@@ -12,56 +12,58 @@ export const index = <
     family: AtomFamily<Value, FamilyArgs>,
     callback: (value: Value, term: Term) => boolean,
     options?: { name?: string },
-): ((term: Term) => Selector<Term[]>) => {
-    const map = new Map()
+): ((term: Term) => Selector<AtomFamilyAtom<Value, FamilyArgs>[]>) => {
+    const map = new Map<
+        ReturnType<typeof stableStringify>,
+        Selector<AtomFamilyAtom<Value, FamilyArgs>[]>
+    >()
     const index = (term: Term) => {
         const termKey = stableStringify(term)
-        if (map.has(termKey)) return map.get(termKey)
+        const existing = map.get(termKey)
+        if (existing) return existing
 
-        const termIndexSelectorSet = new Set<
-            AtomFamilyAtom<Value, FamilyArgs>
+        // Per-atom predicate selectors, cached so we don't recreate them on
+        // every membership change.
+        //
+        // This cache is GROW-ONLY and store-agnostic on purpose. A selector is
+        // a pure definition that valdres evaluates independently per store, so
+        // the same `termSelector` here runs once in the root and once in every
+        // scope that reads it. The previous design kept a mutable Set + Map of
+        // "current members" in this closure and mutated them from inside a
+        // `termIndexSelector` evaluation. Because that evaluation runs per store
+        // — and a scope can have a different family membership than the root
+        // (publish moves members between a scope and the root) — the two stores
+        // clobbered the shared state: `termSelector` in one store could iterate
+        // a snapshot set that still held a member whose predicate-selector entry
+        // had already been deleted by the other store's evaluation, and
+        // `get(undefined)` threw. Deriving membership from `get(family)` on every
+        // evaluation makes each store read its own correct membership, and never
+        // deleting from the predicate cache means a lookup is never undefined.
+        const predicateSelectors = new Map<
+            AtomFamilyAtom<Value, FamilyArgs>,
+            Selector<boolean>
         >()
-        const termIndexSelectorMap = new Map()
-        const termIndexSelector = selector(
-            get => {
-                const allFamilyAtoms = new Set(get(family))
-                const deletedAtoms =
-                    termIndexSelectorSet.symmetricDifference(allFamilyAtoms)
-                const addedAtoms =
-                    allFamilyAtoms.difference(termIndexSelectorSet)
-
-                if (deletedAtoms.size || addedAtoms.size) {
-                    deletedAtoms.forEach(atom => {
-                        termIndexSelectorSet.delete(atom)
-                        termIndexSelectorMap.delete(atom)
-                    })
-                    addedAtoms.forEach(atom => {
-                        termIndexSelectorSet.add(atom)
-                        termIndexSelectorMap.set(
-                            atom,
-                            // the callback triggers on delete. Should be avoided
-                            selector(get => callback(get(atom), term), {
-                                name: `index:callback:selector:${atom.name}`,
-                            }),
-                        )
-                    })
-                    return new Set(termIndexSelectorSet)
-                } else {
-                    return termIndexSelectorSet
-                }
-            },
-            { name: `index:${options?.name}(${termKey})` },
-        )
-
-        const filteredSelector = selector(
-            get => {
-                const set = get(termIndexSelector)
-                const res: AtomFamilyAtom<Value, FamilyArgs>[] = []
-                set.forEach(atom => {
-                    if (get(termIndexSelectorMap.get(atom))) {
-                        res.push(atom)
-                    }
+        const predicateFor = (atom: AtomFamilyAtom<Value, FamilyArgs>) => {
+            let sel = predicateSelectors.get(atom)
+            if (!sel) {
+                sel = selector(get => callback(get(atom), term), {
+                    name: `index:callback:selector:${atom.name}`,
                 })
+                predicateSelectors.set(atom, sel)
+            }
+            return sel
+        }
+
+        const filteredSelector = selector<AtomFamilyAtom<Value, FamilyArgs>[]>(
+            get => {
+                const res: AtomFamilyAtom<Value, FamilyArgs>[] = []
+                const members = get(family) as AtomFamilyAtom<
+                    Value,
+                    FamilyArgs
+                >[]
+                for (const atom of members) {
+                    if (get(predicateFor(atom))) res.push(atom)
+                }
                 return res
             },
             {

--- a/packages/valdres/src/lib/asyncCrossScopeNotification.test.ts
+++ b/packages/valdres/src/lib/asyncCrossScopeNotification.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+// An ASYNC (Promise-returning) selector spanning a root atom and a scope atom,
+// observed by a scope subscriber across a single cross-scope transaction.
+//
+// The cross-scope commit writes the whole tree, then runs ONE propagation pass
+// per store (root-first), deferring all subscriber notification to commit-end
+// (see propagateUpdatedAtoms.NotifyTarget / transaction.commit). The PR's
+// "fires exactly once with the final value" guarantee is for SYNCHRONOUS
+// selectors. A Promise-returning selector cannot honor that at commit time — its
+// committed value IS a pending promise — so its observable contract is:
+//
+//   1 commit-end fire (delivering the pending promise) + 1 resolution fire
+//   (delivering the resolved final value, from handleSelectorResult's .then,
+//   a separate, later microtask outside the commit).
+//
+// These tests PIN that observed sequence exactly. Determinism comes from
+// awaiting the selector's promise + a bounded microtask flush — no wall-clock
+// timers.
+
+// Flush a bounded number of microtask turns. handleSelectorResult chains a
+// couple of .then() hops (promise resolve -> setValueInData -> propagate), so a
+// handful of turns is enough; no setTimeout / real timers.
+const flush = async (turns = 5) => {
+    for (let i = 0; i < turns; i++) await Promise.resolve()
+}
+
+describe("async selector spanning root + scope under a cross-scope txn", () => {
+    test("commit-end fire delivers a pending promise; resolution fire delivers the final value", async () => {
+        const root = store()
+        const S = root.scope("S")
+        const r = atom(1, { name: "acs-r" })
+        const s = atom(10, { name: "acs-s" })
+        S.set(s, 10) // establish the scope-local shadow before the txn
+
+        // Externally-controlled resolvers so resolution is a distinct, awaited
+        // step (not racing the commit).
+        const resolvers: Array<() => void> = []
+        let evals = 0
+        const sum = selector(
+            get => {
+                evals++
+                const rv = get(r)
+                const sv = get(s)
+                return new Promise<number>(res => {
+                    resolvers.push(() => res(rv + sv))
+                })
+            },
+            { name: "acs-sum" },
+        )
+
+        // Record exactly what the scope subscriber observes on each fire.
+        const observed: Array<number | "PROMISE"> = []
+        const cb = mock(() => {
+            const v = S.get(sum)
+            observed.push(v instanceof Promise ? "PROMISE" : v)
+        })
+
+        // --- initial subscribe ---
+        S.sub(sum, cb)
+        // The value starts as a pending promise; the subscriber has NOT fired yet
+        // (resolution is what notifies, and the promise is still pending).
+        expect(S.get(sum)).toBeInstanceOf(Promise)
+        expect(cb).toHaveBeenCalledTimes(0)
+        expect(evals).toBe(1)
+
+        // Resolve the initial promise; the subscriber fires once with 11.
+        resolvers[resolvers.length - 1]()
+        await flush()
+        expect(observed).toEqual([11])
+        expect(cb).toHaveBeenCalledTimes(1)
+        expect(S.get(sum)).toBe(11)
+
+        const evalsBeforeCommit = evals
+        const resolversBeforeCommit = resolvers.length // 1
+        const callsBeforeCommit = cb.mock.calls.length // 1
+
+        // --- the cross-scope txn commit (synchronous, deferred notification) ---
+        root.txn(t => {
+            t.set(r, 2)
+            t.scope("S", st => st.set(s, 20))
+        })
+
+        // CRUCIAL: the commit-end notification fires EXACTLY ONCE, even though
+        // the async selector is reachable by two store-passes (root's
+        // propagateToScopes + the scope's own pass). The deferred NotifyTarget
+        // accumulates the subscriber into one per-store set and fires it once.
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(1)
+
+        // The selector BODY ran once per reaching pass (no cross-pass dedup for
+        // promise selectors — the reference-equality check never prunes a fresh
+        // promise), so two new promises were created during the commit. This is
+        // the documented cost of dropping the dedup guard, not a notification
+        // duplication.
+        expect(evals - evalsBeforeCommit).toBe(2)
+        expect(resolvers.length - resolversBeforeCommit).toBe(2)
+
+        // What the single commit-end fire delivered: a PENDING PROMISE (the
+        // committed value of an async selector mid-flight). NOT a stale numeric
+        // intermediate, and NOT the final 22 (which isn't known yet).
+        expect(observed).toEqual([11, "PROMISE"])
+        expect(S.get(sum)).toBeInstanceOf(Promise)
+
+        // --- the eventual promise RESOLUTION (separate, later microtask) ---
+        // Resolve every promise created during the commit. Only the last-stored
+        // one is the live value; handleSelectorResult's stale-promise guard
+        // drops the others, so resolution notifies exactly once regardless.
+        for (let i = resolversBeforeCommit; i < resolvers.length; i++) {
+            resolvers[i]()
+        }
+        await flush()
+
+        // Total commit-related fires = 2: the commit-end PROMISE fire + one
+        // resolution fire carrying the correct final value 22 (r=2 + s=20).
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(2)
+        expect(observed).toEqual([11, "PROMISE", 22])
+        expect(S.get(sum)).toBe(22)
+    })
+
+    test("resolution notifies exactly once and with the final value, whichever commit-promise resolves first", async () => {
+        // The selector body runs twice during the commit, producing two promises
+        // with identical inputs (r=2, s=20). Only the last-stored promise is the
+        // live value. This pins that resolving them in REVERSE order still yields
+        // exactly one resolution fire delivering 22 — the stale-promise guard
+        // discards the non-live promise's resolution.
+        const root = store()
+        const S = root.scope("S")
+        const r = atom(1, { name: "acs2-r" })
+        const s = atom(10, { name: "acs2-s" })
+        S.set(s, 10)
+
+        const resolvers: Array<() => void> = []
+        const sum = selector(
+            get => {
+                const rv = get(r)
+                const sv = get(s)
+                return new Promise<number>(res => {
+                    resolvers.push(() => res(rv + sv))
+                })
+            },
+            { name: "acs2-sum" },
+        )
+        const observed: Array<number | "PROMISE"> = []
+        const cb = mock(() => {
+            const v = S.get(sum)
+            observed.push(v instanceof Promise ? "PROMISE" : v)
+        })
+        S.sub(sum, cb)
+        resolvers[0]() // resolve initial
+        await flush()
+        expect(observed).toEqual([11])
+
+        const resolversBeforeCommit = resolvers.length
+        const callsBeforeCommit = cb.mock.calls.length
+
+        root.txn(t => {
+            t.set(r, 2)
+            t.scope("S", st => st.set(s, 20))
+        })
+        expect(resolvers.length - resolversBeforeCommit).toBe(2)
+        // one commit-end fire, delivering the pending promise
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(1)
+        expect(observed[observed.length - 1]).toBe("PROMISE")
+
+        // Resolve REVERSE: last-created first, then the earlier (non-live) one.
+        resolvers[resolvers.length - 1]()
+        await flush()
+        resolvers[resolversBeforeCommit]()
+        await flush()
+
+        // Exactly one resolution fire total (the second commit-promise's
+        // resolution is dropped as stale), and the final value is 22.
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(2)
+        expect(observed).toEqual([11, "PROMISE", 22])
+        expect(S.get(sum)).toBe(22)
+    })
+
+    test("deterministic via awaiting the committed promise (no controlled resolvers)", async () => {
+        // Same contract, but the selector returns auto-resolving promises and the
+        // test awaits the committed promise directly — proving the sequence is
+        // observable without any manual resolver plumbing or real timers.
+        const root = store()
+        const S = root.scope("S")
+        const r = atom(1, { name: "acs3-r" })
+        const s = atom(10, { name: "acs3-s" })
+        S.set(s, 10)
+
+        const sum = selector(get => Promise.resolve(get(r) + get(s)), {
+            name: "acs3-sum",
+        })
+        const observed: Array<number | "PROMISE"> = []
+        const cb = mock(() => {
+            const v = S.get(sum)
+            observed.push(v instanceof Promise ? "PROMISE" : v)
+        })
+        S.sub(sum, cb)
+
+        expect(await S.get(sum)).toBe(11)
+        await flush()
+        expect(observed).toEqual([11])
+
+        const callsBeforeCommit = cb.mock.calls.length
+
+        root.txn(t => {
+            t.set(r, 2)
+            t.scope("S", st => st.set(s, 20))
+        })
+
+        // Single commit-end fire delivering a pending promise.
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(1)
+        expect(observed).toEqual([11, "PROMISE"])
+
+        // Await the committed promise; the resolution fire then lands.
+        expect(await S.get(sum)).toBe(22)
+        await flush()
+
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(2)
+        expect(observed).toEqual([11, "PROMISE", 22])
+        expect(S.get(sum)).toBe(22)
+    })
+})

--- a/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
+++ b/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+const mulberry32 = (seed: number) => () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+
+// Regression for the "stale position / stale connector line" bug (beta.4 topo
+// propagation + beta.5 cross-scope `evaluatedSelectors` guard).
+//
+// A cross-scope commit (and the single-store update+delete commit) runs one
+// propagation pass per store and shares a per-commit `evaluatedSelectors` guard
+// so a selector reachable by more than one pass evaluates once. The guard
+// assumed the first reaching pass computes the final value — true when the
+// selector depends only on ATOMS (all writes precede propagation), but FALSE
+// when it depends on an intermediate SELECTOR that is only recomputed in a
+// later pass. The first pass then read a stale intermediate value and the guard
+// locked it in, leaving the selector (and its whole subtree) stale. The app
+// symptom: drag a node and drop it back outside any dropzone (a pure revert) —
+// the dragged subtree settles one row too low because a layout selector kept a
+// value derived from a now-stale input.
+//
+// The fix: a guarded selector is recomputed when one of its dependencies
+// actually changed value later in the commit (tracked by the topo `needsEval`
+// set); only when nothing it depends on moved is the redundant pass skipped.
+
+describe("cross-scope stale intermediate selector", () => {
+    test("scope selector spanning a root atom + an intermediate scope selector stays fresh", () => {
+        const R = atom(1, { name: "csx-R" }) // root atom
+        const A = atom(10, { name: "csx-A" }) // shadowed in scope
+        const N = selector(get => get(A) * 1000, { name: "csx-N" }) // intermediate, scope-internal
+        const M = selector(get => get(R) + get(N), { name: "csx-M" }) // spans R (root) + N (scope)
+
+        const root = store()
+        const S = root.scope("S")
+        S.set(A, 10) // establish the scope shadow
+        S.sub(N, () => {})
+        S.sub(M, () => {})
+        expect(S.get(M)).toBe(10001)
+
+        // Revert-style cross-scope commit: change the root atom AND the scope
+        // atom in one transaction. M is reached in the root pass (via R) before
+        // N is recomputed in the scope pass; it must not stay stale.
+        root.txn(t => {
+            t.set(R, 2)
+            t.scope("S", st => st.set(A, 20))
+        })
+
+        expect(S.get(N)).toBe(20000)
+        expect(S.get(M)).toBe(20002) // was 10002 (R updated, N stale) before the fix
+    })
+
+    test("deeper spanning chain stays fresh (R + N1 -> N2 -> M)", () => {
+        const R = atom(1, { name: "csx2-R" })
+        const A = atom(10, { name: "csx2-A" })
+        const N1 = selector(get => get(A) + 1, { name: "csx2-N1" })
+        const N2 = selector(get => get(N1) * 100, { name: "csx2-N2" })
+        const M = selector(get => get(R) + get(N2), { name: "csx2-M" })
+
+        const root = store()
+        const S = root.scope("S")
+        S.set(A, 10)
+        S.sub(N1, () => {})
+        S.sub(N2, () => {})
+        S.sub(M, () => {})
+        expect(S.get(M)).toBe(1 + (10 + 1) * 100)
+
+        root.txn(t => {
+            t.set(R, 2)
+            t.scope("S", st => st.set(A, 20))
+        })
+
+        expect(S.get(M)).toBe(2 + (20 + 1) * 100)
+    })
+
+    test("a selector live in BOTH root and scope is fresh in each after a cross-scope txn", () => {
+        // The per-commit dedup guard used to be keyed by selector object, not
+        // by store. The same selector subscribed in the root AND a scope was
+        // evaluated in the root pass, marked done, and the scope's (differently
+        // valued) copy was skipped — left stale. The guard is now keyed per
+        // store, so each store evaluates its own copy.
+        const X = atom(1, { name: "ps-X" }) // root atom, read through in scope
+        const Y = atom(2, { name: "ps-Y" }) // shadowed in scope
+        const s0 = selector(get => get(X) + get(Y), { name: "ps-s0" })
+        const s1 = selector(get => get(s0) + get(Y), { name: "ps-s1" })
+
+        const root = store()
+        const S = root.scope("S")
+        S.set(Y, 20)
+        // live in BOTH stores
+        root.sub(s0, () => {})
+        root.sub(s1, () => {})
+        S.sub(s0, () => {})
+        S.sub(s1, () => {})
+        expect(root.get(s0)).toBe(3)
+        expect(S.get(s0)).toBe(21)
+
+        root.txn(t => {
+            t.set(X, 5)
+            t.scope("S", st => st.set(Y, 30))
+        })
+
+        // root: X=5, Y=2  -> s0=7,  s1=9
+        expect(root.get(s0)).toBe(7)
+        expect(root.get(s1)).toBe(9)
+        // scope: X=5 (read-through), Y=30 -> s0=35, s1=65 (was stale 21/41)
+        expect(S.get(s0)).toBe(35)
+        expect(S.get(s1)).toBe(65)
+    })
+
+    test("final observed value is correct (subscriber ends on the fresh value)", () => {
+        const R = atom(1, { name: "csx3-R" })
+        const A = atom(10, { name: "csx3-A" })
+        const N = selector(get => get(A) * 1000, { name: "csx3-N" })
+        const M = selector(get => get(R) + get(N), { name: "csx3-M" })
+        const root = store()
+        const S = root.scope("S")
+        S.set(A, 10)
+        S.sub(N, () => {})
+        const observed: number[] = []
+        S.sub(M, () => observed.push(S.get(M)))
+        expect(S.get(M)).toBe(10001)
+
+        root.txn(t => {
+            t.set(R, 2)
+            t.scope("S", st => st.set(A, 20))
+        })
+
+        // The subscriber must end on the fully-applied value. (It may also
+        // observe the transient intermediate first; synchronous re-renders are
+        // batched by framework bindings, so the only user-visible value is the
+        // last one — which must be correct.)
+        expect(observed.at(-1)).toBe(20002)
+        expect(S.get(M)).toBe(20002)
+    })
+
+    // Randomized DAGs with dynamic deps, scope shadows, and cross-scope txns,
+    // selectors subscribed in both stores. Each seed's final state is checked
+    // against an independent oracle (fresh stores, final atom values applied via
+    // individual sets — never the guarded cross-scope path — then read lazily).
+    // This is what surfaced the cross-store guard bug; it now holds.
+    test("fuzz: cross-scope selectors match an independent oracle", () => {
+        for (let seed = 1; seed <= 300; seed++) {
+            const rnd = mulberry32(seed)
+            const nAtoms = 3 + Math.floor(rnd() * 3)
+            const nSel = 6 + Math.floor(rnd() * 8)
+            const defs = Array.from({ length: nSel }, (_, i) => {
+                const pick = (n: number, max: number) =>
+                    Array.from({ length: n }, () => Math.floor(rnd() * max))
+                return {
+                    deps: pick(1 + Math.floor(rnd() * 2), nAtoms),
+                    selDeps: i > 0 ? pick(Math.floor(rnd() * 2), i) : [],
+                    altSelDeps: i > 0 ? pick(Math.floor(rnd() * 2), i) : [],
+                    ctrl:
+                        i > 0 && rnd() < 0.6
+                            ? { sel: Math.floor(rnd() * i) }
+                            : { atom: Math.floor(rnd() * nAtoms) },
+                    mode: Math.floor(rnd() * 3),
+                }
+            })
+            const build = () => {
+                const atoms = Array.from({ length: nAtoms }, (_, i) =>
+                    atom(i, { name: `fa${i}` }),
+                )
+                const sels: any[] = []
+                defs.forEach((def: any, idx) => {
+                    sels.push(
+                        selector(
+                            get => {
+                                const ctrl =
+                                    "atom" in def.ctrl
+                                        ? get(atoms[def.ctrl.atom])
+                                        : get(sels[def.ctrl.sel])
+                                let acc = def.mode + (ctrl % 3)
+                                if (ctrl % 2 === 0) {
+                                    for (const di of def.deps) acc += get(atoms[di])
+                                    for (const si of def.selDeps) acc += get(sels[si])
+                                } else {
+                                    for (const si of def.altSelDeps)
+                                        acc += get(sels[si]) * 2
+                                }
+                                return acc
+                            },
+                            { name: `fs${idx}` },
+                        ),
+                    )
+                })
+                return { atoms, sels }
+            }
+
+            const I = build()
+            const root = store()
+            const S = root.scope("S")
+            const shadowed = Array.from({ length: nAtoms }, () => rnd() < 0.5)
+            const rootVal = Array.from({ length: nAtoms }, (_, i) => i)
+            const scopeVal: (number | undefined)[] = new Array(nAtoms).fill(undefined)
+            for (let ai = 0; ai < nAtoms; ai++) {
+                if (shadowed[ai]) {
+                    S.set(I.atoms[ai], 100 + ai)
+                    scopeVal[ai] = 100 + ai
+                }
+            }
+            for (let si = 0; si < nSel; si++) {
+                root.sub(I.sels[si], () => {})
+                S.sub(I.sels[si], () => {})
+            }
+
+            for (let step = 0; step < 12; step++) {
+                const rc: [number, number][] = []
+                const sc: [number, number][] = []
+                const m = 1 + Math.floor(rnd() * 3)
+                for (let j = 0; j < m; j++) {
+                    const ai = Math.floor(rnd() * nAtoms)
+                    const v = Math.floor(rnd() * 30)
+                    if (rnd() < 0.5) rc.push([ai, v])
+                    else sc.push([ai, v])
+                }
+                root.txn(t => {
+                    for (const [ai, v] of rc) t.set(I.atoms[ai], v)
+                    if (sc.length)
+                        t.scope("S", st => {
+                            for (const [ai, v] of sc) st.set(I.atoms[ai], v)
+                        })
+                })
+                for (const [ai, v] of rc) rootVal[ai] = v
+                for (const [ai, v] of sc) scopeVal[ai] = v
+            }
+
+            // independent oracle
+            const O = build()
+            const oRoot = store()
+            const oS = oRoot.scope("S")
+            for (let ai = 0; ai < nAtoms; ai++) {
+                oRoot.set(O.atoms[ai], rootVal[ai])
+                if (scopeVal[ai] !== undefined) oS.set(O.atoms[ai], scopeVal[ai]!)
+            }
+            for (let si = 0; si < nSel; si++) {
+                expect(root.get(I.sels[si])).toBe(oRoot.get(O.sels[si]))
+                expect(S.get(I.sels[si])).toBe(oS.get(O.sels[si]))
+            }
+        }
+    })
+})

--- a/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
+++ b/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
@@ -11,24 +11,23 @@ const mulberry32 = (seed: number) => () => {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296
 }
 
-// Regression for the "stale position / stale connector line" bug (beta.4 topo
-// propagation + beta.5 cross-scope `evaluatedSelectors` guard).
+// Regression for the "stale position / stale connector line" bug.
 //
 // A cross-scope commit (and the single-store update+delete commit) runs one
-// propagation pass per store and shares a per-commit `evaluatedSelectors` guard
-// so a selector reachable by more than one pass evaluates once. The guard
-// assumed the first reaching pass computes the final value — true when the
-// selector depends only on ATOMS (all writes precede propagation), but FALSE
-// when it depends on an intermediate SELECTOR that is only recomputed in a
-// later pass. The first pass then read a stale intermediate value and the guard
-// locked it in, leaving the selector (and its whole subtree) stale. The app
-// symptom: drag a node and drop it back outside any dropzone (a pure revert) —
-// the dragged subtree settles one row too low because a layout selector kept a
-// value derived from a now-stale input.
+// propagation pass per store. The original cross-scope work (beta.5 #168) added
+// a per-commit dedup guard so a selector reachable by more than one pass
+// evaluated once — but it (a) keyed by selector object, skipping a scope's copy
+// of a selector also live in the root, and (b) locked in a value an early pass
+// computed from an intermediate selector a later pass corrected. Either way the
+// selector (and its whole subtree) was left stale — e.g. drag a node and drop
+// it back outside any dropzone (a pure revert) and the subtree settles one row
+// too low because a layout selector kept a value derived from a now-stale input.
 //
-// The fix: a guarded selector is recomputed when one of its dependencies
-// actually changed value later in the commit (tracked by the topo `needsEval`
-// set); only when nothing it depends on moved is the redundant pass skipped.
+// The fix removed the cross-pass dedup guard entirely: every value is written
+// first, then each store re-derives its OWN selectors against that final state
+// (a selector reachable by two passes is recomputed in each — the equality
+// check prunes the redundant result), and subscribers are notified once at the
+// end. So each store's copy of a selector ends on its correct final value.
 
 describe("cross-scope stale intermediate selector", () => {
     test("scope selector spanning a root atom + an intermediate scope selector stays fresh", () => {
@@ -80,11 +79,11 @@ describe("cross-scope stale intermediate selector", () => {
     })
 
     test("a selector live in BOTH root and scope is fresh in each after a cross-scope txn", () => {
-        // The per-commit dedup guard used to be keyed by selector object, not
-        // by store. The same selector subscribed in the root AND a scope was
-        // evaluated in the root pass, marked done, and the scope's (differently
-        // valued) copy was skipped — left stale. The guard is now keyed per
-        // store, so each store evaluates its own copy.
+        // The old per-commit dedup guard was keyed by selector object: the same
+        // selector subscribed in the root AND a scope was evaluated in the root
+        // pass, marked done, and the scope's (differently valued) copy was
+        // skipped — left stale. With no guard, each store re-derives its own
+        // copy against the final state, so both land on their correct values.
         const X = atom(1, { name: "ps-X" }) // root atom, read through in scope
         const Y = atom(2, { name: "ps-Y" }) // shadowed in scope
         const s0 = selector(get => get(X) + get(Y), { name: "ps-s0" })
@@ -114,7 +113,7 @@ describe("cross-scope stale intermediate selector", () => {
         expect(S.get(s1)).toBe(65)
     })
 
-    test("final observed value is correct (subscriber ends on the fresh value)", () => {
+    test("subscriber is notified once with the final value (serializable)", () => {
         const R = atom(1, { name: "csx3-R" })
         const A = atom(10, { name: "csx3-A" })
         const N = selector(get => get(A) * 1000, { name: "csx3-N" })
@@ -132,11 +131,9 @@ describe("cross-scope stale intermediate selector", () => {
             t.scope("S", st => st.set(A, 20))
         })
 
-        // The subscriber must end on the fully-applied value. (It may also
-        // observe the transient intermediate first; synchronous re-renders are
-        // batched by framework bindings, so the only user-visible value is the
-        // last one — which must be correct.)
-        expect(observed.at(-1)).toBe(20002)
+        // Notification is deferred to commit end, so the subscriber fires
+        // exactly once, with the fully-applied value — never the intermediate.
+        expect(observed).toEqual([20002])
         expect(S.get(M)).toBe(20002)
     })
 

--- a/packages/valdres/src/lib/deferredCommitSubscriberErrors.test.ts
+++ b/packages/valdres/src/lib/deferredCommitSubscriberErrors.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
+import { store } from "../store"
+
+// A deferred (multi-pass) commit accumulates subscribers per store and fires
+// them once at the very end via notifyDeferred → callSubscribers. This pins
+// what happens when one of those subscribers THROWS. Two deferred paths are
+// covered: (a) a cross-scope txn (root + a scope via t.scope), and (b) a
+// single-store update+delete txn (t.set + t.del of a family member).
+//
+// The contracts pinned here (all observed by probing the real implementation,
+// not guessed):
+//   1. WRITES ARE FULLY APPLIED even though a subscriber throws. The throw
+//      happens in the notify phase, after every write across every store. Final
+//      atom/selector reads return the committed values.
+//   2. WITHIN ONE STORE'S SUBSCRIBER SET, a throwing subscriber does NOT prevent
+//      the OTHER subscribers in that same set from firing (callSubscribers
+//      catches each throw, records the FIRST error, keeps firing the rest), and
+//      the txn ultimately throws that first error.
+//   3. CROSS-ENTRY: notifyDeferred fires EVERY store's entry even if one throws,
+//      then rethrows the FIRST error. So a throwing subscriber in one store
+//      (e.g. root, processed first) does NOT suppress another store's (scope's)
+//      subscribers for writes committed in the same atomic transaction — every
+//      store is notified, and the first error still surfaces from the txn.
+
+describe("deferred commit: a subscriber that throws", () => {
+    describe("(a) cross-scope txn (root + scope)", () => {
+        test("writes are fully applied even though a subscriber throws", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dce-a-r" })
+            const s = atom(10, { name: "dce-a-s" })
+            S.set(s, 10)
+
+            // Subscriber on the root atom throws during the notify phase.
+            root.sub(r, () => {
+                throw new Error("boom-a-1")
+            })
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(r, 2)
+                    t.scope("S", st => st.set(s, 20))
+                }),
+            ).toThrow("boom-a-1")
+
+            // The throw is in the notify phase, AFTER all writes — so both the
+            // root and scope values are the committed ones.
+            expect(root.get(r)).toBe(2)
+            expect(S.get(s)).toBe(20)
+        })
+
+        test("a spanning selector reaches its committed value despite a throw", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dce-a2-r" })
+            const s = atom(10, { name: "dce-a2-s" })
+            S.set(s, 10)
+
+            const sum = selector(get => get(r) + get(s), { name: "dce-a2-sum" })
+            // Subscribe to the spanning selector in the scope; the callback throws.
+            S.sub(sum, () => {
+                throw new Error("boom-a2")
+            })
+            expect(S.get(sum)).toBe(11)
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(r, 2)
+                    t.scope("S", st => st.set(s, 20))
+                }),
+            ).toThrow("boom-a2")
+
+            // Final committed value is observable after the commit, despite the
+            // subscriber throwing.
+            expect(S.get(sum)).toBe(22)
+        })
+
+        test("within one store's set, a throwing subscriber does not stop the others; txn throws the first error", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dce-a3-r" })
+            const s = atom(10, { name: "dce-a3-s" })
+            S.set(s, 10)
+
+            const order: string[] = []
+            const sub1 = mock(() => {
+                order.push("sub1")
+                throw new Error("boom-a3-first")
+            })
+            const sub2 = mock(() => {
+                order.push("sub2")
+            })
+            const sub3 = mock(() => {
+                order.push("sub3")
+                throw new Error("boom-a3-second")
+            })
+            // All three on the SAME store (root), SAME atom => one subscriber set.
+            root.sub(r, sub1)
+            root.sub(r, sub2)
+            root.sub(r, sub3)
+
+            let thrown: unknown
+            try {
+                root.txn(t => {
+                    t.set(r, 2)
+                    t.scope("S", st => st.set(s, 20))
+                })
+            } catch (e) {
+                thrown = e
+            }
+
+            // Every subscriber in the set fired, in registration order.
+            expect(sub1).toHaveBeenCalledTimes(1)
+            expect(sub2).toHaveBeenCalledTimes(1)
+            expect(sub3).toHaveBeenCalledTimes(1)
+            expect(order).toEqual(["sub1", "sub2", "sub3"])
+
+            // The txn rethrows the FIRST error encountered (not the last).
+            expect(thrown).toBeInstanceOf(Error)
+            expect((thrown as Error).message).toBe("boom-a3-first")
+        })
+    })
+
+    describe("(b) single-store update+delete txn (t.set + t.del)", () => {
+        test("writes are fully applied (atom set + family delete) despite a throw", () => {
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "dce-b-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const Y = atom(0, { name: "dce-b-y" })
+
+            const span = selector(get => `${get(fam).length}:${get(Y)}`, {
+                name: "dce-b-span",
+            })
+            root.sub(span, () => {
+                throw new Error("boom-b")
+            })
+            expect(root.get(span)).toBe("2:0")
+
+            expect(() =>
+                root.txn(t => {
+                    t.del(m2)
+                    t.set(Y, 9)
+                }),
+            ).toThrow("boom-b")
+
+            // Both the delete and the set landed, observable after the throw.
+            expect(root.get(span)).toBe("1:9")
+            expect(root.get(Y)).toBe(9)
+            // The deleted member's value is actually evicted from the store.
+            expect(root.data.values.has(m2)).toBe(false)
+        })
+
+        test("within one store's set, a throwing subscriber does not stop the others; txn throws the first error", () => {
+            const root = store()
+            const fam = atomFamily<string>(undefined, { name: "dce-b2-fam" })
+            const m1 = fam("1")
+            const m2 = fam("2")
+            root.set(m1, "a")
+            root.set(m2, "b")
+            const Y = atom(0, { name: "dce-b2-y" })
+
+            const span = selector(get => `${get(fam).length}:${get(Y)}`, {
+                name: "dce-b2-span",
+            })
+
+            const spanSub1 = mock(() => {
+                throw new Error("boom-b2-first")
+            })
+            const spanSub2 = mock(() => {})
+            // Subscriber on Y too — Y is updated in the same deferred commit.
+            const ySub = mock(() => {})
+            root.sub(span, spanSub1)
+            root.sub(span, spanSub2)
+            root.sub(Y, ySub)
+            root.get(span)
+
+            let thrown: unknown
+            try {
+                root.txn(t => {
+                    t.del(m2)
+                    t.set(Y, 9)
+                })
+            } catch (e) {
+                thrown = e
+            }
+
+            // Both span subscribers fired even though the first threw, and the
+            // unrelated Y subscriber in the same store fired too.
+            expect(spanSub1).toHaveBeenCalledTimes(1)
+            expect(spanSub2).toHaveBeenCalledTimes(1)
+            expect(ySub).toHaveBeenCalledTimes(1)
+
+            // Txn rethrows the first error.
+            expect(thrown).toBeInstanceOf(Error)
+            expect((thrown as Error).message).toBe("boom-b2-first")
+        })
+    })
+
+    // CROSS-ENTRY behavior. notifyDeferred fires every per-store entry (root
+    // first, then scopes); if an entry's callSubscribers rethrows, the loop
+    // records the first error and CONTINUES to the remaining entries, rethrowing
+    // the first error only at the end. So a throw in one store's entry does not
+    // suppress another store's notification for the same atomic commit.
+    describe("cross-entry: a throw in one store's entry does NOT suppress others", () => {
+        test("ROOT-entry throw still notifies the SCOPE-entry subscriber; first error surfaces", () => {
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dce-ce-r" })
+            const s = atom(10, { name: "dce-ce-s" })
+            S.set(s, 10)
+
+            const rootSub = mock(() => {
+                throw new Error("boom-root-entry")
+            })
+            const scopeSub = mock(() => {})
+            // Root entry is processed first (root-first); it throws.
+            root.sub(r, rootSub)
+            // Scope entry is processed AFTER root.
+            S.sub(s, scopeSub)
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(r, 2)
+                    t.scope("S", st => st.set(s, 20))
+                }),
+            ).toThrow("boom-root-entry")
+
+            // Root entry fired (and threw)...
+            expect(rootSub).toHaveBeenCalledTimes(1)
+            // ...and the SCOPE entry subscriber is STILL notified — notifyDeferred
+            // fires every store's entry even when an earlier one throws, then
+            // rethrows the first (root) error.
+            expect(scopeSub).toHaveBeenCalledTimes(1)
+
+            expect(S.get(s)).toBe(20)
+            expect(root.get(r)).toBe(2)
+        })
+
+        test("SCOPE-entry throw does NOT suppress the earlier ROOT-entry subscriber", () => {
+            // Root is processed before the scope (root-first), so a scope throw
+            // cannot retroactively suppress the root entry — it already fired.
+            const root = store()
+            const S = root.scope("S")
+            const r = atom(1, { name: "dce-ce2-r" })
+            const s = atom(10, { name: "dce-ce2-s" })
+            S.set(s, 10)
+
+            const rootSub = mock(() => {})
+            const scopeSub = mock(() => {
+                throw new Error("boom-scope-entry")
+            })
+            root.sub(r, rootSub)
+            S.sub(s, scopeSub)
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(r, 2)
+                    t.scope("S", st => st.set(s, 20))
+                }),
+            ).toThrow("boom-scope-entry")
+
+            // Both fired: root (first, cleanly) then scope (which threw).
+            expect(rootSub).toHaveBeenCalledTimes(1)
+            expect(scopeSub).toHaveBeenCalledTimes(1)
+        })
+    })
+})

--- a/packages/valdres/src/lib/parentScopeDeferredObservation.test.ts
+++ b/packages/valdres/src/lib/parentScopeDeferredObservation.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect, mock } from "bun:test"
+import { store } from "../store"
+import { atom } from "../atom"
+import { selector } from "../selector"
+
+// A child scope can run a transaction that ALSO writes to its parent via
+// t.parentScope(...). This is the inverse of the root.txn(t => t.scope(...))
+// path: here the *child* starts the txn and reaches UP into the parent. The
+// commit still walks to the topmost transaction (txnCommit climbs
+// parentTransaction) and runs the same cross-scope, deferred-notification
+// commit — one write pass per store (leaf-first) then one propagation pass per
+// store (root-first), with subscribers fired ONCE at commit end.
+//
+// These pin the parentScope commit path under deferred notification:
+//   1. A selector spanning the parent atom (written via parentScope) and the
+//      child atom (written/shadowed in the child) ends FRESH in both stores.
+//   2. Its subscriber fires exactly ONCE with the final value (no stale
+//      intermediate), in whichever store(s) it is subscribed.
+//   3. onSet on the parent atom (written via parentScope) fires — seeing the
+//      fully-applied child write — and fires before subscribers.
+
+describe("parentScope commit under deferred notification", () => {
+    describe("spanning selector freshness", () => {
+        test("selector spanning parent + child ends fresh in both stores", () => {
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "ps-r" }) // written at parent
+            const c = atom(10, { name: "ps-c" }) // shadowed/written in child
+            child.set(c, 10) // establish the child shadow before the txn
+
+            const sum = selector(get => get(r) + get(c), { name: "ps-sum" })
+            // live in BOTH stores
+            root.sub(sum, () => {})
+            child.sub(sum, () => {})
+            expect(root.get(sum)).toBe(11) // r=1 + root c=10
+            expect(child.get(sum)).toBe(11) // r=1 + child c=10
+
+            child.txn(t => {
+                t.set(c, 20)
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            // child reads r through the parent (9) + its own c (20)
+            expect(child.get(sum)).toBe(29)
+            // root reads its own r (9) + its own c (still 10)
+            expect(root.get(sum)).toBe(19)
+        })
+
+        test("child NEWLY shadows the child atom in the same txn", () => {
+            // No pre-existing child shadow of c; the txn creates it. The child
+            // selector must recompute against the new shadow AND the parent's
+            // new r — never a half-applied intermediate.
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "psn-r" })
+            const c = atom(10, { name: "psn-c" }) // child inherits c initially
+            const sum = selector(get => get(r) + get(c), { name: "psn-sum" })
+            const cb = mock(() => {})
+            child.sub(sum, cb)
+            expect(child.get(sum)).toBe(11)
+
+            child.txn(t => {
+                t.set(c, 20) // first shadow of c in the child
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            expect(child.get(sum)).toBe(29) // 9 + 20
+            expect(root.get(sum)).toBe(19) // 9 + 10 (root keeps its c)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("transitive chain spanning parent + child stays fresh", () => {
+            // A (parent atom only) feeds B (A + child atom). Both selectors span
+            // the two stores; each must end on its final value in the child.
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "pst-r" })
+            const c = atom(10, { name: "pst-c" })
+            child.set(c, 10)
+            const A = selector(get => get(r) * 2, { name: "pst-A" })
+            const B = selector(get => get(A) + get(c), { name: "pst-B" })
+            const cb = mock(() => {})
+            child.sub(B, cb)
+            expect(child.get(B)).toBe(12) // (1*2) + 10
+
+            child.txn(t => {
+                t.set(c, 20)
+                t.parentScope(pt => pt.set(r, 5))
+            })
+
+            expect(child.get(A)).toBe(10) // 5 * 2
+            expect(child.get(B)).toBe(30) // 10 + 20, never the stale 2 + 20 = 22
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("child newly shadows with the same value the parent is set to", () => {
+            // parentScope variant of the newly-shadow hazard: the child shadows X
+            // with the same numeric value the parent simultaneously sets X to.
+            // The child selector still must recompute (it was reading the
+            // inherited 0) and fire exactly once.
+            const root = store()
+            const child = root.scope("C")
+            const X = atom(0, { name: "psm-x" })
+            const sel = selector(get => get(X), { name: "psm-sel" })
+            const cb = mock(() => {})
+            child.sub(sel, cb)
+            expect(child.get(sel)).toBe(0)
+
+            child.txn(t => {
+                t.set(X, 5) // child shadows X=5
+                t.parentScope(pt => pt.set(X, 5)) // parent X=5
+            })
+
+            expect(child.get(sel)).toBe(5)
+            expect(root.get(X)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe("single, final-valued notification", () => {
+        test("child subscriber on the spanning selector fires once with the final value", () => {
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "pso-r" })
+            const c = atom(10, { name: "pso-c" })
+            child.set(c, 10)
+            const sum = selector(get => get(r) + get(c), { name: "pso-sum" })
+            const observed: number[] = []
+            const cb = mock(() => observed.push(child.get(sum)))
+            child.sub(sum, cb)
+            expect(child.get(sum)).toBe(11)
+
+            child.txn(t => {
+                t.set(c, 20)
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            // Deferred notification: the intermediate half-applied value
+            // (1 + 20 = 21, or 9 + 10 = 19) must never be observed.
+            expect(observed).not.toContain(21)
+            expect(observed).toEqual([29])
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+
+        test("the same spanning selector subscribed in BOTH stores fires once per store, each final", () => {
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "psb-r" })
+            const c = atom(10, { name: "psb-c" })
+            child.set(c, 10)
+            const sum = selector(get => get(r) + get(c), { name: "psb-sum" })
+
+            const rootObserved: number[] = []
+            const childObserved: number[] = []
+            const rootCb = mock(() => rootObserved.push(root.get(sum)))
+            const childCb = mock(() => childObserved.push(child.get(sum)))
+            root.sub(sum, rootCb)
+            child.sub(sum, childCb)
+            expect(root.get(sum)).toBe(11)
+            expect(child.get(sum)).toBe(11)
+
+            child.txn(t => {
+                t.set(c, 20)
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            // Each store's subscriber fires once, with that store's final value.
+            expect(rootObserved).toEqual([19]) // 9 + root c (10)
+            expect(childObserved).toEqual([29]) // 9 + child c (20)
+            expect(rootCb).toHaveBeenCalledTimes(1)
+            expect(childCb).toHaveBeenCalledTimes(1)
+        })
+
+        test("a subscriber reading from within its callback sees the fully-applied parent write", () => {
+            // The child subscriber reads the parent atom directly inside its
+            // callback. It must observe the final parent value (9), not the
+            // pre-txn value — proving the parent write landed before notify.
+            const root = store()
+            const child = root.scope("C")
+            const r = atom(1, { name: "psr-r" })
+            const c = atom(10, { name: "psr-c" })
+            child.set(c, 10)
+            const seen: Array<[number, number]> = []
+            child.sub(c, () => seen.push([child.get(r), child.get(c)]))
+
+            child.txn(t => {
+                t.set(c, 20)
+                t.parentScope(pt => pt.set(r, 9))
+            })
+
+            // The child reads r through the parent — it must be the final 9.
+            expect(seen).toEqual([[9, 20]])
+        })
+    })
+
+    describe("onSet timing on a parentScope write", () => {
+        test("onSet on the parent atom fires (seeing the child write) and before subscribers", () => {
+            const root = store()
+            const child = root.scope("C")
+            const c = atom(0, { name: "pot-c" })
+            child.set(c, 0)
+
+            const order: Array<[string, number]> = []
+            const r = atom(0, {
+                name: "pot-r",
+                onSet: () => order.push(["onSet:r", child.get(c)]),
+            })
+            root.sub(r, () => order.push(["sub:r", child.get(c)]))
+
+            child.txn(t => {
+                t.set(c, 7)
+                t.parentScope(pt => pt.set(r, 1))
+            })
+
+            // onSet on the parent atom observes the fully-applied child value
+            // (7) and fires before the subscriber — preserving the legacy
+            // onSet-before-subscribers ordering.
+            expect(order).toEqual([
+                ["onSet:r", 7],
+                ["sub:r", 7],
+            ])
+        })
+
+        test("onSet fires for both the parent atom and the child atom in one txn", () => {
+            // Both atoms carry onSet. Pin the observed firing order: onSets fire
+            // root-first (parent before child), then subscribers root-first.
+            // (Writes run leaf-first, but onSet is deferred to the notify phase
+            // and replayed in the root-first commit plan order.)
+            const root = store()
+            const child = root.scope("C")
+            const order: string[] = []
+            const r = atom(0, {
+                name: "po2-r",
+                onSet: v => order.push(`onSet:r=${v}`),
+            })
+            const c = atom(0, {
+                name: "po2-c",
+                onSet: v => order.push(`onSet:c=${v}`),
+            })
+            child.set(c, 0)
+            root.sub(r, () => order.push("sub:r"))
+            child.sub(c, () => order.push("sub:c"))
+
+            child.txn(t => {
+                t.set(c, 7)
+                t.parentScope(pt => pt.set(r, 1))
+            })
+
+            // All onSets fire before any subscriber; within each group the
+            // parent (root) precedes the child.
+            expect(order).toEqual([
+                "onSet:r=1",
+                "onSet:c=7",
+                "sub:r",
+                "sub:c",
+            ])
+        })
+    })
+})

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -40,12 +40,25 @@ export {
 type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 
 // Deferred-notification target for a multi-pass commit (a cross-scope txn, or a
-// single-store update+delete txn). Each store-pass collects subscribers here
-// (deduped by the Set) instead of firing them; the commit fires them ONCE at
-// the very end — after every value across every store is final. That is what
-// makes a transaction *serializable to observe*: no subscriber, and nothing a
-// subscriber reads, ever sees a half-applied intermediate. Left undefined on
-// the single-store / non-scoped hot path, where firing stays inline.
+// single-store update+delete txn). Each store-pass collects its subscribers here
+// instead of firing them; the commit fires them ONCE at the very end — after
+// every value across every store is final. That is what makes a transaction
+// *serializable to observe*: no subscriber, and nothing a SYNCHRONOUS selector a
+// subscriber reads, ever sees a half-applied intermediate. (Scope: an async /
+// Promise-returning selector still notifies again when its promise resolves — a
+// separate, later microtask, outside the commit — so "fires exactly once with
+// the final value" is the guarantee for synchronous selectors.) Left undefined
+// on the single-store / non-scoped hot path, where firing stays inline.
+//
+// PARTITIONED PER STORE. The same selector/family lives — with different values
+// and different changed members — in the root and in each scope, and a single
+// family subscription is registered in exactly one store (a scope's read-through
+// family subscription is *delegated* into the parent's store AND kept in the
+// scope's store, as two distinct objects). So we collect per StoreData and fire
+// each store's subscriptions only against the family members that changed in
+// THAT store. A flat, store-agnostic map regressed this: a root family
+// subscriber fired for members that only changed in a nested scope, and a
+// scope's delegated+local subscriptions both fired against the merged member set.
 //
 // ⚠️ DO NOT reintroduce a per-commit "evaluate each selector at most once across
 // passes" dedup guard. We shipped one (an `evaluatedSelectors` set, #168) and it
@@ -65,9 +78,22 @@ type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 // optimization *behind* this guarantee: keyed per (store, selector), skipping
 // only a re-eval that is provably value-identical — never as a correctness
 // shortcut that suppresses a needed recompute.
-export type NotifyTarget = {
+type NotifyStoreEntry = {
     subscriptions: Set<Subscription>
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+}
+export type NotifyTarget = Map<StoreData, NotifyStoreEntry>
+
+const notifyEntryFor = (
+    notify: NotifyTarget,
+    data: StoreData,
+): NotifyStoreEntry => {
+    let entry = notify.get(data)
+    if (entry === undefined) {
+        entry = { subscriptions: new Set(), families: new Map() }
+        notify.set(data, entry)
+    }
+    return entry
 }
 
 const reEvaluateSelector = (
@@ -138,30 +164,35 @@ const callSubscribers = (
 }
 
 // Fire the subscribers accumulated by a deferred (multi-pass) commit, once,
-// after every pass has run and every value is final.
+// after every pass has run and every value is final. Per store (root-first, by
+// insertion order): each store's subscriptions fire against only that store's
+// changed family members, so a family subscription never fires for a member
+// that changed in a different store.
 export const notifyDeferred = (notify: NotifyTarget) => {
-    if (notify.subscriptions.size > 0) {
-        callSubscribers(notify.subscriptions, notify.families)
+    for (const entry of notify.values()) {
+        if (entry.subscriptions.size > 0) {
+            callSubscribers(entry.subscriptions, entry.families)
+        }
     }
 }
 
-// Record a pass's changed family members into the deferred notify target, so
-// callSubscribers can resolve family-atom subscriptions once at commit end.
-// This is the NOTIFICATION side only. The per-pass map handed in here is the
-// SAME data a pass uses to drive index bookkeeping (add/deleteFamilyAtomsFromSet)
-// — but those two roles must NOT share one mutable map across passes: the
-// bookkeeping map has to contain only THIS pass's atoms (a delete pass that saw
-// an earlier pass's added atoms would delete them). So each pass keeps its
-// bookkeeping map local and merges it here for notification.
+// Record a pass's changed family members into its store's notify entry, so
+// callSubscribers can resolve that store's family-atom subscriptions once at
+// commit end. This is the NOTIFICATION side only. The per-pass map handed in
+// here is the SAME data a pass uses to drive index bookkeeping
+// (add/deleteFamilyAtomsFromSet) — but those two roles must NOT share one
+// mutable map across passes: the bookkeeping map has to contain only THIS pass's
+// atoms (a delete pass that saw an earlier pass's added atoms would delete them).
+// So each pass keeps its bookkeeping map local and merges it here for notification.
 const collectFamilyAtomsForNotify = (
-    notify: NotifyTarget,
+    entry: NotifyStoreEntry,
     changedByFamily: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
 ) => {
     for (const [family, atoms] of changedByFamily) {
-        let target = notify.families.get(family)
+        let target = entry.families.get(family)
         if (target === undefined) {
             target = new Set()
-            notify.families.set(family, target)
+            entry.families.set(family, target)
         }
         for (const atom of atoms) target.add(atom)
     }
@@ -208,10 +239,11 @@ export const propagateDeletedAtoms = (
     timestamp = performance.now(),
     notify?: NotifyTarget,
 ) => {
-    // When deferring, subscribers accumulate into the commit-level notify
-    // target so this pass fires once, together with the others.
-    if (notify) {
-        subscriptions = notify.subscriptions
+    // When deferring, subscribers accumulate into THIS store's notify entry so
+    // they fire once, at commit end, against this store's changed members.
+    const notifyEntry = notify ? notifyEntryFor(notify, data) : undefined
+    if (notifyEntry) {
+        subscriptions = notifyEntry.subscriptions
     }
     const selectors = new Set<Selector>()
     for (const atom of atoms) {
@@ -237,7 +269,7 @@ export const propagateDeletedAtoms = (
         }
     }
     propagateDirtySelectors(atoms, selectors, data, subscriptions, deletedFamilyAtoms, false, notify)
-    if (notify) collectFamilyAtomsForNotify(notify, deletedFamilyAtoms)
+    if (notifyEntry) collectFamilyAtomsForNotify(notifyEntry, deletedFamilyAtoms)
     // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
     // already updated each scope's family index via recursivelyUpdateIndexes;
     // selectors in those scopes that depend on the family still need to be
@@ -288,7 +320,7 @@ export const propagateAtomUpdate = (
             ) {
                 const subs = data.subscriptions.get(atom)
                 if (subs && subs.size > 0) {
-                    if (notify) addSetToSet(subs, notify.subscriptions)
+                    if (notify) addSetToSet(subs, notifyEntryFor(notify, data).subscriptions)
                     else callSubscribers(subs)
                 }
                 return
@@ -296,7 +328,8 @@ export const propagateAtomUpdate = (
         }
     }
 
-    const subscriptions = notify ? notify.subscriptions : new Set<Subscription>()
+    const notifyEntry = notify ? notifyEntryFor(notify, data) : undefined
+    const subscriptions = notifyEntry ? notifyEntry.subscriptions : new Set<Subscription>()
     // Per-call ONLY (never a cross-pass accumulator): the family atoms updated
     // in THIS call. Drives index bookkeeping (addFamilyAtomsToSet), and is
     // merged into notify.families afterwards for deferred notification — two
@@ -348,7 +381,7 @@ export const propagateAtomUpdate = (
     }
 
     propagateDirtySelectors(atoms, selectors, data, subscriptions, updatedFamilyAtoms, isInitOnly, notify)
-    if (notify) collectFamilyAtomsForNotify(notify, updatedFamilyAtoms)
+    if (notifyEntry) collectFamilyAtomsForNotify(notifyEntry, updatedFamilyAtoms)
 
     if (data.scopes && data.scopes.size > 0) {
         propagateToScopes(atoms, data, isInitOnly, notify)
@@ -365,10 +398,12 @@ export const propagateInScope = (
     isInitOnly = false,
     notify?: NotifyTarget,
 ) => {
-    // Selector subscribers must accumulate into the commit-level set (so they
-    // fire once at the end); `families` is unused here (this entry skips direct
-    // atom/family subscribers — the parent pass collected those).
-    const subscriptions = notify ? notify.subscriptions : new Set<Subscription>()
+    // Selector subscribers must accumulate into THIS store's notify entry (so
+    // they fire once at the end); `families` is unused here (this entry skips
+    // direct atom/family subscribers — the parent pass collected those).
+    const subscriptions = notify
+        ? notifyEntryFor(notify, data).subscriptions
+        : new Set<Subscription>()
     const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
     const selectors = new Set<Selector>()
 

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -39,28 +39,35 @@ export {
 
 type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 
-// Per-commit selector dedup guard, keyed PER STORE. A single cross-scope (or
-// update+delete) commit propagates once per store; the same selector object
-// can be reached more than once within one store (an ancestor's
-// propagateToScopes plus that store's own pass), and we want to evaluate it
-// only once there. But the SAME selector object also lives — with a different
-// value — in the root and in every scope, so the guard must NOT be shared
-// across stores. Keying by StoreData keeps the intra-store dedup while letting
-// each store evaluate its own copy. Left undefined on the single-store /
-// non-scoped hot path, so that path allocates nothing and is unchanged.
-export type EvaluatedSelectors = Map<StoreData, Set<Selector>>
-
-const evaluatedSetFor = (
-    evaluatedSelectors: EvaluatedSelectors | undefined,
-    data: StoreData,
-): Set<Selector> | undefined => {
-    if (evaluatedSelectors === undefined) return undefined
-    let set = evaluatedSelectors.get(data)
-    if (set === undefined) {
-        set = new Set<Selector>()
-        evaluatedSelectors.set(data, set)
-    }
-    return set
+// Deferred-notification target for a multi-pass commit (a cross-scope txn, or a
+// single-store update+delete txn). Each store-pass collects subscribers here
+// (deduped by the Set) instead of firing them; the commit fires them ONCE at
+// the very end — after every value across every store is final. That is what
+// makes a transaction *serializable to observe*: no subscriber, and nothing a
+// subscriber reads, ever sees a half-applied intermediate. Left undefined on
+// the single-store / non-scoped hot path, where firing stays inline.
+//
+// ⚠️ DO NOT reintroduce a per-commit "evaluate each selector at most once across
+// passes" dedup guard. We shipped one (an `evaluatedSelectors` set, #168) and it
+// caused two correctness regressions, both subtle and both expensive to find:
+//   1. Keyed by selector OBJECT, it skipped a scope's copy of a selector that
+//      was also live in the root (different value per store) — left stale.
+//   2. It locked in a value an early pass computed from an intermediate selector
+//      that a LATER pass corrected — also left stale.
+// The model here is deliberately dumb and robust instead: write every value
+// first, then each store re-derives its OWN selectors against that final state
+// (a selector reachable by two passes is simply recomputed in each — the
+// equality check discards the redundant result), then notify once. A selector's
+// value is a pure function of the committed atom state, and running passes
+// root-first means read-through ancestor values are already final, so the last
+// pass to touch a selector always lands on the correct value — no outer fixpoint
+// loop needed. If cross-scope-commit CPU ever matters, add dedup ONLY as a pure
+// optimization *behind* this guarantee: keyed per (store, selector), skipping
+// only a re-eval that is provably value-identical — never as a correctness
+// shortcut that suppresses a needed recompute.
+export type NotifyTarget = {
+    subscriptions: Set<Subscription>
+    families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
 }
 
 const reEvaluateSelector = (
@@ -130,6 +137,14 @@ const callSubscribers = (
     if (hasError) throw firstError
 }
 
+// Fire the subscribers accumulated by a deferred (multi-pass) commit, once,
+// after every pass has run and every value is final.
+export const notifyDeferred = (notify: NotifyTarget) => {
+    if (notify.subscriptions.size > 0) {
+        callSubscribers(notify.subscriptions, notify.families)
+    }
+}
+
 const addSetToSet = (fromSet: Set<any> | undefined, toSet: Set<any>) => {
     if (fromSet && fromSet.size > 0) {
         for (const item of fromSet) {
@@ -161,8 +176,17 @@ export const propagateDeletedAtoms = (
     subscriptions: Set<Subscription> = new Set(),
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>> = new Map(),
     timestamp = performance.now(),
-    evaluatedSelectors?: EvaluatedSelectors,
+    notify?: NotifyTarget,
 ) => {
+    // When deferring, accumulate subscribers into the commit-level notify
+    // target so the delete pass's subscribers fire once, with the update
+    // pass's. NOTE: `families` here is also the deletion-bookkeeping set
+    // (deleteFamilyAtomsFromSet), which must contain ONLY the atoms deleted in
+    // THIS call — so it stays local; we merge it into notify.families (for
+    // family-subscriber notification) only after the bookkeeping is done.
+    if (notify) {
+        subscriptions = notify.subscriptions
+    }
     const selectors = new Set<Selector>()
     for (const atom of atoms) {
         addSetToSet(data.stateDependents.get(atom), selectors)
@@ -186,7 +210,21 @@ export const propagateDeletedAtoms = (
             deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
         }
     }
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, false, evaluatedSelectors)
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, false, notify)
+    // Deferred: merge this call's deleted family atoms into the commit-level
+    // notify target so callSubscribers can resolve family-atom subscriptions at
+    // the end (the local `families` was needed deleted-only for the bookkeeping
+    // above; firing was skipped by propagateDirtySelectors under defer).
+    if (notify && families.size > 0) {
+        for (const [family, familyAtoms] of families) {
+            let target = notify.families.get(family)
+            if (!target) {
+                target = new Set()
+                notify.families.set(family, target)
+            }
+            for (const a of familyAtoms) target.add(a)
+        }
+    }
     // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
     // already updated each scope's family index via recursivelyUpdateIndexes;
     // selectors in those scopes that depend on the family still need to be
@@ -207,7 +245,7 @@ export const propagateDeletedAtoms = (
             }
         }
         for (const [scope, familiesInScope] of scopeFamilies) {
-            propagateInScope(familiesInScope, scope, false, evaluatedSelectors)
+            propagateInScope(familiesInScope, scope, false, notify)
         }
     }
 }
@@ -215,20 +253,15 @@ export const propagateDeletedAtoms = (
 // Top-level entry: notify direct atom subscribers, walk dependent selectors,
 // then cross-propagate into scopes.
 //
-// `evaluatedSelectors` (cross-scope / update+delete commit only): a per-commit
-// guard set. A selector lives in one store but can be reached twice in a single
-// commit — once via an ancestor's propagateToScopes, once via its own store's
-// pass (or via the update pass and the delete pass). Since every value is
-// written before any propagation runs, the redundant reach is skipped — UNLESS
-// a SELECTOR dependency of the already-evaluated selector changed value in the
-// later pass (the earlier evaluation then read a stale intermediate), in which
-// case it is recomputed. See the guard inside propagateDownstreamTopo. Left
-// undefined on the single-store / non-scoped hot path, so that path is unchanged.
+// `notify` (multi-pass commit only): see NotifyTarget. When provided, subscribers
+// are collected into it instead of fired, so the commit can fire them once at
+// the end. Left undefined on the single-store / non-scoped hot path, where
+// firing stays inline and this function is unchanged.
 export const propagateAtomUpdate = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
-    evaluatedSelectors?: EvaluatedSelectors,
+    notify?: NotifyTarget,
 ) => {
     // Fast path: single non-family atom with no dependent selectors and no
     // scopes can skip the full graph walk entirely and just notify subscribers.
@@ -242,14 +275,19 @@ export const propagateAtomUpdate = (
             ) {
                 const subs = data.subscriptions.get(atom)
                 if (subs && subs.size > 0) {
-                    callSubscribers(subs)
+                    if (notify) addSetToSet(subs, notify.subscriptions)
+                    else callSubscribers(subs)
                 }
                 return
             }
         }
     }
 
-    const subscriptions = new Set<Subscription>()
+    const subscriptions = notify ? notify.subscriptions : new Set<Subscription>()
+    // `families` is local: it feeds addFamilyAtomsToSet (index bookkeeping),
+    // which must see only THIS call's family atoms — not those another store's
+    // pass left in a shared map. Merged into notify.families after, for
+    // deferred family-subscriber notification.
     const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
     const selectors = new Set<Selector>()
 
@@ -291,10 +329,20 @@ export const propagateAtomUpdate = (
         }
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, evaluatedSelectors)
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, notify)
+    if (notify && families.size > 0) {
+        for (const [family, familyAtoms] of families) {
+            let target = notify.families.get(family)
+            if (!target) {
+                target = new Set()
+                notify.families.set(family, target)
+            }
+            for (const a of familyAtoms) target.add(a)
+        }
+    }
 
     if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly, evaluatedSelectors)
+        propagateToScopes(atoms, data, isInitOnly, notify)
     }
 }
 
@@ -306,9 +354,12 @@ export const propagateInScope = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
-    evaluatedSelectors?: EvaluatedSelectors,
+    notify?: NotifyTarget,
 ) => {
-    const subscriptions = new Set<Subscription>()
+    // Selector subscribers must accumulate into the commit-level set (so they
+    // fire once at the end); `families` is unused here (this entry skips direct
+    // atom/family subscribers — the parent pass collected those).
+    const subscriptions = notify ? notify.subscriptions : new Set<Subscription>()
     const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
     const selectors = new Set<Selector>()
 
@@ -316,10 +367,10 @@ export const propagateInScope = (
         addSetToSet(data.stateDependents.get(atom), selectors)
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, evaluatedSelectors)
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, notify)
 
     if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly, evaluatedSelectors)
+        propagateToScopes(atoms, data, isInitOnly, notify)
     }
 }
 
@@ -327,7 +378,7 @@ const propagateToScopes = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly: boolean,
-    evaluatedSelectors?: EvaluatedSelectors,
+    notify?: NotifyTarget,
 ) => {
     if (atoms.length === 1) {
         // Fast path for single-atom updates (most common case)
@@ -337,7 +388,7 @@ const propagateToScopes = (
             : data.scopeValueIndex.get(atom)
         for (const [, scope] of data.scopes) {
             if (!shadowingScopes || !shadowingScopes.has(scope)) {
-                propagateInScope(atoms, scope, isInitOnly, evaluatedSelectors)
+                propagateInScope(atoms, scope, isInitOnly, notify)
             }
         }
         return
@@ -359,7 +410,7 @@ const propagateToScopes = (
 
     if (!anyShadowed) {
         for (const [, scope] of data.scopes) {
-            propagateInScope(atoms, scope, isInitOnly, evaluatedSelectors)
+            propagateInScope(atoms, scope, isInitOnly, notify)
         }
         return
     }
@@ -382,7 +433,7 @@ const propagateToScopes = (
             }
         }
         if (atomsToUpdateInScope.length > 0) {
-            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, evaluatedSelectors)
+            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, notify)
         }
     }
 }
@@ -394,7 +445,7 @@ export const propagateDirtySelectors = (
     subscriptions: Set<Subscription>,
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
     isInitOnly = false,
-    evaluatedSelectors?: EvaluatedSelectors,
+    notify?: NotifyTarget,
 ) => {
     const updatedInitializedAtoms = new Set<Atom>(updatedAtoms)
     if (selectors.size > 0) {
@@ -407,10 +458,11 @@ export const propagateDirtySelectors = (
             subscriptions,
             updatedInitializedAtoms,
             isInitOnly,
-            evaluatedSelectors,
         )
     }
-    if (subscriptions.size > 0) {
+    // When deferring (multi-pass commit), the caller owns `subscriptions` /
+    // `families` and fires them once after every pass has run.
+    if (!notify && subscriptions.size > 0) {
         callSubscribers(subscriptions, families)
     }
 }
@@ -429,9 +481,6 @@ const propagateDownstreamTopo = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
-    // The per-store set already resolved by propagateSelectorUpdates (this
-    // walk only ever touches this one store's `data`).
-    evaluatedSelectors?: Set<Selector>, // resolved per-store
 ) => {
     const closure = new Set<Selector>(seeds)
     {
@@ -521,25 +570,6 @@ const propagateDownstreamTopo = (
     while (head < ready.length) {
         const selector = ready[head++]
 
-        // Cross-scope / update+delete commit dedup: already evaluated by an
-        // earlier store-pass this commit. The earlier pass read final ATOM
-        // values (all writes precede propagation), but it may have read a stale
-        // SELECTOR dependency that only settles in a later pass — e.g. a scope
-        // selector reached via a root atom in the root pass's propagateToScopes,
-        // whose sibling scope selector is recomputed in the scope's own pass.
-        // `needsEval.has(selector)` is set only when a dependency actually
-        // CHANGED VALUE this commit (seeds, or `advance` from a changed parent);
-        // when it's set, the earlier evaluation is stale and must be recomputed.
-        // When it's clear, no dependency moved, so we just drain the edges.
-        if (
-            evaluatedSelectors !== undefined &&
-            evaluatedSelectors.has(selector) &&
-            !needsEval.has(selector)
-        ) {
-            advance(selector, false)
-            continue
-        }
-
         const currentValue = data.values.get(selector)
 
         if (isPromiseLike(currentValue) && isInitOnly) {
@@ -575,7 +605,6 @@ const propagateDownstreamTopo = (
             depsChange,
             currentValue,
         )
-        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
@@ -654,7 +683,6 @@ const propagateDownstreamTopo = (
                 depsChange,
                 currentValue,
             )
-            if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
             const added = depsChange.added as Set<State> | undefined
             const removed = depsChange.removed as Set<State> | undefined
             if ((added || removed) && isLive(selector, data)) {
@@ -709,28 +737,14 @@ const propagateSelectorUpdates = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly = false,
-    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     if (selectors.size === 0) return
-
-    // The dedup guard is keyed PER STORE: the same selector object has an
-    // independent value in the root and in each scope, so an evaluation in one
-    // store must not mask the evaluation owed to another. (Before this, a
-    // selector subscribed in both the root and a scope was evaluated in the
-    // root pass, marked done, and the scope's copy was skipped — left stale.)
-    const evaluated = evaluatedSetFor(evaluatedSelectors, data)
 
     let downstreamSeeds: Set<Selector> | undefined
 
     // Reused across every re-evaluated selector — see propagateDownstreamTopo.
     const depsChange: DepsChange = {}
     for (const selector of selectors) {
-        // Cross-scope commit dedup: an earlier pass over THIS store already
-        // evaluated this selector with final values, fired its subscribers, and
-        // walked its downstream. Skip it entirely.
-        if (evaluated !== undefined && evaluated.has(selector)) {
-            continue
-        }
         const currentValue = data.values.get(selector)
         if (isPromiseLike(currentValue) && isInitOnly) continue
         const dependents = data.stateDependents.get(selector)
@@ -753,7 +767,6 @@ const propagateSelectorUpdates = (
             depsChange,
             currentValue,
         )
-        if (evaluated !== undefined) evaluated.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
@@ -789,7 +802,6 @@ const propagateSelectorUpdates = (
             collectedSubscribers,
             updatedInitializedAtoms,
             isInitOnly,
-            evaluated,
         )
     }
 }

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -39,6 +39,30 @@ export {
 
 type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 
+// Per-commit selector dedup guard, keyed PER STORE. A single cross-scope (or
+// update+delete) commit propagates once per store; the same selector object
+// can be reached more than once within one store (an ancestor's
+// propagateToScopes plus that store's own pass), and we want to evaluate it
+// only once there. But the SAME selector object also lives — with a different
+// value — in the root and in every scope, so the guard must NOT be shared
+// across stores. Keying by StoreData keeps the intra-store dedup while letting
+// each store evaluate its own copy. Left undefined on the single-store /
+// non-scoped hot path, so that path allocates nothing and is unchanged.
+export type EvaluatedSelectors = Map<StoreData, Set<Selector>>
+
+const evaluatedSetFor = (
+    evaluatedSelectors: EvaluatedSelectors | undefined,
+    data: StoreData,
+): Set<Selector> | undefined => {
+    if (evaluatedSelectors === undefined) return undefined
+    let set = evaluatedSelectors.get(data)
+    if (set === undefined) {
+        set = new Set<Selector>()
+        evaluatedSelectors.set(data, set)
+    }
+    return set
+}
+
 const reEvaluateSelector = (
     selector: Selector,
     data: StoreData,
@@ -137,7 +161,7 @@ export const propagateDeletedAtoms = (
     subscriptions: Set<Subscription> = new Set(),
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>> = new Map(),
     timestamp = performance.now(),
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     const selectors = new Set<Selector>()
     for (const atom of atoms) {
@@ -191,18 +215,20 @@ export const propagateDeletedAtoms = (
 // Top-level entry: notify direct atom subscribers, walk dependent selectors,
 // then cross-propagate into scopes.
 //
-// `evaluatedSelectors` (cross-scope commit only): a per-commit guard set. A
-// selector lives in one store but can be reached twice in a single cross-scope
+// `evaluatedSelectors` (cross-scope / update+delete commit only): a per-commit
+// guard set. A selector lives in one store but can be reached twice in a single
 // commit — once via an ancestor's propagateToScopes, once via its own store's
-// pass. Since every value is written before any propagation runs, whichever
-// pass reaches a selector first computes its final value; the guard skips the
-// redundant second evaluation. Left undefined on the single-store / non-scoped
-// hot path, so that path is unchanged.
+// pass (or via the update pass and the delete pass). Since every value is
+// written before any propagation runs, the redundant reach is skipped — UNLESS
+// a SELECTOR dependency of the already-evaluated selector changed value in the
+// later pass (the earlier evaluation then read a stale intermediate), in which
+// case it is recomputed. See the guard inside propagateDownstreamTopo. Left
+// undefined on the single-store / non-scoped hot path, so that path is unchanged.
 export const propagateAtomUpdate = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     // Fast path: single non-family atom with no dependent selectors and no
     // scopes can skip the full graph walk entirely and just notify subscribers.
@@ -280,7 +306,7 @@ export const propagateInScope = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly = false,
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     const subscriptions = new Set<Subscription>()
     const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
@@ -301,7 +327,7 @@ const propagateToScopes = (
     atoms: AtomInput[],
     data: StoreData,
     isInitOnly: boolean,
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     if (atoms.length === 1) {
         // Fast path for single-atom updates (most common case)
@@ -368,7 +394,7 @@ export const propagateDirtySelectors = (
     subscriptions: Set<Subscription>,
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
     isInitOnly = false,
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     const updatedInitializedAtoms = new Set<Atom>(updatedAtoms)
     if (selectors.size > 0) {
@@ -403,7 +429,9 @@ const propagateDownstreamTopo = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
-    evaluatedSelectors?: Set<Selector>,
+    // The per-store set already resolved by propagateSelectorUpdates (this
+    // walk only ever touches this one store's `data`).
+    evaluatedSelectors?: Set<Selector>, // resolved per-store
 ) => {
     const closure = new Set<Selector>(seeds)
     {
@@ -493,10 +521,21 @@ const propagateDownstreamTopo = (
     while (head < ready.length) {
         const selector = ready[head++]
 
-        // Cross-scope commit dedup: already evaluated (with final values) by an
-        // earlier store-pass this commit. Its value won't change here, so drain
-        // its pending edges without re-evaluating or re-propagating change.
-        if (evaluatedSelectors !== undefined && evaluatedSelectors.has(selector)) {
+        // Cross-scope / update+delete commit dedup: already evaluated by an
+        // earlier store-pass this commit. The earlier pass read final ATOM
+        // values (all writes precede propagation), but it may have read a stale
+        // SELECTOR dependency that only settles in a later pass — e.g. a scope
+        // selector reached via a root atom in the root pass's propagateToScopes,
+        // whose sibling scope selector is recomputed in the scope's own pass.
+        // `needsEval.has(selector)` is set only when a dependency actually
+        // CHANGED VALUE this commit (seeds, or `advance` from a changed parent);
+        // when it's set, the earlier evaluation is stale and must be recomputed.
+        // When it's clear, no dependency moved, so we just drain the edges.
+        if (
+            evaluatedSelectors !== undefined &&
+            evaluatedSelectors.has(selector) &&
+            !needsEval.has(selector)
+        ) {
             advance(selector, false)
             continue
         }
@@ -670,19 +709,26 @@ const propagateSelectorUpdates = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly = false,
-    evaluatedSelectors?: Set<Selector>,
+    evaluatedSelectors?: EvaluatedSelectors,
 ) => {
     if (selectors.size === 0) return
+
+    // The dedup guard is keyed PER STORE: the same selector object has an
+    // independent value in the root and in each scope, so an evaluation in one
+    // store must not mask the evaluation owed to another. (Before this, a
+    // selector subscribed in both the root and a scope was evaluated in the
+    // root pass, marked done, and the scope's copy was skipped — left stale.)
+    const evaluated = evaluatedSetFor(evaluatedSelectors, data)
 
     let downstreamSeeds: Set<Selector> | undefined
 
     // Reused across every re-evaluated selector — see propagateDownstreamTopo.
     const depsChange: DepsChange = {}
     for (const selector of selectors) {
-        // Cross-scope commit dedup: an earlier store-pass this commit already
+        // Cross-scope commit dedup: an earlier pass over THIS store already
         // evaluated this selector with final values, fired its subscribers, and
         // walked its downstream. Skip it entirely.
-        if (evaluatedSelectors !== undefined && evaluatedSelectors.has(selector)) {
+        if (evaluated !== undefined && evaluated.has(selector)) {
             continue
         }
         const currentValue = data.values.get(selector)
@@ -707,7 +753,7 @@ const propagateSelectorUpdates = (
             depsChange,
             currentValue,
         )
-        if (evaluatedSelectors !== undefined) evaluatedSelectors.add(selector)
+        if (evaluated !== undefined) evaluated.add(selector)
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
@@ -743,7 +789,7 @@ const propagateSelectorUpdates = (
             collectedSubscribers,
             updatedInitializedAtoms,
             isInitOnly,
-            evaluatedSelectors,
+            evaluated,
         )
     }
 }

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -145,6 +145,28 @@ export const notifyDeferred = (notify: NotifyTarget) => {
     }
 }
 
+// Record a pass's changed family members into the deferred notify target, so
+// callSubscribers can resolve family-atom subscriptions once at commit end.
+// This is the NOTIFICATION side only. The per-pass map handed in here is the
+// SAME data a pass uses to drive index bookkeeping (add/deleteFamilyAtomsFromSet)
+// — but those two roles must NOT share one mutable map across passes: the
+// bookkeeping map has to contain only THIS pass's atoms (a delete pass that saw
+// an earlier pass's added atoms would delete them). So each pass keeps its
+// bookkeeping map local and merges it here for notification.
+const collectFamilyAtomsForNotify = (
+    notify: NotifyTarget,
+    changedByFamily: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
+) => {
+    for (const [family, atoms] of changedByFamily) {
+        let target = notify.families.get(family)
+        if (target === undefined) {
+            target = new Set()
+            notify.families.set(family, target)
+        }
+        for (const atom of atoms) target.add(atom)
+    }
+}
+
 const addSetToSet = (fromSet: Set<any> | undefined, toSet: Set<any>) => {
     if (fromSet && fromSet.size > 0) {
         for (const item of fromSet) {
@@ -174,16 +196,20 @@ export const propagateDeletedAtoms = (
     atoms: AtomFamilyAtom<any, any>[],
     data: StoreData,
     subscriptions: Set<Subscription> = new Set(),
-    families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>> = new Map(),
+    // Per-call ONLY (never a cross-pass accumulator): the family atoms deleted
+    // in THIS call. Drives deletion bookkeeping (deleteFamilyAtomsFromSet) and
+    // is merged into notify.families afterwards for deferred notification. See
+    // collectFamilyAtomsForNotify for why bookkeeping and notification must not
+    // share one map across passes.
+    deletedFamilyAtoms: Map<
+        AtomFamily<any>,
+        Set<AtomFamilyAtom<any>>
+    > = new Map(),
     timestamp = performance.now(),
     notify?: NotifyTarget,
 ) => {
-    // When deferring, accumulate subscribers into the commit-level notify
-    // target so the delete pass's subscribers fire once, with the update
-    // pass's. NOTE: `families` here is also the deletion-bookkeeping set
-    // (deleteFamilyAtomsFromSet), which must contain ONLY the atoms deleted in
-    // THIS call — so it stays local; we merge it into notify.families (for
-    // family-subscriber notification) only after the bookkeeping is done.
+    // When deferring, subscribers accumulate into the commit-level notify
+    // target so this pass fires once, together with the others.
     if (notify) {
         subscriptions = notify.subscriptions
     }
@@ -193,15 +219,15 @@ export const propagateDeletedAtoms = (
         addSetToSet(data.subscriptions.get(atom), subscriptions)
 
         if (isFamilyAtom(atom)) {
-            if (!families.has(atom.family)) {
-                families.set(atom.family, new Set())
+            if (!deletedFamilyAtoms.has(atom.family)) {
+                deletedFamilyAtoms.set(atom.family, new Set())
             }
             // @ts-ignore
-            families.get(atom.family).add(atom)
+            deletedFamilyAtoms.get(atom.family).add(atom)
         }
     }
-    if (families.size > 0) {
-        for (const [family, familyAtoms] of families) {
+    if (deletedFamilyAtoms.size > 0) {
+        for (const [family, familyAtoms] of deletedFamilyAtoms) {
             addSetToSet(data.stateDependents.get(family), selectors)
             addSetToSet(data.subscriptions.get(family), subscriptions)
             if (familyAtoms.size === 0)
@@ -210,28 +236,15 @@ export const propagateDeletedAtoms = (
             deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
         }
     }
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, false, notify)
-    // Deferred: merge this call's deleted family atoms into the commit-level
-    // notify target so callSubscribers can resolve family-atom subscriptions at
-    // the end (the local `families` was needed deleted-only for the bookkeeping
-    // above; firing was skipped by propagateDirtySelectors under defer).
-    if (notify && families.size > 0) {
-        for (const [family, familyAtoms] of families) {
-            let target = notify.families.get(family)
-            if (!target) {
-                target = new Set()
-                notify.families.set(family, target)
-            }
-            for (const a of familyAtoms) target.add(a)
-        }
-    }
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, deletedFamilyAtoms, false, notify)
+    if (notify) collectFamilyAtomsForNotify(notify, deletedFamilyAtoms)
     // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
     // already updated each scope's family index via recursivelyUpdateIndexes;
     // selectors in those scopes that depend on the family still need to be
     // re-evaluated so their subscribers get notified.
-    if (families.size > 0 && data.scopes && data.scopes.size > 0) {
+    if (deletedFamilyAtoms.size > 0 && data.scopes && data.scopes.size > 0) {
         const scopeFamilies = new Map<StoreData, AtomFamily<any>[]>()
-        for (const family of families.keys()) {
+        for (const family of deletedFamilyAtoms.keys()) {
             const scopesWithFamily = data.scopeValueIndex.get(family)
             if (scopesWithFamily) {
                 for (const scope of scopesWithFamily) {
@@ -284,28 +297,33 @@ export const propagateAtomUpdate = (
     }
 
     const subscriptions = notify ? notify.subscriptions : new Set<Subscription>()
-    // `families` is local: it feeds addFamilyAtomsToSet (index bookkeeping),
-    // which must see only THIS call's family atoms — not those another store's
-    // pass left in a shared map. Merged into notify.families after, for
-    // deferred family-subscriber notification.
-    const families = new Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>()
+    // Per-call ONLY (never a cross-pass accumulator): the family atoms updated
+    // in THIS call. Drives index bookkeeping (addFamilyAtomsToSet), and is
+    // merged into notify.families afterwards for deferred notification — two
+    // roles, kept in one local map because within a single pass they are the
+    // same data. See collectFamilyAtomsForNotify for why they must not share a
+    // map across passes.
+    const updatedFamilyAtoms = new Map<
+        AtomFamily<any>,
+        Set<AtomFamilyAtom<any>>
+    >()
     const selectors = new Set<Selector>()
 
     for (const atom of atoms) {
         addSetToSet(data.stateDependents.get(atom), selectors)
         addSetToSet(data.subscriptions.get(atom), subscriptions)
         if (isFamilyAtom(atom)) {
-            if (!families.has(atom.family)) {
-                families.set(atom.family, new Set())
+            if (!updatedFamilyAtoms.has(atom.family)) {
+                updatedFamilyAtoms.set(atom.family, new Set())
             }
             // @ts-ignore
-            families.get(atom.family).add(atom)
+            updatedFamilyAtoms.get(atom.family).add(atom)
         }
     }
 
-    if (families.size > 0) {
+    if (updatedFamilyAtoms.size > 0) {
         const timestamp = performance.now()
-        for (const [family, familyAtoms] of families) {
+        for (const [family, familyAtoms] of updatedFamilyAtoms) {
             addSetToSet(data.stateDependents.get(family), selectors)
             addSetToSet(data.subscriptions.get(family), subscriptions)
             if (familyAtoms.size === 0)
@@ -323,23 +341,14 @@ export const propagateAtomUpdate = (
     // addFamilyAtomsToSet, so skip families handled there.
     if (data.scopes && data.scopes.size > 0) {
         for (const atom of atoms) {
-            if (isAtomFamily(atom) && !families.has(atom)) {
+            if (isAtomFamily(atom) && !updatedFamilyAtoms.has(atom)) {
                 recursivelyUpdateIndexes(data, atom)
             }
         }
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, notify)
-    if (notify && families.size > 0) {
-        for (const [family, familyAtoms] of families) {
-            let target = notify.families.get(family)
-            if (!target) {
-                target = new Set()
-                notify.families.set(family, target)
-            }
-            for (const a of familyAtoms) target.add(a)
-        }
-    }
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, updatedFamilyAtoms, isInitOnly, notify)
+    if (notify) collectFamilyAtomsForNotify(notify, updatedFamilyAtoms)
 
     if (data.scopes && data.scopes.size > 0) {
         propagateToScopes(atoms, data, isInitOnly, notify)

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -169,11 +169,27 @@ const callSubscribers = (
 // changed family members, so a family subscription never fires for a member
 // that changed in a different store.
 export const notifyDeferred = (notify: NotifyTarget) => {
+    // Fire EVERY store's subscribers even if one throws, then rethrow the first
+    // error — the same "fire all, surface the first error" contract that
+    // callSubscribers applies within a set, extended across stores. Without the
+    // try/catch, a throwing subscriber in an earlier (root) entry would abort the
+    // loop and silently drop a later (scope) entry's notification for writes that
+    // were already committed in the same atomic transaction.
+    let firstError: unknown
+    let hasError = false
     for (const entry of notify.values()) {
         if (entry.subscriptions.size > 0) {
-            callSubscribers(entry.subscriptions, entry.families)
+            try {
+                callSubscribers(entry.subscriptions, entry.families)
+            } catch (error) {
+                if (!hasError) {
+                    firstError = error
+                    hasError = true
+                }
+            }
         }
     }
+    if (hasError) throw firstError
 }
 
 // Record a pass's changed family members into its store's notify entry, so

--- a/packages/valdres/src/lib/serializableObservation.test.ts
+++ b/packages/valdres/src/lib/serializableObservation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+// Serializable observation: a transaction is atomic, so every observation point
+// (any subscriber fire, any read from within a subscriber callback) must see
+// the fully-applied final state — never a half-settled intermediate. The
+// per-store guard fix makes the FINAL STORED values correct, but a subscriber
+// for a selector evaluated early in one pass and recomputed in a later pass
+// still fires once with the stale intermediate and once with the final value.
+// These tests pin the stronger guarantee (fire only the final value); they are
+// expected to FAIL until notification is deferred to commit-end.
+
+const mulberry32 = (seed: number) => () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+
+describe("serializable observation", () => {
+    test("cross-scope subscriber never observes a stale intermediate", () => {
+        const R = atom(1, { name: "ser-R" })
+        const A = atom(10, { name: "ser-A" })
+        const N = selector(get => get(A) * 1000, { name: "ser-N" })
+        const M = selector(get => get(R) + get(N), { name: "ser-M" })
+        const root = store()
+        const S = root.scope("S")
+        S.set(A, 10)
+        S.sub(N, () => {})
+        const observed: number[] = []
+        S.sub(M, () => observed.push(S.get(M)))
+        expect(S.get(M)).toBe(10001)
+
+        root.txn(t => {
+            t.set(R, 2)
+            t.scope("S", st => st.set(A, 20))
+        })
+
+        // Atomic: the only value ever observed is the final one.
+        expect(observed).toEqual([20002])
+    })
+
+    test("a subscriber that reads a sibling selector sees a consistent snapshot", () => {
+        // M and a sibling P both derive from the same inputs. When M's
+        // subscriber fires, reading P must give a value consistent with the M
+        // it was notified about — i.e. both reflect the same committed state.
+        const R = atom(1, { name: "ser2-R" })
+        const A = atom(10, { name: "ser2-A" })
+        const N = selector(get => get(A) * 1000, { name: "ser2-N" })
+        const M = selector(get => get(R) + get(N), { name: "ser2-M" })
+        const P = selector(get => get(N) - get(R), { name: "ser2-P" })
+        const root = store()
+        const S = root.scope("S")
+        S.set(A, 10)
+        S.sub(N, () => {})
+        S.sub(P, () => {})
+        const snapshots: Array<{ m: number; p: number }> = []
+        S.sub(M, () => snapshots.push({ m: S.get(M), p: S.get(P) }))
+        S.get(M)
+
+        root.txn(t => {
+            t.set(R, 2)
+            t.scope("S", st => st.set(A, 20))
+        })
+
+        // Every observed (M, P) pair must satisfy the invariant M + P === 2*N,
+        // i.e. both read from one committed atom-state. A stale M with a fresh P
+        // (or vice versa) breaks it.
+        for (const { m, p } of snapshots) {
+            expect(m + p).toBe(2 * S.get(N))
+        }
+    })
+
+    test("fuzz: cross-scope subscribers only ever observe final values", () => {
+        for (let seed = 1; seed <= 200; seed++) {
+            const rnd = mulberry32(seed)
+            const R = atom(1, { name: "f-R" })
+            const A = atom(1, { name: "f-A" })
+            const B = atom(1, { name: "f-B" })
+            const n1 = selector(get => get(A) * 10, { name: "f-n1" })
+            const n2 = selector(get => get(B) + get(n1), { name: "f-n2" })
+            const m = selector(get => get(R) + get(n1) + get(n2), { name: "f-m" })
+            const root = store()
+            const S = root.scope("S")
+            S.set(A, 1)
+            S.set(B, 1)
+            const fired: Record<string, number[]> = { n1: [], n2: [], m: [] }
+            S.sub(n1, () => fired.n1.push(S.get(n1)))
+            S.sub(n2, () => fired.n2.push(S.get(n2)))
+            S.sub(m, () => fired.m.push(S.get(m)))
+            // warm
+            S.get(m)
+
+            const steps = 1 + Math.floor(rnd() * 4)
+            for (let s = 0; s < steps; s++) {
+                for (const k of Object.keys(fired)) fired[k].length = 0
+                root.txn(t => {
+                    if (rnd() < 0.7) t.set(R, Math.floor(rnd() * 20))
+                    t.scope("S", st => {
+                        if (rnd() < 0.7) st.set(A, Math.floor(rnd() * 20))
+                        if (rnd() < 0.7) st.set(B, Math.floor(rnd() * 20))
+                    })
+                })
+                const finalN1 = S.get(n1)
+                const finalN2 = S.get(n2)
+                const finalM = S.get(m)
+                for (const v of fired.n1) expect(v).toBe(finalN1)
+                for (const v of fired.n2) expect(v).toBe(finalN2)
+                for (const v of fired.m) expect(v).toBe(finalM)
+            }
+        }
+    })
+})

--- a/packages/valdres/src/lib/serializableObservation.test.ts
+++ b/packages/valdres/src/lib/serializableObservation.test.ts
@@ -5,12 +5,12 @@ import { store } from "../store"
 
 // Serializable observation: a transaction is atomic, so every observation point
 // (any subscriber fire, any read from within a subscriber callback) must see
-// the fully-applied final state — never a half-settled intermediate. The
-// per-store guard fix makes the FINAL STORED values correct, but a subscriber
-// for a selector evaluated early in one pass and recomputed in a later pass
-// still fires once with the stale intermediate and once with the final value.
-// These tests pin the stronger guarantee (fire only the final value); they are
-// expected to FAIL until notification is deferred to commit-end.
+// the fully-applied final state — never a half-settled intermediate. A subscriber
+// for a (synchronous) selector reached by more than one store-pass must therefore
+// fire exactly once, with the final value — never once with a stale intermediate
+// and again with the final value. These tests pin that guarantee, which holds
+// because subscriber notification is deferred to commit-end (see NotifyTarget /
+// notifyDeferred in propagateUpdatedAtoms.ts).
 
 const mulberry32 = (seed: number) => () => {
     seed |= 0

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -844,4 +844,57 @@ describe("cross-scope transactions are atomically observable", () => {
             expect(S.get(count)).toBe(2)
         })
     })
+
+    // Regression: deferred notification must be partitioned PER STORE. A flat,
+    // store-agnostic notify map made a root family subscriber fire for members
+    // that only changed in a nested scope, and fired a scope's delegated+local
+    // family subscriptions against the merged member set (duplicated).
+    describe("cross-scope family-atom subscriptions fire per store", () => {
+        test("root sub fires only for root-changed members; scope sub once per member", () => {
+            const fam = atomFamily<{ v: number } | null, [string]>(null, {
+                name: "csfam",
+            })
+            const root = store()
+            const S = root.scope("S")
+            root.set(fam("a"), { v: 1 }) // pre-existing root member
+
+            const rootFires: string[][] = []
+            const scopeFires: string[][] = []
+            root.sub(fam, (...args: any[]) => rootFires.push(args))
+            S.sub(fam, (...args: any[]) => scopeFires.push(args))
+
+            // one cross-scope txn: root deletes "a", scope adds "b"
+            root.txn(t => {
+                t.del(fam("a"))
+                t.scope("S", st => st.set(fam("b"), { v: 2 }))
+            })
+
+            // root subscriber: only the member that changed at root (NOT the
+            // scope-only "b").
+            expect(rootFires).toEqual([["a"]])
+            // scope subscriber: "a" left its read-through view + it added "b" —
+            // each exactly once (no delegated/local duplication).
+            expect(scopeFires).toEqual([["a"], ["b"]])
+        })
+
+        test("members added in different stores don't leak across", () => {
+            const fam = atomFamily<{ v: number } | null, [string]>(null, {
+                name: "csfam2",
+            })
+            const root = store()
+            const S = root.scope("S")
+            const rootFires: string[][] = []
+            const scopeFires: string[][] = []
+            root.sub(fam, (...a: any[]) => rootFires.push(a))
+            S.sub(fam, (...a: any[]) => scopeFires.push(a))
+
+            root.txn(t => {
+                t.set(fam("c"), { v: 1 }) // root add
+                t.scope("S", st => st.set(fam("d"), { v: 2 })) // scope add
+            })
+
+            expect(rootFires).toEqual([["c"]]) // never ["d"]
+            expect(scopeFires).toEqual([["c"], ["d"]]) // sees root "c" (read-through) + own "d", once each
+        })
+    })
 })

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -561,14 +561,16 @@ describe("cross-scope transactions are atomically observable", () => {
         })
     })
 
-    describe("deduped union-propagation", () => {
-        test("a root+scope spanning selector evaluates its body once per commit", () => {
+    describe("union-propagation: serializable single notification", () => {
+        test("a root+scope spanning selector is notified once with the final value", () => {
             // The selector is reachable both via the root's propagateToScopes
-            // and via the scope's own propagation pass. The per-commit
-            // `evaluatedSelectors` guard makes it evaluate exactly once —
-            // whichever pass reaches it first computes the final value (all
-            // writes are applied before any propagation), and the other is
-            // skipped rather than recomputed-then-discarded.
+            // and via the scope's own propagation pass. With no cross-pass dedup
+            // guard it is recomputed in each reaching pass (the later pass
+            // reading the now-final inputs), but notification is deferred to the
+            // end of the commit — so the subscriber fires exactly once, with the
+            // fully-applied value. (The body running once per pass is the cost
+            // of dropping the dedup; the guarantee that matters is the single,
+            // final-valued notification.)
             const root = store()
             const S = root.scope("S")
             const r = atom(1, { name: "dd-r" })
@@ -594,14 +596,13 @@ describe("cross-scope transactions are atomically observable", () => {
             })
 
             expect(S.get(sum)).toBe(22)
-            expect(evals - before).toBe(1) // single body evaluation
-            expect(cb).toHaveBeenCalledTimes(1) // single notification
+            expect(evals - before).toBe(2) // recomputed once per reaching pass
+            expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
 
-        test("deeper spanning chain: each selector body runs once", () => {
+        test("deeper spanning chain: each selector is notified once with its final value", () => {
             // r (root) and s (scope) feed a → b. Both a and b span the two
-            // stores; both must evaluate exactly once across the commit's two
-            // store-passes.
+            // stores; each is recomputed in both passes but observed once, final.
             const root = store()
             const S = root.scope("S")
             const r = atom(1, { name: "dd2-r" })
@@ -636,16 +637,17 @@ describe("cross-scope transactions are atomically observable", () => {
 
             expect(S.get(a)).toBe(22)
             expect(S.get(b)).toBe(42)
-            expect(aEvals - aBefore).toBe(1)
-            expect(bEvals - bBefore).toBe(1)
+            // Final values are correct; bodies recompute per reaching pass.
+            expect(aEvals - aBefore).toBe(2)
+            expect(bEvals - bBefore).toBe(2)
         })
 
-        test("single-store update + delete: spanning selector body runs once", () => {
+        test("single-store update + delete: spanning selector is notified once with its final value", () => {
             // A selector depending on both an updated atom AND a deleted family
             // is reachable by the commit's update pass (propagateAtomUpdate) and
-            // its delete pass (propagateDeletedAtoms). The shared guard makes it
-            // evaluate once. (This double-eval predates the cross-scope work — it
-            // lives in the single-store fast path too.)
+            // its delete pass (propagateDeletedAtoms). It recomputes in each, but
+            // deferred notification fires its subscriber once, with the final
+            // value.
             const root = store()
             const fam = atomFamily<string>(undefined, { name: "ud-fam" })
             const m1 = fam("1")
@@ -673,8 +675,8 @@ describe("cross-scope transactions are atomically observable", () => {
             })
 
             expect(root.get(span)).toBe("1:9")
-            expect(evals - before).toBe(1)
-            expect(cb).toHaveBeenCalledTimes(1)
+            expect(evals - before).toBe(2) // recomputed in the update and delete passes
+            expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
 
         test("cross-scope: scope selector spanning a root atom + a root-deleted family runs once", () => {

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -19,9 +19,10 @@ import {
     renderAtomFamilyIndex,
 } from "./atomFamilyIndex"
 import {
+    notifyDeferred,
     propagateAtomUpdate,
     propagateDeletedAtoms,
-    type EvaluatedSelectors,
+    type NotifyTarget,
 } from "./propagateUpdatedAtoms"
 import { setAtoms } from "./setAtoms"
 import { writeAtoms, type DeferredOnSet } from "./writeAtoms"
@@ -273,22 +274,24 @@ export class Transaction {
                 // Updates and a delete in one single-store txn: a selector that
                 // depends on both an updated atom and the deleted family is
                 // reachable by the update pass (propagateAtomUpdate) and the
-                // delete pass (propagateDeletedAtoms). Share a guard so it
-                // evaluates once. (Splitting setAtoms into writeAtoms + propagate
-                // lets the same guard span both passes.)
-                const evaluatedSelectors: EvaluatedSelectors = new Map()
+                // delete pass (propagateDeletedAtoms). Defer subscriber
+                // notification across both passes so an observer never sees the
+                // update pass's value of a selector the delete pass recomputes
+                // (and vice versa). No cross-pass dedup guard: each pass
+                // re-derives its selectors against the fully-written state, so
+                // the later pass corrects any value the earlier one computed
+                // from a not-yet-final selector input. (See NotifyTarget.)
+                const notify: NotifyTarget = {
+                    subscriptions: new Set(),
+                    families: new Map(),
+                }
                 const updatedAtoms = writeAtoms(
                     this._atomMap,
                     this.data,
                     initializedAtomsSet,
                 )
                 if (updatedAtoms.length > 0) {
-                    propagateAtomUpdate(
-                        updatedAtoms,
-                        this.data,
-                        false,
-                        evaluatedSelectors,
-                    )
+                    propagateAtomUpdate(updatedAtoms, this.data, false, notify)
                 }
                 deleteAtomFamilyAtoms(this._deleteSet, this.data)
                 propagateDeletedAtoms(
@@ -297,8 +300,9 @@ export class Transaction {
                     undefined,
                     undefined,
                     undefined,
-                    evaluatedSelectors,
+                    notify,
                 )
+                notifyDeferred(notify)
             } else {
                 setAtoms(this._atomMap, this.data, initializedAtomsSet)
             }
@@ -354,26 +358,28 @@ export class Transaction {
         }
 
         // One propagation pass per store, root-first (ancestors before
-        // descendants). Order matters for correctness with the dedup guard: an
-        // ancestor's pass cross-propagates its atom changes into descendant
-        // scopes (propagateToScopes), so a scope selector that transitively
-        // depends on an ancestor atom is recomputed with final upstream values
-        // before the scope's own pass runs. Running leaf-first instead could
-        // evaluate such a selector against a still-stale upstream scope selector
-        // and the guard would then skip its correcting re-eval.
+        // descendants). Order matters: an ancestor's pass cross-propagates its
+        // atom changes into descendant scopes (propagateToScopes), so a scope
+        // selector that transitively depends on an ancestor atom is recomputed
+        // with final upstream values before — or again in — the scope's own pass.
         //
-        // `evaluatedSelectors` is a per-commit guard so a selector reachable by
-        // more than one store-pass (e.g. spanning an ancestor atom and a scope
-        // atom, or an updated atom and a deleted family) evaluates exactly once:
-        // whichever pass reaches it first computes its final value (all writes
-        // are already applied, and root-first guarantees upstream selectors are
-        // settled first), and later passes skip it. Without the guard the result
-        // is still correct — the equality check discards the redundant recompute
-        // — but the body would run once per reaching pass.
-        const evaluatedSelectors: EvaluatedSelectors = new Map()
+        // Defer all subscriber notification to the end of the commit. Each
+        // store's pass settles its own selectors against the fully-written
+        // state (root-first, so read-through ancestor values are final); firing
+        // only after every pass has run means every observer reads the final,
+        // consistent snapshot — never a value a later pass still corrects
+        // (serializable observation). There is deliberately NO cross-pass dedup
+        // guard: a selector reachable by two passes is simply recomputed in each
+        // (the equality check prunes the redundant result), and the deferred
+        // notification fires its subscriber exactly once. See the warning on
+        // NotifyTarget for why a dedup guard must not come back.
+        const notify: NotifyTarget = {
+            subscriptions: new Set(),
+            families: new Map(),
+        }
         for (const { data, updatedAtoms, deleted } of plan) {
             if (updatedAtoms.length > 0) {
-                propagateAtomUpdate(updatedAtoms, data, false, evaluatedSelectors)
+                propagateAtomUpdate(updatedAtoms, data, false, notify)
             }
             if (deleted) {
                 propagateDeletedAtoms(
@@ -382,10 +388,11 @@ export class Transaction {
                     undefined,
                     undefined,
                     undefined,
-                    evaluatedSelectors,
+                    notify,
                 )
             }
         }
+        notifyDeferred(notify)
     }
 
     // Depth-first pre-order: this store, then each nested scope. Produces a

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -281,10 +281,7 @@ export class Transaction {
                 // re-derives its selectors against the fully-written state, so
                 // the later pass corrects any value the earlier one computed
                 // from a not-yet-final selector input. (See NotifyTarget.)
-                const notify: NotifyTarget = {
-                    subscriptions: new Set(),
-                    families: new Map(),
-                }
+                const notify: NotifyTarget = new Map()
                 const updatedAtoms = writeAtoms(
                     this._atomMap,
                     this.data,
@@ -373,10 +370,7 @@ export class Transaction {
         // (the equality check prunes the redundant result), and the deferred
         // notification fires its subscriber exactly once. See the warning on
         // NotifyTarget for why a dedup guard must not come back.
-        const notify: NotifyTarget = {
-            subscriptions: new Set(),
-            families: new Map(),
-        }
+        const notify: NotifyTarget = new Map()
         for (const { data, updatedAtoms, deleted } of plan) {
             if (updatedAtoms.length > 0) {
                 propagateAtomUpdate(updatedAtoms, data, false, notify)

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -2,7 +2,6 @@ import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { GetValue } from "../types/GetValue"
-import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
@@ -22,6 +21,7 @@ import {
 import {
     propagateAtomUpdate,
     propagateDeletedAtoms,
+    type EvaluatedSelectors,
 } from "./propagateUpdatedAtoms"
 import { setAtoms } from "./setAtoms"
 import { writeAtoms, type DeferredOnSet } from "./writeAtoms"
@@ -276,7 +276,7 @@ export class Transaction {
                 // delete pass (propagateDeletedAtoms). Share a guard so it
                 // evaluates once. (Splitting setAtoms into writeAtoms + propagate
                 // lets the same guard span both passes.)
-                const evaluatedSelectors = new Set<Selector>()
+                const evaluatedSelectors: EvaluatedSelectors = new Map()
                 const updatedAtoms = writeAtoms(
                     this._atomMap,
                     this.data,
@@ -370,7 +370,7 @@ export class Transaction {
         // settled first), and later passes skip it. Without the guard the result
         // is still correct — the equality check discards the redundant recompute
         // — but the body would run once per reaching pass.
-        const evaluatedSelectors = new Set<Selector>()
+        const evaluatedSelectors: EvaluatedSelectors = new Map()
         for (const { data, updatedAtoms, deleted } of plan) {
             if (updatedAtoms.length > 0) {
                 propagateAtomUpdate(updatedAtoms, data, false, evaluatedSelectors)

--- a/packages/valdres/src/utils/isAtom.ts
+++ b/packages/valdres/src/utils/isAtom.ts
@@ -1,4 +1,4 @@
 import type { Atom } from "../types/Atom"
 
 export const isAtom = <V>(state: any): state is Atom<V> =>
-    Object.hasOwn(state, "defaultValue")
+    state && Object.hasOwn(state, "defaultValue")

--- a/packages/valdres/src/utils/isGlobalAtom.ts
+++ b/packages/valdres/src/utils/isGlobalAtom.ts
@@ -1,4 +1,4 @@
 import type { GlobalAtom } from "../types/GlobalAtom"
 
 export const isGlobalAtom = <V>(state: any): state is GlobalAtom<V> =>
-    Object.hasOwn(state, "stores")
+    state && Object.hasOwn(state, "stores")


### PR DESCRIPTION
## Summary

Fixes two beta.4/beta.5 propagation regressions reported from a scoped app, and replaces the fragile cross-pass dedup guard with a model that's correct *and* serializable to observe.

### Symptom B — stale position / stale connector lines
After a cross-scope transaction (e.g. drag a node and drop it back outside any dropzone — a pure revert), a selector and its whole subtree were left stale (the subtree "settled one row too low"). Root cause: the per-commit `evaluatedSelectors` dedup guard added in beta.5 (#168)
- was keyed by selector **object**, so it skipped a scope's copy of a selector that was also live in the root (same object, different value per store); and
- locked in a value an early pass computed from an **intermediate selector** that a later pass corrected.

### Symptom C — `index()` crash on publish
`SelectorEvaluationError: Cannot convert undefined or null to object` inside `index:…:termSelector`. `index()` kept **mutable closure state** (`termIndexSelectorSet` / `termIndexSelectorMap`) captured once but mutated by `termIndexSelector` evaluating in *both* the root and a scope with divergent family membership (publish moves members scope→root) — the two stores clobbered the shared map and the filtered selector iterated a member whose predicate entry the other store had deleted. Reproduced deterministically (scopes + family churn, no txn needed).

## Approach

- **Removed the cross-pass dedup guard entirely.** Multi-pass commits (cross-scope, and single-store update+delete) now: write every value first → each store re-derives its **own** selectors against that final state (a selector reachable by two passes is recomputed in each; the equality check prunes the redundant result) → **defer all subscriber notification to commit end**, firing each subscriber once. A transaction is now *serializable to observe*: no subscriber, and nothing a subscriber reads, ever sees a half-applied intermediate. A prominent comment on `NotifyTarget` documents why a dedup guard must not return.
- **`index()` rewritten** to derive membership from `get(family)` on every evaluation (correct per store) with a grow-only, store-agnostic predicate-selector cache — no shared mutable membership to desync.
- **Defensive:** `isAtom` / `isGlobalAtom` gained the `state &&` null-guard the other `is*` helpers already have, so a stale read degrades gracefully instead of throwing.

## Trade-off
A selector reachable by N passes now runs its body N times in cross-scope / update+delete commits (the dropped optimization). This path is **not** on any benchmark; the single-store / non-scoped hot path is untouched. If it ever matters, dedup can return as a pure optimization *behind* the serializable guarantee (per `(store, selector)`, value-identical skips only) — see the `NotifyTarget` note.

## Tests
- New `crossScopeStaleSelector.test.ts` (deterministic + independent-oracle fuzz) and `serializableObservation.test.ts` (fire-once / consistent-snapshot).
- New `indexConstructor.multiStore.test.ts` (divergent root/scope membership, publish-style move, no-crash churn fuzz).
- The #168 "evaluates once" tests are restated to assert the guarantee (notified once, final value).
- Full valdres suite green (383 tests); full monorepo green via `bun --filter '*' test` (937 tests). Changeset included.

## Not in scope (deliberate)
A deeper refactor to make propagation *never* mutate the family index (pure derive+notify) was investigated and **deferred** — it's entangled with the scope-index re-link and the gated write path, and the footgun it would remove is already neutralized here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)