### PR TITLE
feat(valdres): add StoreChange kind "unset" so txn unsets are distinguishable from sets

### DIFF
--- a/.changeset/scope-unset-reinherit.md
+++ b/.changeset/scope-unset-reinherit.md
@@ -23,9 +23,13 @@ override that was inherited at the target point).
   subscriptions resume tracking parent changes again.
 - No-op (no notification) when the store holds no own value for the atom.
 - Throws for non-atoms.
-- Surfaces on `store.onChange` as a `kind: "set"` change carrying the reverted
-  value, tagged with the new `StoreChangeMeta.source` `"unset"` — so a consumer
-  can tell the value was dropped without overloading the `"delete"` kind.
+- Surfaces on `store.onChange` as a new `kind: "unset"` change carrying the
+  reverted value, tagged with the new `StoreChangeMeta.source` `"unset"` — so a
+  consumer can tell the value was dropped (and decide whether to drop its own
+  override or apply the reverted value) without overloading the `"set"` or
+  `"delete"` kinds. The per-change `kind` is `"unset"` even inside a transaction
+  (where `meta.source` is `"transaction"`), so an unset stays distinguishable
+  from a set within a mixed transaction batch.
 - Transaction form: `txn.unset(atom)` (and `t.scope(id, st => st.unset(atom))`),
   collapsed into the transaction's single `onChange` callback. Within a
   transaction, a later `set`/`reset` of the same atom supersedes a buffered

--- a/packages/valdres/src/indexConstructor.multiStore.test.ts
+++ b/packages/valdres/src/indexConstructor.multiStore.test.ts
@@ -128,7 +128,11 @@ describe("index() across root + scope", () => {
             }
             void members
         }
