### PR TITLE
test(valdres): stabilize flaky maxAge/SWR tests with a deterministic fake clock

### DIFF
--- a/.changeset/stabilize-maxage-tests-fake-clock.md
+++ b/.changeset/stabilize-maxage-tests-fake-clock.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only: stabilize the flaky maxAge / staleWhileRevalidate / staleIfError
+tests by replacing real wall-clock waits (`setInterval` + `await wait(N)`) with
+a deterministic fake clock (`jest.useFakeTimers()`, which also fakes
+`Date.now()`). Adds `test/utils/fakeClock.ts` (`useFakeClock` / `withFakeClock`
+/ `mockAsyncSource`) and migrates the timing tests in `atom.test.ts` and
+`cacheMeta.test.ts`. No library code changes — no release.

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -2,22 +2,7 @@ import { describe, test, expect, mock, spyOn } from "bun:test"
 import { atom } from "./atom"
 import { selector } from "./selector"
 import { store } from "./store"
-import { wait } from "../test/utils/wait"
-
-const waitFor = async (callback: () => void, timeoutMs = 2000) => {
-    const deadline = Date.now() + timeoutMs
-    let lastError: unknown
-    while (true) {
-        try {
-            callback()
-            return
-        } catch (e) {
-            lastError = e
-            if (Date.now() >= deadline) throw lastError
-            await wait(5)
-        }
-    }
-}
+import { withFakeClock, mockAsyncSource } from "../test/utils/fakeClock"
 
 describe("atom", () => {
     test("is good", () => {
@@ -311,189 +296,165 @@ describe("atom", () => {
         expect(store1.get(atom2)).toBe(3)
     })
 
-    test("atom with maxAge", async () => {
-        const setIntervalSpy = spyOn(global, "setInterval")
-        const clearIntervalSpy = spyOn(global, "clearInterval")
-        const store1 = store()
-        const atom1 = atom(() => Date.now(), { maxAge: 2 })
-        const res: any[] = []
-        expect(setIntervalSpy).toHaveBeenCalledTimes(0)
-        expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
-
-        const callback = mock(() => {
-            res.push(store1.get(atom1))
-        })
-        const unsubscribe = store1.sub(atom1, callback)
-        expect(setIntervalSpy).toHaveBeenCalledTimes(1)
-        expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
-        await wait(2)
-        expect(callback).toHaveBeenCalledTimes(1)
-        expect(res).toHaveLength(1)
-        await wait(2)
-        expect(callback).toHaveBeenCalledTimes(2)
-        expect(res).toHaveLength(2)
-        unsubscribe()
-        expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
-        await wait(4)
-        expect(callback).toHaveBeenCalledTimes(2)
-        expect(res).toHaveLength(2)
-        setIntervalSpy.mockRestore()
-        clearIntervalSpy.mockRestore()
-    })
-
-    test("atom with maxAge async rejection does not cause unhandled rejection", async () => {
-        const store1 = store()
-        let callCount = 0
-        const atomCallback = () => {
-            callCount++
-            if (callCount > 1) {
-                return new Promise((_, reject) =>
-                    setTimeout(() => reject(new Error("fetch failed")), 1),
-                )
-            }
-            return new Promise(resolve =>
-                setTimeout(() => resolve(callCount), 1),
-            )
-        }
-
-        const atom1 = atom(atomCallback, {
-            maxAge: 10,
-            staleWhileRevalidate: 100,
-        })
-
-        const callback = mock(() => {
-            store1.get(atom1)
-        })
-        const unsubscribe = store1.sub(atom1, callback)
-        await waitFor(() => expect(store1.get(atom1)).toBe(1))
-        // Wait for the interval to fire with a rejection
-        await wait(50)
-        expect(callCount).toBeGreaterThanOrEqual(2)
-        // Cleanup should work without errors
-        unsubscribe()
-    })
-
-    test("atom with maxAge async and staleWhileRevalidate: 0 shows promise during revalidation", async () => {
-        const store1 = store()
-        const maxAge = 50
-        let fetchCount = 0
-        const resolvers: Array<(v: number) => void> = []
-        const atomCallback = () => {
-            fetchCount++
-            return new Promise<number>(resolve => {
-                resolvers.push(resolve)
-            })
-        }
-        const atom1 = atom(atomCallback, { maxAge, staleWhileRevalidate: 0 })
-
-        // Capture every value the store transitions through. Asserting against
-        // store1.get() directly is racy: the maxAge interval keeps firing, so a
-        // resolved value can be replaced by a fresh pending promise before the
-        // assertion runs (a subsequent tick would never resolve, and the test
-        // would time out).
-        const observed: any[] = []
-        const callback = mock(() => {
-            observed.push(store1.get(atom1))
-        })
-        const unsubscribe = store1.sub(atom1, callback)
-
-        // Initially holds a pending promise
-        expect(store1.get(atom1)).toBeInstanceOf(Promise)
-
-        resolvers[0](100)
-        await waitFor(() => expect(observed).toContain(100))
-
-        // The next maxAge tick should trigger a fresh fetch.
-        await waitFor(() => expect(fetchCount).toBe(2))
-
-        // With staleWhileRevalidate: 0, that fresh fetch publishes a pending
-        // promise as the loading state. We verify by checking that *some*
-        // value observed after 100 was a Promise (rather than reading
-        // store1.get() right now, which races with later ticks).
-        const indexOf100 = observed.indexOf(100)
-        const promiseAfter100 = observed
-            .slice(indexOf100 + 1)
-            .find(v => v instanceof Promise)
-        expect(promiseAfter100).toBeInstanceOf(Promise)
-
-        // Resolve revalidation. Use observed (not store1.get()) because a
-        // later tick may replace 200 with a new pending promise.
-        resolvers[1](200)
-        await waitFor(() => expect(observed).toContain(200))
-
-        unsubscribe()
-    })
-
-    test("atom with maxAge async and staleWhileRevalidate", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<(v: number) => void> = []
-        const atomCallback = () => {
-            fetchCount++
-            return new Promise<number>(resolve => {
-                resolvers.push(resolve)
-            })
-        }
-
-        const atom1 = atom(atomCallback, {
-            maxAge: 30,
-            staleWhileRevalidate: 200,
-        })
-
-        const res: any[] = []
-        const callback = mock(() => {
-            res.push(store1.get(atom1))
-        })
-
-        // Subscribe — triggers initial fetch
-        const unsubscribe = store1.sub(atom1, callback)
-        expect(fetchCount).toBe(1)
-
-        // Initially the store holds the pending promise
-        expect(store1.get(atom1)).toBeInstanceOf(Promise)
-
-        // Resolve the initial fetch
-        resolvers[0](100)
-        await wait(1)
-
-        // Subscriber notified with resolved value
-        expect(store1.get(atom1)).toBe(100)
-        expect(res).toContain(100)
-
-        // Wait for maxAge to expire and trigger revalidation
-        await wait(50)
-        expect(fetchCount).toBe(2)
-
-        // While revalidation is in-flight, store still returns
-        // the stale value (not a promise) — this is the key
-        // stale-while-revalidate behavior
-        expect(store1.get(atom1)).toBe(100)
-
-        // Resolve the revalidation
-        resolvers[1](200)
-        await wait(1)
-
-        // Value updated, subscriber notified
-        expect(store1.get(atom1)).toBe(200)
-        expect(res).toContain(200)
-
-        unsubscribe()
-    })
-
-    test(
-        "staleWhileRevalidate window expiration flips to pending promise",
-        async () => {
+    test("atom with maxAge", () =>
+        withFakeClock(async clock => {
+            const setIntervalSpy = spyOn(global, "setInterval")
+            const clearIntervalSpy = spyOn(global, "clearInterval")
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<(v: number) => void> = []
+            const atom1 = atom(() => Date.now(), { maxAge: 2 })
+            const res: any[] = []
+            expect(setIntervalSpy).toHaveBeenCalledTimes(0)
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
+
+            const callback = mock(() => {
+                res.push(store1.get(atom1))
+            })
+            const unsubscribe = store1.sub(atom1, callback)
+            expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
+            await clock.advance(2) // one maxAge tick
+            expect(callback).toHaveBeenCalledTimes(1)
+            expect(res).toHaveLength(1)
+            await clock.advance(2) // second tick
+            expect(callback).toHaveBeenCalledTimes(2)
+            expect(res).toHaveLength(2)
+            unsubscribe()
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+            await clock.advance(4) // interval cleared → no more ticks
+            expect(callback).toHaveBeenCalledTimes(2)
+            expect(res).toHaveLength(2)
+            setIntervalSpy.mockRestore()
+            clearIntervalSpy.mockRestore()
+        }))
+
+    test("atom with maxAge async rejection does not cause unhandled rejection", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let callCount = 0
             const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>(resolve => {
-                    resolvers.push(resolve)
-                })
+                callCount++
+                if (callCount > 1) {
+                    return new Promise((_, reject) =>
+                        setTimeout(() => reject(new Error("fetch failed")), 1),
+                    )
+                }
+                return new Promise(resolve =>
+                    setTimeout(() => resolve(callCount), 1),
+                )
             }
 
             const atom1 = atom(atomCallback, {
+                maxAge: 10,
+                staleWhileRevalidate: 100,
+            })
+
+            const callback = mock(() => {
+                store1.get(atom1)
+            })
+            const unsubscribe = store1.sub(atom1, callback)
+            await clock.advance(1) // initial fetch resolves
+            expect(store1.get(atom1)).toBe(1)
+            // Let the interval fire and revalidate with a rejection
+            await clock.advance(50)
+            expect(callCount).toBeGreaterThanOrEqual(2)
+            // Cleanup should work without errors
+            unsubscribe()
+        }))
+
+    test("atom with maxAge async and staleWhileRevalidate: 0 shows promise during revalidation", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const maxAge = 50
+            const source = mockAsyncSource<number>()
+            const atom1 = atom(source.fn, { maxAge, staleWhileRevalidate: 0 })
+
+            // Capture every value the store transitions through via the
+            // subscription so we can prove the swr=0 loading state appeared.
+            const observed: any[] = []
+            const callback = mock(() => {
+                observed.push(store1.get(atom1))
+            })
+            const unsubscribe = store1.sub(atom1, callback)
+
+            // Initially holds a pending promise
+            expect(store1.get(atom1)).toBeInstanceOf(Promise)
+
+            await source.resolve(100) // settle the initial fetch
+            expect(observed).toContain(100)
+
+            // The next maxAge tick triggers a fresh fetch.
+            await clock.advance(maxAge)
+            expect(source.callCount).toBe(2)
+
+            // With staleWhileRevalidate: 0, that fresh fetch publishes a
+            // pending promise as the loading state.
+            const indexOf100 = observed.indexOf(100)
+            const promiseAfter100 = observed
+                .slice(indexOf100 + 1)
+                .find(v => v instanceof Promise)
+            expect(promiseAfter100).toBeInstanceOf(Promise)
+
+            // Resolve revalidation.
+            await source.resolve(200)
+            expect(observed).toContain(200)
+
+            unsubscribe()
+        }))
+
+    test("atom with maxAge async and staleWhileRevalidate", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+
+            const atom1 = atom(source.fn, {
+                maxAge: 30,
+                staleWhileRevalidate: 200,
+            })
+
+            const res: any[] = []
+            const callback = mock(() => {
+                res.push(store1.get(atom1))
+            })
+
+            // Subscribe — triggers initial fetch
+            const unsubscribe = store1.sub(atom1, callback)
+            expect(source.callCount).toBe(1)
+
+            // Initially the store holds the pending promise
+            expect(store1.get(atom1)).toBeInstanceOf(Promise)
+
+            // Resolve the initial fetch
+            await source.resolve(100)
+
+            // Subscriber notified with resolved value
+            expect(store1.get(atom1)).toBe(100)
+            expect(res).toContain(100)
+
+            // Wait for maxAge to expire and trigger revalidation
+            await clock.advance(50)
+            expect(source.callCount).toBe(2)
+
+            // While revalidation is in-flight, store still returns
+            // the stale value (not a promise) — this is the key
+            // stale-while-revalidate behavior
+            expect(store1.get(atom1)).toBe(100)
+
+            // Resolve the revalidation
+            await source.resolve(200)
+
+            // Value updated, subscriber notified
+            expect(store1.get(atom1)).toBe(200)
+            expect(res).toContain(200)
+
+            unsubscribe()
+        }))
+
+    test("staleWhileRevalidate window expiration flips to pending promise", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 50,
             })
@@ -502,44 +463,35 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0](100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait for revalidation to start (do NOT resolve)
-            await waitFor(() => expect(fetchCount).toBe(2))
+            // Advance to the revalidation tick (do NOT resolve)
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
             // Within SWR window — stale value still visible
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait past the SWR window (50ms) with revalidation still in flight
-            await wait(80)
+            // Advance past the SWR window (50ms) with revalidation still in flight
+            await clock.advance(80)
 
             // SWR window expired — store should flip to the pending promise
             expect(store1.get(atom1)).toBeInstanceOf(Promise)
 
             // Resolving the in-flight request still updates the value
-            resolvers[1](200)
-            await waitFor(() => expect(store1.get(atom1)).toBe(200))
+            await source.resolve(200)
+            expect(store1.get(atom1)).toBe(200)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "staleWhileRevalidate timeout is cleared on revalidation resolve",
-        async () => {
+    test("staleWhileRevalidate timeout is cleared on revalidation resolve", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<(v: number) => void> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>(resolve => {
-                    resolvers.push(resolve)
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 200,
             })
@@ -568,140 +520,92 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0](1)
-            await wait(1)
+            await source.resolve(1)
 
-            // Wait for revalidation tick
-            await waitFor(() => expect(fetchCount).toBe(2))
+            // Advance to the revalidation tick
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
             // A staleWhileRevalidate timeout was created
             expect(staleTimeoutIds.length).toBe(1)
 
             // Resolve the revalidation — should clear the timeout
-            resolvers[1](2)
-            await wait(1)
+            await source.resolve(2)
             expect(clearedIds.has(staleTimeoutIds[0])).toBe(true)
 
             unsubscribe()
 
             setTimeoutSpy.mockRestore()
             clearTimeoutSpy.mockRestore()
-        },
-    )
+        }))
 