-    })
+        // 1500 seeded iterations run in <1s locally but sit near the default
+        // 5000ms bun-test timeout on a loaded CI runner (observed 5029/5055ms).
+        // Give this deterministic no-crash sweep headroom so runner variance
+        // can't flake it; the workload (and thus coverage) is unchanged.
+    }, 20_000)
 
     test("publish-style: move members from scope to root in a cross-scope txn", () => {
         const fam = atomFamily<{ kind: string } | null, [string]>(null, {

--- a/packages/valdres/src/lib/notifyChangeListeners.ts
+++ b/packages/valdres/src/lib/notifyChangeListeners.ts
@@ -181,10 +181,13 @@ export const reportAtomChanges = (
 /** Report that `data`'s own value for `atom` was unset (called from unsetValue,
  *  after the value and its bookkeeping have been removed). The store now reads
  *  `revertedValue` — the inherited parent value on a scope, or the default on a
- *  root — so the change is a `kind: "set"` carrying that value, NOT a `"delete"`
- *  (the atom still exists, only this store's own value is gone). The originating
- *  `source` ("unset", or "transaction" when buffered into a txn) lives on the
- *  change batch's meta. */
+ *  root — carried as the change's `value`. The change is a `kind: "unset"`, NOT
+ *  a `"set"` (so a consumer can drop the override rather than treat the reverted
+ *  value as a new write) and NOT a `"delete"` (the atom still exists, only this
+ *  store's own value is gone). The batch's `meta.source` is "unset" for a
+ *  standalone unset, or "transaction" when buffered into a txn — but the
+ *  per-change kind stays "unset" either way, so it's distinguishable even inside
+ *  a mixed transaction. */
 export const reportUnsetAtom = (
     atom: Atom<any>,
     data: StoreData,
@@ -195,7 +198,7 @@ export const reportUnsetAtom = (
     const group: ChangeGroup = {
         data,
         changes: [
-            { kind: "set", atom, value: revertedValue, scope: scopePath(data) },
+            { kind: "unset", atom, value: revertedValue, scope: scopePath(data) },
         ],
     }
     emitGroup(group, report)

--- a/packages/valdres/src/lib/unsetValue.test.ts
+++ b/packages/valdres/src/lib/unsetValue.test.ts
@@ -338,7 +338,7 @@ describe("scope.unset — invalid input", () => {
 })
 
 describe("scope.unset — nested scopes", () => {
-    test("inner scope inherits through a unset outer scope", () => {
+    test("inner scope inherits through an unset outer scope", () => {
         const root = store()
         const outer = root.scope("outer")
         const inner = outer.scope("inner")
@@ -461,7 +461,7 @@ describe("scope.unset — transaction form", () => {
         expect(root.data.scopeValueIndex.get(a)).toBeUndefined()
     })
 
-    test("a unset inside a txn reports kind 'unset' per-change (source stays 'transaction')", () => {
+    test("an unset inside a txn reports kind 'unset' per-change (source stays 'transaction')", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -516,7 +516,7 @@ describe("scope.unset — transaction form", () => {
         expect(scoped.get(a)).toBe(10)
     })
 
-    test("a set after a unset in the same txn wins (re-shadows)", () => {
+    test("a set after an unset in the same txn wins (re-shadows)", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -534,7 +534,7 @@ describe("scope.unset — transaction form", () => {
         expect(scoped.data.values.get(a)).toBe(5)
     })
 
-    test("a unset after a set in the same txn wins (re-inherits)", () => {
+    test("an unset after a set in the same txn wins (re-inherits)", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -551,7 +551,7 @@ describe("scope.unset — transaction form", () => {
         expect(scoped.data.values.has(a)).toBe(false)
     })
 
-    test("reading a unset atom mid-txn returns the inherited value, not the stale shadow", () => {
+    test("reading an unset atom mid-txn returns the inherited value, not the stale shadow", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -568,7 +568,7 @@ describe("scope.unset — transaction form", () => {
         expect(readInside).toBe(10)
     })
 
-    test("a functional set after a unset uses the inherited value as its base", () => {
+    test("a functional set after an unset uses the inherited value as its base", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -584,7 +584,7 @@ describe("scope.unset — transaction form", () => {
         expect(scoped.get(a)).toBe(11)
     })
 
-    test("an inner scope reads through a unset outer scope mid-txn", () => {
+    test("an inner scope reads through an unset outer scope mid-txn", () => {
         const root = store()
         const outer = root.scope("outer")
         const inner = outer.scope("inner")
@@ -606,7 +606,7 @@ describe("scope.unset — transaction form", () => {
         expect(inner.get(a)).toBe(10)
     })
 
-    test("a single-store scoped transaction reads a unset atom as inherited", () => {
+    test("a single-store scoped transaction reads an unset atom as inherited", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)

--- a/packages/valdres/src/lib/unsetValue.test.ts
+++ b/packages/valdres/src/lib/unsetValue.test.ts
@@ -270,7 +270,7 @@ describe("unset — root store", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes).toEqual([
-            { kind: "set", atom: a, value: 1, scope: [] },
+            { kind: "unset", atom: a, value: 1, scope: [] },
         ])
         expect(root.get(a)).toBe(1)
     })
@@ -389,7 +389,7 @@ describe("scope.unset — nested scopes", () => {
 })
 
 describe("scope.unset — onChange", () => {
-    test("emits a 'set' change with the inherited value and source 'unset'", () => {
+    test("emits an 'unset' change carrying the inherited value, source 'unset'", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -404,7 +404,7 @@ describe("scope.unset — onChange", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes).toEqual([
-            { kind: "set", atom: a, value: 10, scope: ["child"] },
+            { kind: "unset", atom: a, value: 10, scope: ["child"] },
         ])
     })
 
@@ -423,14 +423,14 @@ describe("scope.unset — onChange", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes[0]).toEqual({
-            kind: "set",
+            kind: "unset",
             atom: a,
             value: 10,
             scope: ["child"],
         })
     })
 
-    test("the unset change uses kind 'set', never 'delete'", () => {
+    test("the unset change uses kind 'unset', never 'set' or 'delete'", () => {
         const root = store()
         const scoped = root.scope("child")
         const a = atom(1)
@@ -440,7 +440,7 @@ describe("scope.unset — onChange", () => {
         let received: readonly StoreChange[] = []
         scoped.onChange(changes => (received = changes))
         scoped.unset(a)
-        expect(received[0]!.kind).toBe("set")
+        expect(received[0]!.kind).toBe("unset")
     })
 })
 
@@ -459,6 +459,45 @@ describe("scope.unset — transaction form", () => {
         expect(scoped.get(a)).toBe(10)
         expect(scoped.data.values.has(a)).toBe(false)
         expect(root.data.scopeValueIndex.get(a)).toBeUndefined()
+    })
+
+    test("a unset inside a txn reports kind 'unset' per-change (source stays 'transaction')", () => {
+        const root = store()
+        const scoped = root.scope("child")
+        const a = atom(1)
+        const b = atom(1)
+        root.set(a, 10)
+        scoped.set(a, 99)
+
+        const calls: { changes: readonly StoreChange[]; meta: any }[] = []
+        scoped.onChange((changes, meta) => calls.push({ changes, meta }))
+
+        // A mixed txn: a real set of `b` alongside an unset of `a`. The batch
+        // source is "transaction", so the per-change kind is the only signal
+        // that distinguishes the unset (drop the override) from the set.
+        root.txn(t => {
+            t.scope("child", st => {
+                st.set(b, 5)
+                st.unset(a)
+            })
+        })
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]!.meta.source).toBe("transaction")
+        const aChange = calls[0]!.changes.find(c => c.atom === a)
+        const bChange = calls[0]!.changes.find(c => c.atom === b)
+        expect(aChange).toEqual({
+            kind: "unset",
+            atom: a,
+            value: 10,
+            scope: ["child"],
+        })
+        expect(bChange).toEqual({
+            kind: "set",
+            atom: b,
+            value: 5,
+            scope: ["child"],
+        })
     })
 
     test("a scoped subscriber fires once when a transaction unsets its shadow", () => {

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -95,8 +95,8 @@ export const effectiveValueAfterUnset = (
  *  store has no own value for `atom`. Otherwise removes the value + bookkeeping,
  *  notifies subscribers, dependent selectors, and nested scopes of the reverted
  *  value, re-delegates scope subscriptions so future parent changes are observed
- *  again, and reports the change on `store.onChange` as a `kind: "set"` (the
- *  reverted value) with `meta.source === "unset"`. */
+ *  again, and reports the change on `store.onChange` as a `kind: "unset"` (carrying
+ *  the reverted value) with `meta.source === "unset"`. */
 export const unsetValue = <V>(atom: Atom<V>, data: StoreData): void => {
     if (!isAtom(atom)) throw new Error(InvalidStateError)
 

--- a/packages/valdres/src/types/StoreChange.ts
+++ b/packages/valdres/src/types/StoreChange.ts
@@ -7,6 +7,16 @@ import type { AtomFamilyAtom } from "./AtomFamilyAtom"
  *  - `"set"`    — the atom now holds `value` (a direct `set`/`reset`, an async
  *                 atom resolving, a cache revalidation, …; the originating
  *                 operation is on `StoreChangeMeta.source`).
+ *  - `"unset"`  — the store dropped its own value for the atom (`store.unset` /
+ *                 `txn.unset`); the atom now reverts to what it otherwise reads,
+ *                 carried as `value` (the inherited parent value on a scope, the
+ *                 default on a root). The atom still exists — this is NOT a
+ *                 `"delete"`. A flat value-mirror can read `value`; an
+ *                 inheritance-aware consumer switches on the kind to drop the
+ *                 override. `"unset"` is also on `StoreChangeMeta.source` for a
+ *                 standalone unset, but inside a transaction the source is
+ *                 `"transaction"`, so this per-change kind is the only signal
+ *                 distinguishing it from a set.
  *  - `"delete"` — the (family) atom was removed (`store.del` / `txn.del`). There
  *                 is no value: the entry is gone from the store.
  *
@@ -16,6 +26,12 @@ import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 export type StoreChange =
     | {
           kind: "set"
+          atom: Atom<any> | AtomFamilyAtom<any, any>
+          value: unknown
+          scope: string[]
+      }
+    | {
+          kind: "unset"
           atom: Atom<any> | AtomFamilyAtom<any, any>
           value: unknown
           scope: string[]

--- a/packages/valdres/src/types/StoreChangeSource.ts
+++ b/packages/valdres/src/types/StoreChangeSource.ts
@@ -7,11 +7,13 @@
  *  - `"unset"`       — `store.unset`: a store dropped its own value for an atom,
  *                      which now reverts to what it otherwise reads (a scope
  *                      re-inherits the parent; a root reverts to the default).
- *                      The reported change is a `"set"` carrying that reverted
- *                      value (NOT a `"delete"` — the atom still exists, only the
- *                      store's own value is gone). A consumer keying off
- *                      `source === "unset"` knows to drop the override from a
- *                      per-store view.
+ *                      The reported change is a `kind: "unset"` carrying that
+ *                      reverted value (NOT a `"delete"` — the atom still exists,
+ *                      only the store's own value is gone). A consumer keying off
+ *                      either `source === "unset"` or the per-change `kind` knows
+ *                      to drop the override from a per-store view. Note `txn.unset`
+ *                      reports `source === "transaction"`, so inside a txn the
+ *                      per-change `kind: "unset"` is the signal that survives.
  *  - `"transaction"` — `store.txn` (and the implicit commit in `batchUpdates` mode)
  *  - `"revalidate"`  — a maxAge / stale-while-revalidate cache refresh
  *  - `"async-set"`   — a previously-pending async value resolved (an async `set`


### PR DESCRIPTION
## What

Adds a `kind: "unset"` variant to the `StoreChange` discriminated union so an `unset` is distinguishable from a `set` at the **per-change** level — not just via the batch-level `meta.source`.

## Why

A `store.unset` / `txn.unset` reverts a store's own value to what it would otherwise read (the inherited parent value on a scope, the default on a root). It was reported on `onChange` as `{ kind: "set", value: <reverted> }`, distinguishable from a real write only by `meta.source === "unset"`.

That works for a standalone `store.unset` (the whole batch *is* the unset). It breaks inside a transaction: the batch source is necessarily `"transaction"`, and the per-change `kind: "set"` was the only remaining signal — so an inheritance-aware adapter mirroring changes outward would treat the inherited value as a fresh override instead of dropping it. Note a `delete` inside the same txn stayed distinguishable (`kind: "delete"`); only `unset` lost the thread.

## How

- New `{ kind: "unset", atom, value, scope }` variant in `StoreChange` (carries the reverted value).
- `reportUnsetAtom` emits `kind: "unset"` instead of `kind: "set"`. This is the **only** constructor of an unset change, and all three callers (standalone, single-store txn, cross-scope txn) route through it.
- `meta.source` is untouched (`"unset"` standalone, `"transaction"` in a txn). The per-change `kind` is now what disambiguates, making `unset` symmetric with `delete` — marked at both the batch and per-change level.

A flat value-mirror can still read `value`; an inheritance-aware consumer switches on `kind` to drop the override.

## Compatibility

`onChange` (#175) and `unset` (#177) are unreleased beta, so no shipped consumer depends on the old `kind: "set"` shape. The #177 changeset is amended to document the final shape rather than ship a contradiction (no separate changeset added).

## Test plan

- Red-first: added a mixed-txn test (`set(b)` + `unset(a)` in one transaction) asserting `a` reports `kind: "unset"` and `b` reports `kind: "set"`, with `meta.source === "transaction"`. Updated the three standalone assertions to the new contract.
- `bun test` (valdres): **475 pass / 0 fail**
- `tsgo --noEmit`: clean (no exhaustive-switch breakage)
- `bunx changeset status --since=origin/main`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)