-    test(
-        "maxAge interval should skip tick while revalidation is in-flight",
-        async () => {
-            // If revalidation takes longer than maxAge, the interval should
-            // NOT start another revalidation. This prevents unbounded
-            // accumulation of in-flight promises and matches HTTP cache
-            // semantics (don't re-fetch while already revalidating).
+    test("maxAge interval should skip tick while revalidation is in-flight", () =>
+        withFakeClock(async clock => {
+            // If revalidation takes longer than maxAge, the interval must NOT
+            // start another revalidation — no unbounded accumulation of
+            // in-flight promises, matching HTTP cache semantics (don't re-fetch
+            // while already revalidating).
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<(v: number) => void> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>(resolve => {
-                    resolvers.push(resolve)
-                })
-            }
+            const source = mockAsyncSource<number>()
+            const atom1 = atom(source.fn, { maxAge: 15, staleWhileRevalidate: 200 })
 
-            // maxAge is 15ms — interval fires frequently
-            const atom1 = atom(atomCallback, {
-                maxAge: 15,
+            const unsubscribe = store1.sub(atom1, () => {})
+
+            await source.resolve(1) // settle the initial fetch
+            expect(source.callCount).toBe(1)
+
+            await clock.advance(60) // four 15ms ticks fire...
+            expect(source.callCount).toBe(2) // ...but only one revalidation starts
+
+            await source.resolve(2) // settle the in-flight revalidation
+            expect(store1.get(atom1)).toBe(2)
+
+            await clock.advance(20) // revalidation done → next tick may fetch
+            expect(source.callCount).toBe(3)
+
+            unsubscribe()
+        }))
+
+    test("staleIfError keeps stale value on revalidation rejection", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
                 staleWhileRevalidate: 200,
+                // Wide enough that the rejection lands within the window; the
+                // value being tested is the within-window restore-stale
+                // behavior, not the window length itself.
+                staleIfError: 60_000,
             })
 
             const callback = mock(() => {})
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0](1)
-            await wait(1)
-            expect(fetchCount).toBe(1)
+            await source.resolve(100)
+            expect(store1.get(atom1)).toBe(100)
 
-            // Wait long enough for multiple ticks to fire (3-4x maxAge)
-            // but DON'T resolve the revalidation promise
-            await wait(60)
+            // Advance to the revalidation tick
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
-            // Only one revalidation should have started, even though
-            // multiple interval ticks fired
-            expect(fetchCount).toBe(2)
+            // Reject the revalidation
+            await source.reject(new Error("network error"))
 
-            // Resolve the pending revalidation
-            resolvers[1](2)
-            await wait(1)
-            expect(store1.get(atom1)).toBe(2)
-
-            // Now the next tick should be allowed to start a new revalidation
-            await wait(20)
-            expect(fetchCount).toBe(3)
+            // With staleIfError, the stale value should be preserved
+            expect(store1.get(atom1)).toBe(100)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test("staleIfError keeps stale value on revalidation rejection", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{
-            resolve: (v: number) => void
-            reject: (e: Error) => void
-        }> = []
-        const atomCallback = () => {
-            fetchCount++
-            return new Promise<number>((resolve, reject) => {
-                resolvers.push({ resolve, reject })
-            })
-        }
-
-        const atom1 = atom(atomCallback, {
-            maxAge: 20,
-            staleWhileRevalidate: 200,
-            // Wide enough that this test stays within the window even on a
-            // slow CI runner; the value being tested is the within-window
-            // restore-stale behavior, not the window length itself.
-            staleIfError: 60_000,
-        })
-
-        const callback = mock(() => {})
-        const unsubscribe = store1.sub(atom1, callback)
-
-        // Resolve initial fetch
-        resolvers[0].resolve(100)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(100)
-
-        // Wait for revalidation
-        await waitFor(() => expect(fetchCount).toBe(2))
-
-        // Reject the revalidation
-        resolvers[1].reject(new Error("network error"))
-        await wait(1)
-
-        // With staleIfError, the stale value should be preserved
-        expect(store1.get(atom1)).toBe(100)
-
-        unsubscribe()
-    })
-
-    test(
-        "staleIfError window expiration stops serving stale on error",
-        async () => {
+    test("staleIfError window expiration stops serving stale on error", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleIfError: 30,
             })
@@ -710,19 +614,17 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait long enough for maxAge + staleIfError to expire
-            await wait(60)
-            expect(fetchCount).toBeGreaterThanOrEqual(2)
+            // Advance long enough for maxAge + staleIfError to expire
+            await clock.advance(60)
+            expect(source.callCount).toBeGreaterThanOrEqual(2)
 
             // Reject all pending revalidations
-            for (let i = 1; i < resolvers.length; i++) {
-                resolvers[i].reject(new Error("network error"))
+            for (let i = 1; i < source.callCount; i++) {
+                await source.reject(new Error("network error"), i)
             }
-            await wait(1)
 
             // staleIfError window has passed — the rejected promise should
             // remain in the store (not the stale value, not deleted)
@@ -731,26 +633,14 @@ describe("atom", () => {
             expect(val).toBeInstanceOf(Promise)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "SWR revalidation rejection keeps stale value visible",
-        async () => {
+    test("SWR revalidation rejection keeps stale value visible", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 200,
             })
@@ -759,42 +649,29 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait for revalidation
-            await waitFor(() => expect(fetchCount).toBe(2))
+            // Advance to the revalidation tick
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
             // Reject the revalidation
-            resolvers[1].reject(new Error("network error"))
-            await wait(1)
+            await source.reject(new Error("network error"))
 
             // With SWR (no staleIfError), the stale value should still
             // be preserved — rejection shouldn't delete it
             expect(store1.get(atom1)).toBe(100)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "SWR + staleIfError: rejection past window shows error",
-        async () => {
+    test("SWR + staleIfError: rejection past window shows error", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 200,
                 staleIfError: 30,
@@ -804,84 +681,60 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait past maxAge + staleIfError (20 + 30 = 50ms)
-            await wait(60)
-            expect(fetchCount).toBeGreaterThanOrEqual(2)
+            // Advance past maxAge + staleIfError (20 + 30 = 50ms)
+            await clock.advance(60)
+            expect(source.callCount).toBeGreaterThanOrEqual(2)
 
             // Reject all pending revalidations
-            for (let i = 1; i < resolvers.length; i++) {
-                resolvers[i].reject(new Error("network error"))
+            for (let i = 1; i < source.callCount; i++) {
+                await source.reject(new Error("network error"), i)
             }
-            await wait(1)
 
             // Past staleIfError window — stale value should NOT be served
             expect(store1.get(atom1)).not.toBe(100)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test("staleIfError works when atom value is undefined", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{
-            resolve: (v: undefined) => void
-            reject: (e: Error) => void
-        }> = []
-        const atomCallback = () => {
-            fetchCount++
-            return new Promise<undefined>((resolve, reject) => {
-                resolvers.push({ resolve, reject })
-            })
-        }
-
-        const atom1 = atom(atomCallback, {
-            maxAge: 20,
-            staleIfError: 60_000,
-        })
-
-        const callback = mock(() => {})
-        const unsubscribe = store1.sub(atom1, callback)
-
-        // Resolve initial fetch with undefined
-        resolvers[0].resolve(undefined)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(undefined)
-
-        // Wait for revalidation
-        await waitFor(() => expect(fetchCount).toBe(2))
-
-        // Reject — within staleIfError window, should restore undefined
-        resolvers[1].reject(new Error("network error"))
-        await wait(1)
-
-        // The stale value (undefined) should be restored, not the rejected promise
-        expect(store1.get(atom1)).toBe(undefined)
-
-        unsubscribe()
-    })
-
-    test(
-        "staleIfError recovery: succeed → fail → succeed",
-        async () => {
+    test("staleIfError works when atom value is undefined", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<undefined>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
+                staleIfError: 60_000,
+            })
+
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            // Resolve initial fetch with undefined
+            await source.resolve(undefined)
+            expect(store1.get(atom1)).toBe(undefined)
+
+            // Advance to the revalidation tick
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
+
+            // Reject — within staleIfError window, should restore undefined
+            await source.reject(new Error("network error"))
+
+            // The stale value (undefined) should be restored, not the rejected promise
+            expect(store1.get(atom1)).toBe(undefined)
+
+            unsubscribe()
+        }))
+
+    test("staleIfError recovery: succeed → fail → succeed", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleIfError: 60_000,
             })
@@ -890,59 +743,43 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait for first revalidation, reject it
-            await waitFor(() => expect(fetchCount).toBe(2))
-            resolvers[1].reject(new Error("network error"))
-            await wait(1)
+            // Advance to the first revalidation, reject it
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
+            await source.reject(new Error("network error"))
 
             // Within staleIfError window — stale value restored
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait for next revalidation, resolve it
-            await waitFor(() => expect(fetchCount).toBe(3))
-            resolvers[2].resolve(200)
-            await wait(1)
+            // Advance to the next revalidation, resolve it
+            await clock.advance(20)
+            expect(source.callCount).toBe(3)
+            await source.resolve(200)
 
             // Value should be updated to 200
             expect(store1.get(atom1)).toBe(200)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "multiple consecutive failures with staleIfError",
-        async () => {
+    test("multiple consecutive failures with staleIfError", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            // Use generously-sized windows. The production code initializes
-            // lastSuccessTime at subscribe time and only updates it on a
-            // tick-driven revalidation success — not on the initial fetch.
-            // With a tight staleIfError (e.g. 40ms) the first rejection check
-            // races the wall clock on slow CI runners and falls outside the
-            // window, so the stale value isn't restored.
+            // The production code initializes lastSuccessTime at subscribe
+            // time and only updates it on a tick-driven revalidation success
+            // — not on the initial fetch.
             const maxAge = 50
             const staleIfError = 200
-            const atom1 = atom(atomCallback, { maxAge, staleIfError })
+            const atom1 = atom(source.fn, { maxAge, staleIfError })
 
-            // Capture every observed value via the subscription callback so
-            // assertions don't race with the next maxAge tick replacing the
-            // store value with a fresh pending promise.
+            // Capture every observed value via the subscription callback so we
+            // can assert on the sequence of values the store transitioned
+            // through across revalidations.
             const observed: any[] = []
             const callback = mock(() => {
                 observed.push(store1.get(atom1))
@@ -950,66 +787,52 @@ describe("atom", () => {
             const unsubscribe = store1.sub(atom1, callback)
 
             // Resolve initial fetch
-            resolvers[0].resolve(100)
-            await waitFor(() => expect(observed).toContain(100))
+            await source.resolve(100)
+            expect(observed).toContain(100)
 
             // First revalidation: reject (within staleIfError window)
-            await waitFor(() => expect(fetchCount).toBe(2))
-            resolvers[1].reject(new Error("fail 1"))
-            // Stale value should be restored — wait for it via the callback.
-            await waitFor(() =>
-                expect(observed[observed.length - 1]).toBe(100),
-            )
+            await clock.advance(maxAge)
+            expect(source.callCount).toBe(2)
+            await source.reject(new Error("fail 1"))
+            // Stale value should be restored.
+            expect(observed[observed.length - 1]).toBe(100)
 
             // Second revalidation: succeed (resets the window). Capture the
-            // success time so we can wait deterministically past the window.
-            await waitFor(() => expect(fetchCount).toBe(3))
-            resolvers[2].resolve(200)
-            await waitFor(() => expect(observed).toContain(200))
+            // success time so we can advance deterministically past the window.
+            await clock.advance(maxAge)
+            expect(source.callCount).toBe(3)
+            await source.resolve(200)
+            expect(observed).toContain(200)
             const lastSuccessAt = Date.now()
 
-            // Wait past maxAge + staleIfError from the last success, plus a
-            // buffer to absorb scheduler jitter.
+            // Advance past maxAge + staleIfError from the last success.
             const elapsed = Date.now() - lastSuccessAt
-            await wait(maxAge + staleIfError + 50 - elapsed)
+            await clock.advance(maxAge + staleIfError + 50 - elapsed)
 
             // A revalidation tick should have fired by now.
-            expect(fetchCount).toBeGreaterThanOrEqual(4)
+            expect(source.callCount).toBeGreaterThanOrEqual(4)
 
             // Reject all pending revalidations (past window now)
-            for (let i = 3; i < resolvers.length; i++) {
-                resolvers[i].reject(new Error("fail N"))
+            for (let i = 3; i < source.callCount; i++) {
+                await source.reject(new Error("fail N"), i)
             }
 
             // Past staleIfError window — stale value (200) should NOT be
-            // restored. Wait for the rejection microtask to settle, then
-            // verify the store is no longer holding 200.
-            await waitFor(() => expect(store1.get(atom1)).not.toBe(200))
+            // restored.
+            expect(store1.get(atom1)).not.toBe(200)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "swr finite: window expires then reject within staleIfError restores stale",
-        async () => {
+    test("swr finite: window expires then reject within staleIfError restores stale", () =>
+        withFakeClock(async clock => {
             // After the SWR timeout flips the store to the pending promise,
             // a subsequent rejection within the staleIfError window must
             // bring the stale value back — not leave the rejected promise.
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 30,
                 staleIfError: 60_000,
@@ -1018,52 +841,35 @@ describe("atom", () => {
             const callback = mock(() => {})
             const unsubscribe = store1.sub(atom1, callback)
 
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait for revalidation to start (don't resolve)
-            await waitFor(() => expect(fetchCount).toBe(2))
+            // Advance to the revalidation tick (don't resolve)
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
             // Within SWR window — stale visible
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait past SWR window (30ms) — should flip to pending promise
-            await wait(50)
+            // Advance past SWR window (30ms) — should flip to pending promise
+            await clock.advance(50)
             expect(store1.get(atom1)).toBeInstanceOf(Promise)
 
             // Reject — within staleIfError window, stale should be restored
-            resolvers[1].reject(new Error("network error"))
-            await wait(1)
+            await source.reject(new Error("network error"))
             expect(store1.get(atom1)).toBe(100)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "swr=0: reject within staleIfError window restores stale",
-        async () => {
+    test("swr=0: reject within staleIfError window restores stale", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 // swr=0 means store flips to the pending promise during
-                // revalidation. After reject, handleReject restores stale,
-                // but setAndPropagate flushes via queueMicrotask — if the
-                // next setInterval tick fires before that flush commits,
-                // it overwrites the restored value with a new pending
-                // promise that never resolves. A long maxAge keeps the
-                // next tick far away so the assertion has time to land.
+                // revalidation. After reject, handleReject restores stale.
+                // A long maxAge keeps the next tick far away.
                 maxAge: 200,
                 staleWhileRevalidate: 0,
                 staleIfError: 60_000,
@@ -1072,41 +878,27 @@ describe("atom", () => {
             const callback = mock(() => {})
             const unsubscribe = store1.sub(atom1, callback)
 
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            await waitFor(() => expect(fetchCount).toBe(2))
+            await clock.advance(200)
+            expect(source.callCount).toBe(2)
             // swr=0: pending promise is visible during revalidation
             expect(store1.get(atom1)).toBeInstanceOf(Promise)
 
-            resolvers[1].reject(new Error("network error"))
             // Within staleIfError window — stale should be restored.
-            // Poll because the catch handler propagates over a few
-            // microtask ticks; a fixed wait(1) is racy on CI.
-            await waitFor(() => expect(store1.get(atom1)).toBe(100))
+            await source.reject(new Error("network error"))
+            expect(store1.get(atom1)).toBe(100)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "swr=0: reject past staleIfError window leaves rejected promise",
-        async () => {
+    test("swr=0: reject past staleIfError window leaves rejected promise", () =>
+        withFakeClock(async clock => {
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 0,
                 staleIfError: 30,
@@ -1115,62 +907,45 @@ describe("atom", () => {
             const callback = mock(() => {})
             const unsubscribe = store1.sub(atom1, callback)
 
-            resolvers[0].resolve(100)
-            await wait(1)
+            await source.resolve(100)
             expect(store1.get(atom1)).toBe(100)
 
-            // Wait past maxAge + staleIfError (50ms)
-            await wait(60)
-            expect(fetchCount).toBeGreaterThanOrEqual(2)
+            // Advance past maxAge + staleIfError (50ms)
+            await clock.advance(60)
+            expect(source.callCount).toBeGreaterThanOrEqual(2)
 
-            for (let i = 1; i < resolvers.length; i++) {
-                resolvers[i].reject(new Error("network error"))
+            for (let i = 1; i < source.callCount; i++) {
+                await source.reject(new Error("network error"), i)
             }
 
             // Past staleIfError window — stale value should NOT be served.
-            // Poll so the catch handler has time to settle.
-            let val: unknown
-            await waitFor(() => {
-                val = store1.get(atom1)
-                expect(val).not.toBe(100)
-                expect(val).toBeInstanceOf(Promise)
-            })
+            const val = store1.get(atom1)
+            expect(val).not.toBe(100)
+            expect(val).toBeInstanceOf(Promise)
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "reject when no good value exists yet shows the rejected promise",
-        async () => {
+    test("reject when no good value exists yet shows the rejected promise", () =>
+        withFakeClock(async clock => {
             // Init never resolves → lastGoodValue stays NO_VALUE.
             // When the first revalidation rejects, there is nothing to
             // restore — the store should hold the rejected promise so
             // consumers see the error rather than a forever-pending one.
             const store1 = store()
-            let fetchCount = 0
-            const resolvers: Array<{
-                resolve: (v: number) => void
-                reject: (e: Error) => void
-            }> = []
-            const atomCallback = () => {
-                fetchCount++
-                return new Promise<number>((resolve, reject) => {
-                    resolvers.push({ resolve, reject })
-                })
-            }
+            const source = mockAsyncSource<number>()
 
-            const atom1 = atom(atomCallback, { maxAge: 20 })
+            const atom1 = atom(source.fn, { maxAge: 20 })
 
             const callback = mock(() => {})
             const unsubscribe = store1.sub(atom1, callback)
 
-            // Don't resolve init — wait for revalidation tick
-            await waitFor(() => expect(fetchCount).toBe(2))
+            // Don't resolve init — advance to the revalidation tick
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
             // Reject the revalidation
-            resolvers[1].reject(new Error("network error"))
-            await wait(1)
+            await source.reject(new Error("network error"))
 
             // No stale exists — store must hold a rejected promise
             const val = store1.get(atom1)
@@ -1180,17 +955,15 @@ describe("atom", () => {
                     () => "resolved" as const,
                     () => "rejected" as const,
                 ),
-                wait(50).then(() => "pending" as const),
+                clock.settle().then(() => "pending" as const),
             ])
             expect(settled).toBe("rejected")
 
             unsubscribe()
-        },
-    )
+        }))
 
-    test(
-        "async atom should recover after init rejection",
-        async () => {
+    test("async atom should recover after init rejection", () =>
+        withFakeClock(async clock => {
             // Concern: if the async init function rejects, the rejected
             // promise stays in data.values permanently. The atom never
             // retries and store.get() returns a rejected promise forever.
@@ -1212,7 +985,7 @@ describe("atom", () => {
 
             const callback = mock(() => {})
             const unsub1 = store1.sub(atom1, callback)
-            await wait(5)
+            await clock.settle() // let the rejected init promise settle
 
             // First access — rejected promise is stuck in the store
             const value = store1.get(atom1)
@@ -1221,14 +994,13 @@ describe("atom", () => {
 
             // Re-subscribing should retry the init function and recover
             const unsub2 = store1.sub(atom1, callback)
-            await wait(5)
+            await clock.settle() // let the retried init promise settle
 
             expect(callCount).toBe(2)
             expect(store1.get(atom1)).toBe(42)
 
             unsub2()
-        },
-    )
+        }))
 
     test("mutable atom", () => {
         const store1 = store()
@@ -1300,114 +1072,106 @@ describe("subscriber error handling", () => {
         expect(() => store1.set(countAtom, 1)).toThrow("subscriber error")
     })
 
-    test("atom with maxAge async: in-flight promise should not update store after unsubscribe", async () => {
-        const store1 = store()
-        let resolver: (v: number) => void
-        let fetchCount = 0
-        const atomCallback = () => {
-            fetchCount++
-            return new Promise<number>(resolve => {
-                resolver = resolve
+    test("atom with maxAge async: in-flight promise should not update store after unsubscribe", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+            // Use SWR so the stale value stays visible during revalidation
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
+                staleWhileRevalidate: 1000,
             })
-        }
-        // Use SWR so the stale value stays visible during revalidation
-        const atom1 = atom(atomCallback, {
-            maxAge: 20,
-            staleWhileRevalidate: 1000,
-        })
 
-        const callback = mock(() => {})
-        const unsubscribe = store1.sub(atom1, callback)
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
 
-        // Resolve the initial defaultValue call
-        resolver!(1)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(1)
+            // Resolve the initial defaultValue call
+            await source.resolve(1)
+            expect(store1.get(atom1)).toBe(1)
 
-        // Wait for the interval to fire — this calls defaultValue() again,
-        // creating a new in-flight promise. With SWR the store keeps value 1.
-        await wait(25)
-        expect(fetchCount).toBe(2)
-        expect(store1.get(atom1)).toBe(1)
+            // Advance so the interval fires — this calls defaultValue() again,
+            // creating a new in-flight promise. With SWR the store keeps value 1.
+            await clock.advance(25)
+            expect(source.callCount).toBe(2)
+            expect(store1.get(atom1)).toBe(1)
 
-        // Unsubscribe while the second promise is still pending.
-        // Cleanup runs: clears the interval and pending timeouts.
-        unsubscribe()
+            // Unsubscribe while the second promise is still pending.
+            // Cleanup runs: clears the interval and pending timeouts.
+            unsubscribe()
 
-        // Now resolve the in-flight promise AFTER cleanup
-        resolver!(999)
-        await wait(1)
+            // Now resolve the in-flight promise AFTER cleanup
+            await source.resolve(999)
 
-        // The resolved value 999 must not have been written to the store —
-        // the cancelled in-flight promise should be ignored on resolution.
-        // (We assert via the raw cache to avoid triggering lazy maxAge
-        // revalidation on an unmounted read, which is unrelated to the
-        // cleanup invariant being verified here.)
-        expect(store1.data.values.get(atom1)).toBe(1)
-    })
+            // The resolved value 999 must not have been written to the store —
+            // the cancelled in-flight promise should be ignored on resolution.
+            // (We assert via the raw cache to avoid triggering lazy maxAge
+            // revalidation on an unmounted read, which is unrelated to the
+            // cleanup invariant being verified here.)
+            expect(store1.data.values.get(atom1)).toBe(1)
+        }))
 
-    test("stale init promise from before lazy eviction does not clobber new value", async () => {
-        const resolvers: Array<(v: string) => void> = []
-        let calls = 0
-        const a = atom<string | Promise<string>>(
-            () => {
-                calls++
-                const idx = calls
-                return new Promise<string>(resolve => {
-                    resolvers.push(value => resolve(`${value}-${idx}`))
-                })
-            },
-            { maxAge: 30, name: "test/stale-init-promise-guard" },
-        )
-        const s = store()
+    test("stale init promise from before lazy eviction does not clobber new value", () =>
+        withFakeClock(async clock => {
+            const resolvers: Array<(v: string) => void> = []
+            let calls = 0
+            const a = atom<string | Promise<string>>(
+                () => {
+                    calls++
+                    const idx = calls
+                    return new Promise<string>(resolve => {
+                        resolvers.push(value => resolve(`${value}-${idx}`))
+                    })
+                },
+                { maxAge: 30, name: "test/stale-init-promise-guard" },
+            )
+            const s = store()
 
-        // First init kicks off promise#1.
-        const firstPending = s.get(a)
-        expect(typeof (firstPending as Promise<string>).then).toBe("function")
-        expect(calls).toBe(1)
+            // First init kicks off promise#1.
+            const firstPending = s.get(a)
+            expect(typeof (firstPending as Promise<string>).then).toBe("function")
+            expect(calls).toBe(1)
 
-        await wait(50) // past maxAge
+            await clock.advance(50) // past maxAge
 
-        // Lazy eviction + re-init: promise#2.
-        s.get(a)
-        expect(calls).toBe(2)
+            // Lazy eviction + re-init: promise#2.
+            s.get(a)
+            expect(calls).toBe(2)
 
-        // Resolve promise#2 → store updates to v-2.
-        resolvers[1]("v")
-        await Promise.resolve()
-        await Promise.resolve()
-        expect(s.get(a)).toBe("v-2")
+            // Resolve promise#2 → store updates to v-2.
+            resolvers[1]("v")
+            await clock.settle()
+            expect(s.get(a)).toBe("v-2")
 
-        // Late resolve of stale promise#1 — must NOT clobber v-2.
-        resolvers[0]("v")
-        await Promise.resolve()
-        await Promise.resolve()
-        expect(s.get(a)).toBe("v-2")
-    })
+            // Late resolve of stale promise#1 — must NOT clobber v-2.
+            resolvers[0]("v")
+            await clock.settle()
+            expect(s.get(a)).toBe("v-2")
+        }))
 
-    test("atom with maxAge: last subscriber unsubscribing clears interval even if it was not the first", async () => {
-        const setIntervalSpy = spyOn(global, "setInterval")
-        const clearIntervalSpy = spyOn(global, "clearInterval")
-        const store1 = store()
-        const atom1 = atom(() => Date.now(), { maxAge: 50 })
+    test("atom with maxAge: last subscriber unsubscribing clears interval even if it was not the first", () =>
+        withFakeClock(async () => {
+            const setIntervalSpy = spyOn(global, "setInterval")
+            const clearIntervalSpy = spyOn(global, "clearInterval")
+            const store1 = store()
+            const atom1 = atom(() => Date.now(), { maxAge: 50 })
 
-        // First subscription creates the interval
-        const unsub1 = store1.sub(atom1, () => {})
-        expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+            // First subscription creates the interval
+            const unsub1 = store1.sub(atom1, () => {})
+            expect(setIntervalSpy).toHaveBeenCalledTimes(1)
 
-        // Second subscription does NOT create a new interval
-        const unsub2 = store1.sub(atom1, () => {})
-        expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+            // Second subscription does NOT create a new interval
+            const unsub2 = store1.sub(atom1, () => {})
+            expect(setIntervalSpy).toHaveBeenCalledTimes(1)
 
-        // Unsub the first subscriber — still one left, interval should stay
-        unsub1()
-        expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
+            // Unsub the first subscriber — still one left, interval should stay
+            unsub1()
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(0)
 
-        // Unsub the last subscriber — interval should be cleaned up
-        unsub2()
-        expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+            // Unsub the last subscriber — interval should be cleaned up
+            unsub2()
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
 
-        setIntervalSpy.mockRestore()
-        clearIntervalSpy.mockRestore()
-    })
+            setIntervalSpy.mockRestore()
+            clearIntervalSpy.mockRestore()
+        }))
 })

--- a/packages/valdres/src/cacheMeta.test.ts
+++ b/packages/valdres/src/cacheMeta.test.ts
@@ -3,20 +3,7 @@ import { atom } from "./atom"
 import { cacheMeta } from "./cacheMeta"
 import { selector } from "./selector"
 import { store } from "./store"
-import { wait } from "../test/utils/wait"
-
-const waitFor = async (callback: () => void, count = 0, maxRetries = 200) => {
-    try {
-        callback()
-        return
-    } catch (e) {
-        if (count >= maxRetries) {
-            throw new Error(`waitFor timed out after ${maxRetries} retries`, { cause: e })
-        }
-        await wait(1)
-        return waitFor(callback, count + 1, maxRetries)
-    }
-}
+import { withFakeClock, mockAsyncSource } from "../test/utils/fakeClock"
 
 describe("cacheMeta", () => {
     test("returns cache metadata for atom with maxAge", async () => {
@@ -44,76 +31,62 @@ describe("cacheMeta", () => {
         expect(meta).toBeNull()
     })
 
-    test("isRevalidating updates during async revalidation", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{ resolve: (v: any) => void }> = []
+    test("isRevalidating updates during async revalidation", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
 
-        const atom1 = atom(
-            () =>
-                new Promise(resolve => {
-                    resolvers.push({ resolve })
-                    fetchCount++
-                }),
-            { maxAge: 20, staleWhileRevalidate: 200 },
-        )
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
+                staleWhileRevalidate: 200,
+            })
 
-        // Record every isRevalidating emission. The setInterval driving
-        // revalidation keeps firing, so sampling the *current* value races
-        // against the next tick — we assert on the history instead.
-        const history: boolean[] = []
-        const metaSel = cacheMeta(atom1)
-        store1.sub(metaSel, () => {
-            const m = store1.get(metaSel)
-            if (m) history.push(m.isRevalidating)
-        })
+            // Record every isRevalidating emission as the meta selector emits.
+            const history: boolean[] = []
+            const metaSel = cacheMeta(atom1)
+            store1.sub(metaSel, () => {
+                const m = store1.get(metaSel)
+                if (m) history.push(m.isRevalidating)
+            })
 
-        store1.sub(atom1, () => {})
-        resolvers[0].resolve(100)
+            store1.sub(atom1, () => {})
+            await source.resolve(100) // settle initial fetch
 
-        // Wait until revalidation starts (first true)
-        await waitFor(() => expect(history).toContain(true))
-        const firstTrueIdx = history.indexOf(true)
-        expect(fetchCount).toBeGreaterThanOrEqual(2)
+            // maxAge elapses → revalidation tick starts (isRevalidating true)
+            await clock.advance(20)
+            expect(history).toContain(true)
+            const firstTrueIdx = history.indexOf(true)
+            expect(source.callCount).toBeGreaterThanOrEqual(2)
 
-        // Resolve the revalidation. isRevalidating must flip to false
-        // at least once *after* we observed it go true.
-        resolvers[1].resolve(200)
-        await waitFor(() =>
-            expect(history.slice(firstTrueIdx + 1)).toContain(false),
-        )
-    })
+            // Resolve the revalidation. isRevalidating flips back to false.
+            await source.resolve(200)
+            expect(history.slice(firstTrueIdx + 1)).toContain(false)
+        }))
 
-    test("cacheMeta is reactive via subscriptions", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{ resolve: (v: any) => void }> = []
+    test("cacheMeta is reactive via subscriptions", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
 
-        const atom1 = atom(
-            () =>
-                new Promise(resolve => {
-                    resolvers.push({ resolve })
-                    fetchCount++
-                }),
-            { maxAge: 20, staleWhileRevalidate: 200 },
-        )
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
+                staleWhileRevalidate: 200,
+            })
 
-        const metaSelector = cacheMeta(atom1)
-        store1.sub(atom1, () => {})
-        resolvers[0].resolve(100)
-        await wait(1)
+            const metaSelector = cacheMeta(atom1)
+            store1.sub(atom1, () => {})
+            await source.resolve(100) // settle initial fetch
 
-        const metaCallback = mock(() => {})
-        store1.sub(metaSelector, metaCallback, false)
+            const metaCallback = mock(() => {})
+            store1.sub(metaSelector, metaCallback, false)
 
-        // Wait for revalidation to start
-        await waitFor(() => expect(fetchCount).toBe(2))
-        // Give propagation time to reach the selector subscriber
-        await wait(5)
+            // maxAge elapses → revalidation starts, updating isRevalidating
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
-        // metaCallback should have been called when isRevalidating changed
-        expect(metaCallback).toHaveBeenCalled()
-    })
+            // metaCallback should have been called when isRevalidating changed
+            expect(metaCallback).toHaveBeenCalled()
+        }))
 
     test("cacheMeta reflects staleWhileRevalidate and staleIfError config", async () => {
         const store1 = store()
@@ -144,28 +117,30 @@ describe("cacheMeta", () => {
 })
 
 describe("reactive maxAge", () => {
-    test("maxAge as atom changes interval timing", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const maxAgeAtom = atom(50)
+    test("maxAge as atom changes interval timing", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let fetchCount = 0
+            const maxAgeAtom = atom(50)
 
-        const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeAtom })
+            const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeAtom })
 
-        store1.sub(atom1, () => {})
-        expect(fetchCount).toBe(1)
+            store1.sub(atom1, () => {})
+            expect(fetchCount).toBe(1)
 
-        // Wait for first revalidation at 50ms
-        await waitFor(() => expect(fetchCount).toBe(2))
+            // First revalidation fires at 50ms
+            await clock.advance(50)
+            expect(fetchCount).toBe(2)
 
-        // Change maxAge to much longer — should slow down
-        store1.set(maxAgeAtom, 5000)
+            // Change maxAge to much longer — should slow down
+            store1.set(maxAgeAtom, 5000)
 
-        const countAfterChange = fetchCount
-        await wait(100)
+            const countAfterChange = fetchCount
+            await clock.advance(100)
 
-        // Should not have fired again with the long interval
-        expect(fetchCount).toBeLessThanOrEqual(countAfterChange + 1)
-    })
+            // Should not have fired again with the long interval
+            expect(fetchCount).toBeLessThanOrEqual(countAfterChange + 1)
+        }))
 
     test("maxAge as atom reflects in cacheMeta", async () => {
         const store1 = store()
@@ -181,199 +156,191 @@ describe("reactive maxAge", () => {
         expect(store1.get(cacheMeta(atom1))!.maxAge).toBe(200)
     })
 
-    test("maxAge as selector", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const fastMode = atom(true)
-        const maxAgeSelector = selector(get => (get(fastMode) ? 20 : 5000))
+    test("maxAge as selector", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let fetchCount = 0
+            const fastMode = atom(true)
+            const maxAgeSelector = selector(get => (get(fastMode) ? 20 : 5000))
 
-        const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeSelector })
+            const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeSelector })
 
-        store1.sub(atom1, () => {})
-        expect(fetchCount).toBe(1)
+            store1.sub(atom1, () => {})
+            expect(fetchCount).toBe(1)
 
-        // Fast mode: should revalidate quickly
-        await waitFor(() => expect(fetchCount).toBe(2))
+            // Fast mode: revalidates at 20ms
+            await clock.advance(20)
+            expect(fetchCount).toBe(2)
 
-        // Switch to slow mode
-        store1.set(fastMode, false)
-        const countAfterSwitch = fetchCount
-        await wait(80)
+            // Switch to slow mode
+            store1.set(fastMode, false)
+            const countAfterSwitch = fetchCount
+            await clock.advance(80)
 
-        // Should not have revalidated again with 5000ms interval
-        expect(fetchCount).toBeLessThanOrEqual(countAfterSwitch + 1)
-    })
+            // Should not have revalidated again with 5000ms interval
+            expect(fetchCount).toBeLessThanOrEqual(countAfterSwitch + 1)
+        }))
 
-    test("staleWhileRevalidate as atom", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{ resolve: (v: any) => void }> = []
-        const swrAtom = atom(200)
+    test("staleWhileRevalidate as atom", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+            const swrAtom = atom(200)
 
-        const atom1 = atom(
-            () =>
-                new Promise(resolve => {
-                    resolvers.push({ resolve })
-                    fetchCount++
-                }),
-            { maxAge: 20, staleWhileRevalidate: swrAtom },
-        )
+            const atom1 = atom(source.fn, {
+                maxAge: 20,
+                staleWhileRevalidate: swrAtom,
+            })
 
-        store1.sub(atom1, () => {})
-        resolvers[0].resolve(100)
-        await wait(1)
+            store1.sub(atom1, () => {})
+            await source.resolve(100) // settle initial fetch
 
-        expect(store1.get(atom1)).toBe(100)
+            expect(store1.get(atom1)).toBe(100)
 
-        // Wait for revalidation
-        await waitFor(() => expect(fetchCount).toBe(2))
+            // maxAge elapses → revalidation fetch starts
+            await clock.advance(20)
+            expect(source.callCount).toBe(2)
 
-        // SWR: stale value should still be visible
-        expect(store1.get(atom1)).toBe(100)
+            // SWR: stale value should still be visible
+            expect(store1.get(atom1)).toBe(100)
 
-        // Resolve revalidation
-        resolvers[1].resolve(200)
-        await wait(1)
-        expect(store1.get(atom1)).toBe(200)
+            // Resolve revalidation
+            await source.resolve(200)
+            expect(store1.get(atom1)).toBe(200)
 
-        // cacheMeta reflects SWR value
-        expect(store1.get(cacheMeta(atom1))!.staleWhileRevalidate).toBe(200)
+            // cacheMeta reflects SWR value
+            expect(store1.get(cacheMeta(atom1))!.staleWhileRevalidate).toBe(200)
 
-        // Change SWR
-        store1.set(swrAtom, 500)
-        expect(store1.get(cacheMeta(atom1))!.staleWhileRevalidate).toBe(500)
-    })
+            // Change SWR
+            store1.set(swrAtom, 500)
+            expect(store1.get(cacheMeta(atom1))!.staleWhileRevalidate).toBe(500)
+        }))
 
-    test("staleIfError as atom", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const resolvers: Array<{
-            resolve: (v: any) => void
-            reject: (e: any) => void
-        }>[] = []
-        const staleIfErrorAtom = atom(500)
+    test("staleIfError as atom", () =>
+        withFakeClock(async () => {
+            const store1 = store()
+            const source = mockAsyncSource<number>()
+            const staleIfErrorAtom = atom(500)
 
-        const atom1 = atom(
-            () =>
-                new Promise((resolve, reject) => {
-                    resolvers.push([{ resolve, reject }])
-                    fetchCount++
-                }),
-            {
+            const atom1 = atom(source.fn, {
                 maxAge: 20,
                 staleWhileRevalidate: 200,
                 staleIfError: staleIfErrorAtom,
-            },
-        )
+            })
 
-        store1.sub(atom1, () => {})
-        resolvers[0][0].resolve(100)
-        await wait(1)
+            store1.sub(atom1, () => {})
+            await source.resolve(100) // settle initial fetch
 
-        expect(store1.get(cacheMeta(atom1))!.staleIfError).toBe(500)
+            expect(store1.get(cacheMeta(atom1))!.staleIfError).toBe(500)
 
-        store1.set(staleIfErrorAtom, 1000)
-        expect(store1.get(cacheMeta(atom1))!.staleIfError).toBe(1000)
-    })
+            store1.set(staleIfErrorAtom, 1000)
+            expect(store1.get(cacheMeta(atom1))!.staleIfError).toBe(1000)
+        }))
 
-    test("global atom: cacheMeta visible in both stores with single interval", async () => {
-        const store1 = store()
-        const store2 = store()
-        let fetchCount = 0
+    test("global atom: cacheMeta visible in both stores with single interval", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const store2 = store()
+            let fetchCount = 0
 
-        const atom1 = atom(() => ++fetchCount, {
-            global: true,
-            maxAge: 30,
-        })
+            const atom1 = atom(() => ++fetchCount, {
+                global: true,
+                maxAge: 30,
+            })
 
-        store1.sub(atom1, () => {})
-        store2.sub(atom1, () => {})
+            store1.sub(atom1, () => {})
+            store2.sub(atom1, () => {})
 
-        // Global atoms call defaultValue during init for each store + globalStore
-        const countAfterInit = fetchCount
+            // Global atoms call defaultValue during init for each store + globalStore
+            const countAfterInit = fetchCount
 
-        // Both stores see cacheMeta
-        const meta1 = store1.get(cacheMeta(atom1))
-        const meta2 = store2.get(cacheMeta(atom1))
-        expect(meta1).toBeDefined()
-        expect(meta2).toBeDefined()
-        expect(meta1!.maxAge).toBe(30)
-        expect(meta2!.maxAge).toBe(30)
-        expect(meta1!.isRevalidating).toBe(false)
-        expect(meta2!.isRevalidating).toBe(false)
+            // Both stores see cacheMeta
+            const meta1 = store1.get(cacheMeta(atom1))
+            const meta2 = store2.get(cacheMeta(atom1))
+            expect(meta1).toBeDefined()
+            expect(meta2).toBeDefined()
+            expect(meta1!.maxAge).toBe(30)
+            expect(meta2!.maxAge).toBe(30)
+            expect(meta1!.isRevalidating).toBe(false)
+            expect(meta2!.isRevalidating).toBe(false)
 
-        // Wait for exactly one revalidation — only one interval should fire
-        await waitFor(() => expect(fetchCount).toBe(countAfterInit + 1))
+            // maxAge elapses → exactly one revalidation (single shared interval)
+            await clock.advance(30)
+            expect(fetchCount).toBe(countAfterInit + 1)
 
-        // Only one extra call, not two (proves single interval)
-        expect(fetchCount).toBe(countAfterInit + 1)
+            // Only one extra call, not two (proves single interval)
+            expect(fetchCount).toBe(countAfterInit + 1)
 
-        // Both stores see the updated value
-        expect(store1.get(atom1)).toBe(store2.get(atom1))
-    })
+            // Both stores see the updated value
+            expect(store1.get(atom1)).toBe(store2.get(atom1))
+        }))
 
-    test("global atom: reactive maxAge restarts the shared interval", async () => {
-        const store1 = store()
-        const store2 = store()
-        let fetchCount = 0
-        const maxAgeAtom = atom(30)
+    test("global atom: reactive maxAge restarts the shared interval", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const store2 = store()
+            let fetchCount = 0
+            const maxAgeAtom = atom(30)
 
-        const atom1 = atom(() => ++fetchCount, {
-            global: true,
-            maxAge: maxAgeAtom,
-        })
+            const atom1 = atom(() => ++fetchCount, {
+                global: true,
+                maxAge: maxAgeAtom,
+            })
 
-        store1.sub(atom1, () => {})
-        store2.sub(atom1, () => {})
-        const countAfterInit = fetchCount
+            store1.sub(atom1, () => {})
+            store2.sub(atom1, () => {})
+            const countAfterInit = fetchCount
 
-        // Wait for first revalidation
-        await waitFor(() => expect(fetchCount).toBe(countAfterInit + 1))
+            // First revalidation fires at 30ms
+            await clock.advance(30)
+            expect(fetchCount).toBe(countAfterInit + 1)
 
-        // Both stores see the value
-        expect(store1.get(atom1)).toBe(store2.get(atom1))
+            // Both stores see the value
+            expect(store1.get(atom1)).toBe(store2.get(atom1))
 
-        // Change maxAge to very long — should slow down
-        store1.set(maxAgeAtom, 5000)
+            // Change maxAge to very long — should slow down
+            store1.set(maxAgeAtom, 5000)
 
-        // cacheMeta reflects the new maxAge in both stores
-        expect(store1.get(cacheMeta(atom1))!.maxAge).toBe(5000)
-        expect(store2.get(cacheMeta(atom1))!.maxAge).toBe(5000)
+            // cacheMeta reflects the new maxAge in both stores
+            expect(store1.get(cacheMeta(atom1))!.maxAge).toBe(5000)
+            expect(store2.get(cacheMeta(atom1))!.maxAge).toBe(5000)
 
-        const countAfterChange = fetchCount
-        await wait(100)
+            const countAfterChange = fetchCount
+            await clock.advance(100)
 
-        // Should not have revalidated again with the long interval
-        expect(fetchCount).toBeLessThanOrEqual(countAfterChange + 1)
-    })
+            // Should not have revalidated again with the long interval
+            expect(fetchCount).toBeLessThanOrEqual(countAfterChange + 1)
+        }))
 
-    test("unsubscribe cleans up reactive config subscriptions", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const maxAgeAtom = atom(30)
+    test("unsubscribe cleans up reactive config subscriptions", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let fetchCount = 0
+            const maxAgeAtom = atom(30)
 
-        const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeAtom })
+            const atom1 = atom(() => ++fetchCount, { maxAge: maxAgeAtom })
 
-        const unsub = store1.sub(atom1, () => {})
-        expect(fetchCount).toBe(1)
+            const unsub = store1.sub(atom1, () => {})
+            expect(fetchCount).toBe(1)
 
-        // Wait for one revalidation
-        await waitFor(() => expect(fetchCount).toBe(2))
+            // One revalidation fires at 30ms
+            await clock.advance(30)
+            expect(fetchCount).toBe(2)
 
-        // Unsubscribe — should clean up both the interval and the reactive sub
-        unsub()
+            // Unsubscribe — should clean up both the interval and the reactive sub
+            unsub()
 
-        const countAfterUnsub = fetchCount
-        await wait(100)
+            const countAfterUnsub = fetchCount
+            await clock.advance(100)
 
-        // No more revalidation calls
-        expect(fetchCount).toBe(countAfterUnsub)
+            // No more revalidation calls
+            expect(fetchCount).toBe(countAfterUnsub)
 
-        // Setting the maxAge atom should not cause errors or side effects
-        store1.set(maxAgeAtom, 1)
-        await wait(50)
-        expect(fetchCount).toBe(countAfterUnsub)
-    })
+            // Setting the maxAge atom should not cause errors or side effects
+            store1.set(maxAgeAtom, 1)
+            await clock.advance(50)
+            expect(fetchCount).toBe(countAfterUnsub)
+        }))
 
     test("cacheMeta returns null before any subscription", () => {
         const store1 = store()
@@ -384,16 +351,18 @@ describe("reactive maxAge", () => {
         expect(meta).toBeNull()
     })
 
-    test("static number maxAge still works (no regression)", async () => {
-        const store1 = store()
-        let fetchCount = 0
-        const atom1 = atom(() => ++fetchCount, { maxAge: 20 })
+    test("static number maxAge still works (no regression)", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let fetchCount = 0
+            const atom1 = atom(() => ++fetchCount, { maxAge: 20 })
 
-        const callback = mock(() => {})
-        store1.sub(atom1, callback)
-        expect(fetchCount).toBe(1)
+            const callback = mock(() => {})
+            store1.sub(atom1, callback)
+            expect(fetchCount).toBe(1)
 
-        await waitFor(() => expect(fetchCount).toBe(2))
-        expect(store1.get(atom1)).toBe(2)
-    })
+            await clock.advance(20)
+            expect(fetchCount).toBe(2)
+            expect(store1.get(atom1)).toBe(2)
+        }))
 })

--- a/packages/valdres/test/utils/fakeClock.ts
+++ b/packages/valdres/test/utils/fakeClock.ts
@@ -1,4 +1,4 @@
-import { jest, setSystemTime } from "bun:test"
+import { jest } from "bun:test"
 
 /** Drain the microtask queue so promise (`.then`) chains scheduled by a timer
  *  or a manual resolve settle before the next assertion. A few passes cover the
@@ -16,15 +16,23 @@ export type FakeClock = {
     /** Parity shim for jest/vitest's not-yet-implemented (oven-sh/bun#16142)
      *  async timer API. Identical to `advance`. */
     advanceTimersByTimeAsync: (ms: number) => Promise<void>
-    /** Restore real timers and system time. Must run after every test that
-     *  installed the clock, or fake timers leak into sibling tests. */
+    /** Restore real timers (and the real `Date.now()`). Must run after every
+     *  test that installed the clock, or fake timers leak into sibling tests. */
     restore: () => void
 }
 
 /** Install a deterministic clock for maxAge / SWR / interval tests, removing
  *  real wall-clock dependence so tick-count and freshness-window assertions
- *  never race CI scheduling. `jest.useFakeTimers()` also fakes `Date.now()`, so
- *  the maxAge interval and its time-window math advance in lockstep.
+ *  never race CI scheduling. `jest.useFakeTimers()` also fakes `Date.now()`, and
+ *  `advanceTimersByTime` advances it in lockstep with the timer queue — which is
+ *  what the maxAge code's `Date.now() - lastWrite` freshness math relies on.
+ *
+ *  Do NOT add `setSystemTime()` to anchor an absolute start time. Verified in
+ *  Bun 1.3.13: `setSystemTime` before `useFakeTimers` is overwritten (no-op);
+ *  `setSystemTime` after `useFakeTimers` pins `Date.now()` so that
+ *  `advanceTimersByTime` no longer moves it, which breaks the freshness windows.
+ *  The tests only need relative advancement, so plain `useFakeTimers` is correct
+ *  and `useRealTimers` fully restores the real clock on its own.
  *
  *  Bun's `advanceTimersByTime` already drains microtasks between timer firings
  *  (unlike jest's sync version), so timer→`.then`→timer chains resolve on their
@@ -33,8 +41,7 @@ export type FakeClock = {
  *  (oven-sh/bun#16142), hence the shim above.
  *
  *  Prefer `withFakeClock` so restoration is automatic. */
-export const useFakeClock = (start = new Date("2020-01-01T00:00:00Z")): FakeClock => {
-    setSystemTime(start)
+export const useFakeClock = (): FakeClock => {
     jest.useFakeTimers()
     const advance = async (ms: number) => {
         jest.advanceTimersByTime(ms)
@@ -46,7 +53,6 @@ export const useFakeClock = (start = new Date("2020-01-01T00:00:00Z")): FakeCloc
         advanceTimersByTimeAsync: advance,
         restore: () => {
             jest.useRealTimers()
-            setSystemTime()
         },
     }
 }
@@ -58,9 +64,8 @@ export const useFakeClock = (start = new Date("2020-01-01T00:00:00Z")): FakeCloc
  */
 export const withFakeClock = async (
     body: (clock: FakeClock) => Promise<void> | void,
-    start?: Date,
 ) => {
-    const clock = useFakeClock(start)
+    const clock = useFakeClock()
     try {
         await body(clock)
     } finally {

--- a/packages/valdres/test/utils/fakeClock.ts
+++ b/packages/valdres/test/utils/fakeClock.ts
@@ -1,0 +1,103 @@
+import { jest, setSystemTime } from "bun:test"
+
+/** Drain the microtask queue so promise (`.then`) chains scheduled by a timer
+ *  or a manual resolve settle before the next assertion. A few passes cover the
+ *  shallow chains valdres uses (tick → fetch → handleResolve → updateMeta). */
+const drainMicrotasks = async (passes = 4) => {
+    for (let i = 0; i < passes; i++) await Promise.resolve()
+}
+
+export type FakeClock = {
+    /** Advance fake time by `ms` (firing due timers), then settle promises. */
+    advance: (ms: number) => Promise<void>
+    /** Settle pending promise callbacks without moving time — e.g. after
+     *  manually resolving a mocked fetch. */
+    settle: () => Promise<void>
+    /** Parity shim for jest/vitest's not-yet-implemented (oven-sh/bun#16142)
+     *  async timer API. Identical to `advance`. */
+    advanceTimersByTimeAsync: (ms: number) => Promise<void>
+    /** Restore real timers and system time. Must run after every test that
+     *  installed the clock, or fake timers leak into sibling tests. */
+    restore: () => void
+}
+
+/** Install a deterministic clock for maxAge / SWR / interval tests, removing
+ *  real wall-clock dependence so tick-count and freshness-window assertions
+ *  never race CI scheduling. `jest.useFakeTimers()` also fakes `Date.now()`, so
+ *  the maxAge interval and its time-window math advance in lockstep.
+ *
+ *  Bun's `advanceTimersByTime` already drains microtasks between timer firings
+ *  (unlike jest's sync version), so timer→`.then`→timer chains resolve on their
+ *  own; `advance` just adds a trailing drain so an awaited assertion sees the
+ *  settled result. The async `*Async` timer APIs remain unimplemented upstream
+ *  (oven-sh/bun#16142), hence the shim above.
+ *
+ *  Prefer `withFakeClock` so restoration is automatic. */
+export const useFakeClock = (start = new Date("2020-01-01T00:00:00Z")): FakeClock => {
+    setSystemTime(start)
+    jest.useFakeTimers()
+    const advance = async (ms: number) => {
+        jest.advanceTimersByTime(ms)
+        await drainMicrotasks()
+    }
+    return {
+        advance,
+        settle: () => drainMicrotasks(),
+        advanceTimersByTimeAsync: advance,
+        restore: () => {
+            jest.useRealTimers()
+            setSystemTime()
+        },
+    }
+}
+
+/** Run `body` with a fake clock installed, restoring real timers afterwards
+ *  even if it throws — no per-test install/restore boilerplate:
+ *
+ *      test("...", () => withFakeClock(async clock => { ... }))
+ */
+export const withFakeClock = async (
+    body: (clock: FakeClock) => Promise<void> | void,
+    start?: Date,
+) => {
+    const clock = useFakeClock(start)
+    try {
+        await body(clock)
+    } finally {
+        clock.restore()
+    }
+}
+
+/** A controllable async data source for maxAge atoms. `fn` is the atom's
+ *  default factory; each call records one fetch and returns a fresh pending
+ *  promise. Resolve or reject the in-flight fetch by hand — microtasks are
+ *  drained so the store settles before the next assertion. Replaces the
+ *  hand-rolled `resolvers[]` arrays the timing tests used to repeat. */
+export const mockAsyncSource = <T = unknown>() => {
+    const pending: Array<{ resolve: (v: T) => void; reject: (e: unknown) => void }> = []
+    let callCount = 0
+    return {
+        fn: (): Promise<T> =>
+            new Promise<T>((resolve, reject) => {
+                callCount++
+                pending.push({ resolve, reject })
+            }),
+        /** Number of times the source has been invoked (fetches started). */
+        get callCount() {
+            return callCount
+        },
+        /** Resolve a fetch (default: the latest in flight), then settle. */
+        resolve: async (value: T, index = pending.length - 1) => {
+            pending[index]?.resolve(value)
+            await drainMicrotasks()
+        },
+        /** Reject a fetch (default: the latest in flight), then settle. */
+        reject: async (
+            error: unknown = new Error("mock fetch failed"),
+            index = pending.length - 1,
+        ) => {
+            pending[index]?.reject(error)
+            await drainMicrotasks()
+        },
+    }
+}


### PR DESCRIPTION
## Why

The maxAge / staleWhileRevalidate / staleIfError tests drove the **real wall clock** — `setInterval` + `await wait(N)` + real `Date.now()` — and asserted on how many interval ticks fired in a fixed real-time window. Under CI scheduling jitter a 15ms interval could fire inside a "1ms" gap, so e.g. `expect(fetchCount).toBe(1)` intermittently saw `2`. This is the recurring flake (the last failure was "maxAge interval should skip tick while revalidation is in-flight"). Re-running just rolled the dice again.

## The fix: a deterministic clock

`jest.useFakeTimers()` — which I verified also fakes `Date.now()` in Bun 1.3.13, so the maxAge interval and its freshness-window math advance in lockstep. New `test/utils/fakeClock.ts`:

- **`useFakeClock` / `withFakeClock`** — install + auto-restore fake timers (the wrapper keeps each test free of install/restore boilerplate).
- **`clock.advance(ms)`** — advance fake time, fire due timers, drain microtasks.
- **`advanceTimersByTimeAsync`** — parity shim. The async timer APIs are still unimplemented upstream ([oven-sh/bun#16142](https://github.com/oven-sh/bun/issues/16142)), but Bun's *sync* `advanceTimersByTime` already drains microtasks between timer firings (unlike jest's), so a trailing flush is all that's needed.
- **`mockAsyncSource`** — a controllable async fetch (`fn` / `callCount` / `resolve` / `reject`) that replaces the hand-rolled `resolvers[]` + `fetchCount` boilerplate the tests repeated ~20×.

## Scope

Migrated every timing test in `atom.test.ts` and `cacheMeta.test.ts`. Purely-synchronous config-read tests were left as-is (no clock needed).

## Faithfulness (this is test infra — assertions must not be weakened)

- `expect()` counts preserved exactly: **148** (atom) / **53** (cacheMeta).
- Assertion **multiset identical** to `main` (verified by a normalized diff — zero real differences).
- Loose-matcher counts unchanged — no `toBe(N)` was relaxed into `toBeGreaterThanOrEqual`/`toContain`/etc.
- Spy-based tests (`spyOn(global, "setInterval"/...)`) kept their spy assertions; the spy is installed after `useFakeTimers`, so it correctly observes valdres's calls to the faked globals.

## Result

- Deterministic: each migrated file run **25× locally, 0 failures**; full suite **372 pass, 0 fail**; `tsgo --noEmit` clean; no fake-timer leakage into sibling tests.
- Faster: `atom.test.ts` ~1.5s → ~19ms, `cacheMeta.test.ts` ~700ms → ~18ms.
- **Net −267 lines** — the tests are also shorter and read as a clear advance/resolve/assert narrative.

Test-only; no library code changed (empty changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
