### PR TITLE
feat(valdres): report selector changes through store.onChange

### DIFF
--- a/.changeset/onchange-selectors.md
+++ b/.changeset/onchange-selectors.md
@@ -1,0 +1,56 @@
+---
+"valdres": minor
+---
+
+`store.onChange` can now also report **selector** (derived state) changes, gated
+by an options object, and the `StoreChange` shape is reworked around `type` +
+`state`.
+
+**Options — two independent toggles:**
+
+- `atoms` (default `true`) — atom `set` / `unset` / `delete` changes.
+- `selectors` (default `false`) — selectors that recomputed to a new value.
+
+```ts
+store.onChange((changes, meta) => {
+  for (const c of changes) {
+    if (c.type === "selector") console.log("derived", c.state, "→", c.value)
+    else if (c.kind === "delete") console.log("deleted", c.state)
+    else console.log("atom", c.state, "→", c.value) // set | unset
+  }
+}, { selectors: true })
+
+// selectors only:
+store.onChange(cs => …, { atoms: false, selectors: true })
+```
+
+A `{ selectors: true }` listener additionally receives `{ type: "selector", state,
+value, scope }` for selectors that recomputed as a consequence of an operation —
+in the same single callback as the atom changes. Within a store's changes, atom
+entries precede that store's selector entries; descendant-scope recomputes carry
+their scope path.
+
+Only **live** selectors (those with a subscriber or a downstream dependent, i.e.
+already recomputed this pass) and only **genuine value changes** (respecting the
+selector's `equal`) are reported — so selector reporting forces no extra
+evaluation, and an orphaned selector whose cache is merely dropped is not
+reported. An async selector resolving surfaces as a `type: "selector"` change with
+`meta.source === "async-set"`. When no selector listener is active the propagation
+hot path is unchanged (gated on a global counter, no allocation).
+
+The callback's `changes` type follows the options: `AtomChange[]` by default,
+`StoreChange[]` with `{ selectors: true }`, `SelectorChange[]` with
+`{ atoms: false, selectors: true }`.
+
+**`StoreChange` shape.** `store.onChange` is unreleased, so this is its initial
+public shape (no migration from a prior release):
+
+- Each change has a `type` (`"atom" | "selector"`) and a `state` field — the
+  changed atom or selector. (`state` matches valdres's `State` type and the
+  `store.get`/`store.sub` parameter, so `store.get(change.state)` reads naturally.)
+- Atom changes carry a `kind`: `"set" | "unset" | "delete"`. Selector changes
+  have **no `kind`** — a selector has no operation, only a recomputed value.
+  Discriminate selector-vs-atom on `type`; switch on `kind` only after narrowing
+  to `type: "atom"`.
+- New exported types: `AtomChange`, `SelectorChange` (with
+  `StoreChange = AtomChange | SelectorChange`).

--- a/.changeset/store-onchange.md
+++ b/.changeset/store-onchange.md
@@ -12,12 +12,15 @@ stale-while-revalidate refreshes** and **async default resolutions**.
 
 The callback receives `(changes, meta)`:
 
-- `changes` — an array of `StoreChange`, a discriminated union on `kind`:
-  `{ kind: "set", atom, value, scope }` for a value change, or
-  `{ kind: "delete", atom, scope }` for a family-atom deletion (`store.del` /
-  `txn.del`) — a deletion carries no `value`. A direct `set`/`reset` (or an async
-  atom resolving) delivers a one-element array; a transaction delivers a single
-  callback with all of its changes.
+- `changes` — an array of `StoreChange`, discriminated on `type`
+  (`"atom" | "selector"`). Atom changes additionally carry a `kind`:
+  `{ type: "atom", kind: "set", state, value, scope }` for a value change,
+  `{ type: "atom", kind: "delete", state, scope }` for a family-atom deletion
+  (`store.del` / `txn.del`, no `value`), or `kind: "unset"` when a store drops its
+  own value. (Selector changes have no `kind` — see the selector-reporting
+  changeset.) A direct `set`/`reset` (or an async atom resolving) delivers the
+  change(s) from that operation; a transaction delivers a single callback with all
+  of its changes.
 - `scope` — the chain of scope ids from the outermost scope down to where the
   change occurred (the ids you'd pass to `.scope()` to reach it), empty (`[]`)
   for a root store. Unambiguous for nested scopes that share a leaf name. A

--- a/packages/valdres/src/index.ts
+++ b/packages/valdres/src/index.ts
@@ -53,7 +53,11 @@ export type { SetAtomValue } from "./types/SetAtomValue"
 export type { SyncSetAtom } from "./types/SyncSetAtom"
 export type { State } from "./types/State"
 export type { Store } from "./types/Store"
-export type { StoreChange } from "./types/StoreChange"
+export type {
+    AtomChange,
+    SelectorChange,
+    StoreChange,
+} from "./types/StoreChange"
 export type { StoreChangeCallback } from "./types/StoreChangeCallback"
 export type { StoreChangeMeta } from "./types/StoreChangeMeta"
 export type { StoreChangeSource } from "./types/StoreChangeSource"

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -15,6 +15,11 @@ import {
 import { getState } from "./getState"
 import { isLive, onLiveDependencyRemoved, unmountOrphanedDeps } from "./mountAtom"
 import {
+    changeListenerRegistry,
+    hasSelectorChangeListener,
+    reportSelectorChanges,
+} from "./notifyChangeListeners"
+import {
     propagateAtomUpdate,
     propagateDirtySelectors,
 } from "./propagateUpdatedAtoms"
@@ -320,13 +325,32 @@ export const handleSelectorResult = <Value>(
                 (subs && subs.size > 0) ||
                 (dependents && dependents.size > 0)
             ) {
+                // Collect downstream selectors that recompute as a result, so a
+                // `{ selectors: true }` listener sees them alongside this
+                // selector. Off the hot path unless a selector listener exists on
+                // this store's chain (not merely some unrelated root store).
+                const changedSelectors =
+                    changeListenerRegistry.selectorCount !== 0 &&
+                    hasSelectorChangeListener(data)
+                        ? new Set<Selector>()
+                        : undefined
                 propagateDirtySelectors(
                     [],
                     new Set(dependents),
                     data,
                     new Set(subs),
                     new Map(),
+                    false,
+                    undefined,
+                    changedSelectors,
                 )
+                if (changedSelectors) {
+                    // This selector itself just resolved from a pending promise
+                    // to `resolved` — a genuine value change. Report it (and the
+                    // downstream it triggered) as an "async-set" batch.
+                    changedSelectors.add(selector)
+                    reportSelectorChanges(changedSelectors, data, "async-set")
+                }
             }
         }).catch(() => {
             pendingAsyncDeps.delete(value as Promise<any>)

--- a/packages/valdres/src/lib/notifyChangeListeners.ts
+++ b/packages/valdres/src/lib/notifyChangeListeners.ts
@@ -1,10 +1,12 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+import type { Selector } from "../types/Selector"
 import type { StoreChange } from "../types/StoreChange"
 import type { StoreChangeMeta } from "../types/StoreChangeMeta"
 import type { StoreChangeSource } from "../types/StoreChangeSource"
 import type { StoreData } from "../types/StoreData"
 import { isAtomFamily } from "../utils/isAtomFamily"
+import { isSelectorFamily } from "../utils/isSelectorFamily"
 
 /** One store's slice of an operation's changes. */
 export type ChangeGroup = {
@@ -16,7 +18,12 @@ export type ChangeGroup = {
  *  threaded (like NotifyTarget) through the commit's per-store propagation
  *  passes, and flushed once at the end — so a whole transaction produces exactly
  *  one `onChange` callback, serializable by construction (no save/restore global
- *  state; reentrancy is handled by each commit owning its own sink). */
+ *  state; reentrancy is handled by each commit owning its own sink).
+ *
+ *  Also used by the immediate (non-transaction) path when a selector listener is
+ *  active: a single set/del that cascades selector recomputes into descendant
+ *  scopes produces multiple groups, and buffering them into one sink (tagged
+ *  with the real `source`, not `"transaction"`) keeps it one callback. */
 export type ChangeSink = {
     source: StoreChangeSource
     name: string | undefined
@@ -29,13 +36,16 @@ export type ChangeSink = {
  *  Passed as a normal argument — never ambient state. */
 export type ChangeReport = StoreChangeSource | ChangeSink
 
-/** Global listener count across every store — the cheap "is anyone watching at
- *  all" gate. Every emit site checks `count !== 0` first, so when nothing
- *  anywhere is watching (the overwhelmingly common case) the change pipeline
- *  does a single property read and no work or allocation. Maintained by
- *  onStoreChange. (Unlike the per-commit sink, this is legitimately global: it
- *  only changes on subscribe/unsubscribe, never mid-traversal.) */
-export const changeListenerRegistry = { count: 0 }
+/** Global listener counts across every store — the cheap "is anyone watching"
+ *  gates. Every emit site checks `count !== 0` first, so when nothing anywhere
+ *  is watching (the overwhelmingly common case) the change pipeline does a
+ *  single property read and no work or allocation. `selectorCount` is the same
+ *  gate for selector reporting: when zero, selector collection never allocates
+ *  and the propagation hot path is byte-identical to before the feature.
+ *  Maintained by onStoreChange. (Unlike the per-commit sink, these are
+ *  legitimately global: they only change on subscribe/unsubscribe, never
+ *  mid-traversal.) */
+export const changeListenerRegistry = { count: 0, selectorCount: 0 }
 
 /** True iff `data` or any ancestor store has a change listener. Short-circuits
  *  on the global count, then walks the parent chain (a change in a scope is
@@ -46,6 +56,24 @@ export const hasChangeListener = (data: StoreData): boolean => {
     while (store) {
         const listeners = store.changeListeners
         if (listeners !== undefined && listeners.size > 0) return true
+        store = store.parent
+    }
+    return false
+}
+
+/** True iff `data` or any ancestor has a listener that opted into selector
+ *  changes. Gates whether selector entries are worth emitting for a change in
+ *  `data`. Short-circuits on the global selectorCount. */
+export const hasSelectorChangeListener = (data: StoreData): boolean => {
+    if (changeListenerRegistry.selectorCount === 0) return false
+    let store: StoreData | undefined = data
+    while (store) {
+        const listeners = store.changeListeners
+        if (listeners !== undefined) {
+            for (const flags of listeners.values()) {
+                if (flags.selectors) return true
+            }
+        }
         store = store.parent
     }
     return false
@@ -70,7 +98,12 @@ const scopePath = (data: StoreData): string[] => {
  *  A listener on store S receives the changes that occurred in S or any of its
  *  descendant scopes — and only those. We achieve that by walking each group's
  *  origin store up the parent chain and accumulating that group's changes into
- *  every ancestor (and the origin itself) that has listeners. */
+ *  every ancestor (and the origin itself) that has listeners.
+ *
+ *  A listener that did NOT opt into selectors receives only `type: "atom"`
+ *  entries (an atoms-only view, built lazily per bucket). Selector entries only
+ *  exist when a selector listener is active, so the common path hands every
+ *  listener the same array with no filtering. */
 export const notifyChangeListeners = (
     groups: ChangeGroup[],
     meta: StoreChangeMeta,
@@ -100,13 +133,46 @@ export const notifyChangeListeners = (
         // so this store's set can be gone by the time we reach it.
         const listeners = store.changeListeners
         if (listeners === undefined || listeners.size === 0) continue
+        // Per-listener views, built at most once per bucket and only when a
+        // listener actually needs a filtered slice. When the bucket has no
+        // selector entries (the common case) `atomOnly` is the original array —
+        // no allocation; likewise `selectorOnly` when there are no atom entries.
+        let hasSelector: boolean | undefined
+        let hasAtom: boolean | undefined
+        let atomOnly: readonly StoreChange[] | undefined
+        let selectorOnly: readonly StoreChange[] | undefined
         // Snapshot so a listener that unsubscribes mid-dispatch doesn't skip a
         // sibling, and capture errors so one listener can't starve the rest.
         let firstError: unknown
         let hasError = false
-        for (const listener of [...listeners]) {
+        for (const [listener, flags] of [...listeners]) {
+            let payload: readonly StoreChange[]
+            if (flags.atoms && flags.selectors) {
+                payload = changes
+            } else if (flags.atoms) {
+                if (atomOnly === undefined) {
+                    hasSelector ??= changes.some(c => c.type === "selector")
+                    atomOnly = hasSelector
+                        ? changes.filter(c => c.type === "atom")
+                        : changes
+                }
+                payload = atomOnly
+            } else if (flags.selectors) {
+                if (selectorOnly === undefined) {
+                    hasAtom ??= changes.some(c => c.type === "atom")
+                    selectorOnly = hasAtom
+                        ? changes.filter(c => c.type === "selector")
+                        : changes
+                }
+                payload = selectorOnly
+            } else {
+                continue // listener opted out of everything
+            }
+            // Don't fire an empty callback — e.g. an atoms-only listener whose
+            // bucket carried only descendant-scope selector changes.
+            if (payload.length === 0) continue
             try {
-                listener(changes, meta)
+                listener(payload, meta)
             } catch (error) {
                 if (!hasError) {
                     firstError = error
@@ -119,20 +185,26 @@ export const notifyChangeListeners = (
 }
 
 /** Build one store's change group from the atoms that changed and/or were
- *  deleted in it. Changed atoms become `{ kind: "set", value }` (value read back
- *  out of `data.values` — values are always written before propagation runs);
- *  deleted atoms become `{ kind: "delete" }` with no value.
+ *  deleted in it, plus any selectors that recomputed to a new value. Changed
+ *  atoms become `{ type: "atom", kind: "set", value }` (value read back out of
+ *  `data.values` — values are always written before propagation runs); deleted
+ *  atoms become `{ kind: "delete" }` with no value; changed selectors become
+ *  `{ type: "selector", value }` (no `kind` — a selector has no operation),
+ *  appended AFTER the atom entries so a store's atoms precede its derived
+ *  changes.
  *
- *  Skipped: valdres-internal atoms (`__valdresInternal`, e.g. cacheMeta) and
- *  atom-family container objects (an `AtomFamily` flows through propagation when
- *  its membership changes, but individual members are reported on their own as
- *  family-atom sets/deletions — the container is internal bookkeeping). `atoms`
- *  may contain duplicates (writeAtoms merges lazily-initialized atoms into its
- *  changed list); we dedupe by identity. */
+ *  Skipped: valdres-internal atoms/selectors (`__valdresInternal`, e.g.
+ *  cacheMeta) and family container objects (an `AtomFamily`/`SelectorFamily`
+ *  flows through propagation when its membership changes, but individual members
+ *  are reported on their own). A selector whose re-eval threw has its cached
+ *  value dropped — skipped, there is no value to report. `atoms` may contain
+ *  duplicates (writeAtoms merges lazily-initialized atoms into its changed
+ *  list); we dedupe by identity. */
 const buildChangeGroup = (
     data: StoreData,
     changedAtoms?: (Atom<any> | AtomFamilyAtom<any, any>)[],
     deletedAtoms?: (Atom<any> | AtomFamilyAtom<any, any>)[],
+    changedSelectors?: Set<Selector<any>>,
 ): ChangeGroup => {
     const scope = scopePath(data)
     const changes: StoreChange[] = []
@@ -142,13 +214,35 @@ const buildChangeGroup = (
             if (atom.__valdresInternal || isAtomFamily(atom)) continue
             if (seen?.has(atom)) continue
             ;(seen ??= new Set()).add(atom)
-            changes.push({ kind: "set", atom, value: data.values.get(atom), scope })
+            changes.push({
+                type: "atom",
+                kind: "set",
+                state: atom,
+                value: data.values.get(atom),
+                scope,
+            })
         }
     }
     if (deletedAtoms) {
         for (const atom of deletedAtoms) {
             if (atom.__valdresInternal || isAtomFamily(atom)) continue
-            changes.push({ kind: "delete", atom, scope })
+            changes.push({ type: "atom", kind: "delete", state: atom, scope })
+        }
+    }
+    if (changedSelectors) {
+        for (const selector of changedSelectors) {
+            if (
+                (selector as { __valdresInternal?: boolean }).__valdresInternal ||
+                isSelectorFamily(selector)
+            )
+                continue
+            if (!data.values.has(selector)) continue
+            changes.push({
+                type: "selector",
+                state: selector,
+                value: data.values.get(selector),
+                scope,
+            })
         }
     }
     return { data, changes }
@@ -156,7 +250,7 @@ const buildChangeGroup = (
 
 /** Route one group per `report`: buffer into a transaction sink, or fire
  *  immediately tagged with the source. Internal — call via reportAtomChanges /
- *  reportDeletedAtoms. */
+ *  reportDeletedAtoms / reportSelectorChanges. */
 const emitGroup = (group: ChangeGroup, report: ChangeReport) => {
     if (group.changes.length === 0) return
     if (typeof report === "string") {
@@ -167,15 +261,22 @@ const emitGroup = (group: ChangeGroup, report: ChangeReport) => {
 }
 
 /** Report the atoms whose values just changed in `data` (called from
- *  propagateAtomUpdate, after values are written). Guards on the precise
- *  ancestor check so a store nobody watches does no allocation. */
+ *  propagateAtomUpdate, after values are written), plus any selectors that
+ *  recomputed in the same pass. Guards on the precise ancestor check so a store
+ *  nobody watches does no allocation; selectors are appended only when an
+ *  ancestor actually wants them. */
 export const reportAtomChanges = (
     atoms: (Atom<any> | AtomFamilyAtom<any, any>)[],
     data: StoreData,
     report: ChangeReport,
+    changedSelectors?: Set<Selector<any>>,
 ) => {
     if (!hasChangeListener(data)) return
-    emitGroup(buildChangeGroup(data, atoms), report)
+    const selectors =
+        changedSelectors && changedSelectors.size > 0 && hasSelectorChangeListener(data)
+            ? changedSelectors
+            : undefined
+    emitGroup(buildChangeGroup(data, atoms, undefined, selectors), report)
 }
 
 /** Report that `data`'s own value for `atom` was unset (called from unsetValue,
@@ -198,31 +299,61 @@ export const reportUnsetAtom = (
     const group: ChangeGroup = {
         data,
         changes: [
-            { kind: "unset", atom, value: revertedValue, scope: scopePath(data) },
+            {
+                type: "atom",
+                kind: "unset",
+                state: atom,
+                value: revertedValue,
+                scope: scopePath(data),
+            },
         ],
     }
     emitGroup(group, report)
 }
 
-/** Report deleted family atoms in `data` (called from propagateDeletedAtoms). */
+/** Report deleted family atoms in `data` (called from propagateDeletedAtoms),
+ *  plus any selectors the deletion recomputed. */
 export const reportDeletedAtoms = (
     atoms: (Atom<any> | AtomFamilyAtom<any, any>)[],
     data: StoreData,
     report: ChangeReport,
+    changedSelectors?: Set<Selector<any>>,
 ) => {
     if (!hasChangeListener(data)) return
-    emitGroup(buildChangeGroup(data, undefined, atoms), report)
+    const selectors =
+        changedSelectors && changedSelectors.size > 0 && hasSelectorChangeListener(data)
+            ? changedSelectors
+            : undefined
+    emitGroup(buildChangeGroup(data, undefined, atoms, selectors), report)
 }
 
-/** Create a transaction's change sink. `source` is `"transaction"`; `name` is
- *  the optional `store.txn(fn, name)` label. */
-export const createChangeSink = (name: string | undefined): ChangeSink => ({
-    source: "transaction",
+/** Report selectors that recomputed in a descendant scope where no atom value
+ *  changed (called from propagateInScope). Emits a selector-only group, and only
+ *  when an ancestor actually opted into selector changes. */
+export const reportSelectorChanges = (
+    changedSelectors: Set<Selector<any>>,
+    data: StoreData,
+    report: ChangeReport,
+) => {
+    if (changedSelectors.size === 0) return
+    if (!hasSelectorChangeListener(data)) return
+    emitGroup(buildChangeGroup(data, undefined, undefined, changedSelectors), report)
+}
+
+/** Create a change sink. `source` defaults to `"transaction"` (the txn commit
+ *  path); the immediate path passes the operation's real source so a cascaded,
+ *  buffered batch still reports its true origin. `name` is the optional
+ *  `store.txn(fn, name)` label. */
+export const createChangeSink = (
+    name: string | undefined,
+    source: StoreChangeSource = "transaction",
+): ChangeSink => ({
+    source,
     name,
     groups: [],
 })
 
-/** Flush a transaction's accumulated changes as a single callback. */
+/** Flush a sink's accumulated changes as a single callback. */
 export const flushChangeSink = (sink: ChangeSink) => {
     if (sink.groups.length > 0) {
         notifyChangeListeners(sink.groups, { source: sink.source, name: sink.name })

--- a/packages/valdres/src/lib/onStoreChange.test.ts
+++ b/packages/valdres/src/lib/onStoreChange.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock } from "bun:test"
 import { store } from "../store"
 import { atom } from "../atom"
 import { atomFamily } from "../atomFamily"
+import { selector } from "../selector"
 import type { StoreChange } from "../types/StoreChange"
 import { wait } from "../../test/utils/wait"
 
@@ -30,7 +31,9 @@ describe("store.onChange", () => {
         store1.set(atom1, 2)
 
         expect(calls.length).toBe(1)
-        expect(calls[0]).toEqual([{ kind: "set", atom: atom1, value: 2, scope: [] }])
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: atom1, value: 2, scope: [] },
+        ])
         unsub()
     })
 
@@ -55,7 +58,9 @@ describe("store.onChange", () => {
 
         store1.reset(atom1)
 
-        expect(calls).toEqual([[{ kind: "set", atom: atom1, value: 1, scope: [] }]])
+        expect(calls).toEqual([
+            [{ type: "atom", kind: "set", state: atom1, value: 1, scope: [] }],
+        ])
         unsub()
     })
 
@@ -73,8 +78,8 @@ describe("store.onChange", () => {
 
         expect(calls.length).toBe(1)
         expect(calls[0]).toEqual([
-            { kind: "set", atom: atom1, value: 2, scope: [] },
-            { kind: "set", atom: atom2, value: "b", scope: [] },
+            { type: "atom", kind: "set", state: atom1, value: 2, scope: [] },
+            { type: "atom", kind: "set", state: atom2, value: "b", scope: [] },
         ])
         unsub()
     })
@@ -93,7 +98,9 @@ describe("store.onChange", () => {
         })
 
         expect(calls.length).toBe(1)
-        expect(calls[0]).toEqual([{ kind: "set", atom: atom2, value: 3, scope: [] }])
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: atom2, value: 3, scope: [] },
+        ])
         unsub()
     })
 
@@ -210,7 +217,7 @@ describe("store.onChange", () => {
         await Promise.resolve()
         await Promise.resolve()
 
-        const change = calls.flat().find(c => c.atom === asyncAtom)
+        const change = calls.flat().find(c => c.state === asyncAtom)
         expect(change).toMatchObject({ kind: "set", value: 42 })
         unsub()
     })
@@ -229,18 +236,23 @@ describe("store.onChange", () => {
         // reports the refreshed value — the change that previously bypassed
         // onChange entirely.
         await waitFor(() => {
-            const reported = changes.filter(c => c.atom === atom1)
+            const reported = changes.filter(c => c.state === atom1)
             expect(
-                reported.some(c => c.kind === "set" && (c.value as number) >= 2),
+                reported.some(
+                    c =>
+                        c.type === "atom" &&
+                        c.kind === "set" &&
+                        (c.value as number) >= 2,
+                ),
             ).toBe(true)
         })
 
         // The cacheMeta atom updates on every tick but must never surface.
-        expect(changes.some(c => c.atom === (atom1 as any).__cacheMeta)).toBe(
+        expect(changes.some(c => c.state === (atom1 as any).__cacheMeta)).toBe(
             false,
         )
         expect(
-            changes.some(c => (c.atom as any).__valdresInternal === true),
+            changes.some(c => (c.state as any).__valdresInternal === true),
         ).toBe(false)
 
         unsubAtom()
@@ -302,7 +314,15 @@ describe("store.onChange", () => {
         child.set(atom1, "scoped")
 
         expect(calls).toEqual([
-            [{ kind: "set", atom: atom1, value: "scoped", scope: ["child"] }],
+            [
+                {
+                    type: "atom",
+                    kind: "set",
+                    state: atom1,
+                    value: "scoped",
+                    scope: ["child"],
+                },
+            ],
         ])
         unsub()
     })
@@ -319,11 +339,20 @@ describe("store.onChange", () => {
         nested.set(atom1, "nested-value")
 
         expect(calls).toEqual([
-            [{ kind: "set", atom: atom1, value: "root-value", scope: [] }],
             [
                 {
+                    type: "atom",
                     kind: "set",
-                    atom: atom1,
+                    state: atom1,
+                    value: "root-value",
+                    scope: [],
+                },
+            ],
+            [
+                {
+                    type: "atom",
+                    kind: "set",
+                    state: atom1,
                     value: "nested-value",
                     scope: ["child", "nested"],
                 },
@@ -345,7 +374,15 @@ describe("store.onChange", () => {
         childA.set(atom1, "a") // in the subtree — seen
 
         expect(aCalls).toEqual([
-            [{ kind: "set", atom: atom1, value: "a", scope: ["a"] }],
+            [
+                {
+                    type: "atom",
+                    kind: "set",
+                    state: atom1,
+                    value: "a",
+                    scope: ["a"],
+                },
+            ],
         ])
         unsub()
     })
@@ -367,8 +404,14 @@ describe("store.onChange", () => {
 
         expect(calls.length).toBe(1)
         expect(calls[0]).toEqual([
-            { kind: "set", atom: atom1, value: 1, scope: [] },
-            { kind: "set", atom: atom2, value: 2, scope: ["child"] },
+            { type: "atom", kind: "set", state: atom1, value: 1, scope: [] },
+            {
+                type: "atom",
+                kind: "set",
+                state: atom2,
+                value: 2,
+                scope: ["child"],
+            },
         ])
         unsub()
     })
@@ -386,7 +429,7 @@ describe("store.onChange", () => {
         expect(calls.length).toBe(1)
         expect(calls[0][0]).toMatchObject({
             kind: "set",
-            atom: atom1,
+            state: atom1,
             value: promise,
         })
 
@@ -395,7 +438,9 @@ describe("store.onChange", () => {
 
         // The resolution is reported as a separate change.
         expect(calls.length).toBe(2)
-        expect(calls[1]).toEqual([{ kind: "set", atom: atom1, value: 42, scope: [] }])
+        expect(calls[1]).toEqual([
+            { type: "atom", kind: "set", state: atom1, value: 42, scope: [] },
+        ])
         unsub()
     })
 
@@ -408,7 +453,7 @@ describe("store.onChange", () => {
         store1.set(family("x"), "custom")
 
         const familyAtom = family("x")
-        const reported = calls.flat().find(c => c.atom === familyAtom)
+        const reported = calls.flat().find(c => c.state === familyAtom)
         expect(reported).toMatchObject({ kind: "set", value: "custom" })
         unsub()
     })
@@ -424,8 +469,13 @@ describe("store.onChange", () => {
         store1.del(familyAtom)
 
         expect(calls.length).toBe(1)
-        const change = calls[0].find(c => c.atom === familyAtom)
-        expect(change).toEqual({ kind: "delete", atom: familyAtom, scope: [] })
+        const change = calls[0].find(c => c.state === familyAtom)
+        expect(change).toEqual({
+            type: "atom",
+            kind: "delete",
+            state: familyAtom,
+            scope: [],
+        })
         expect(change).not.toHaveProperty("value")
         unsub()
     })
@@ -445,11 +495,19 @@ describe("store.onChange", () => {
         })
 
         expect(calls.length).toBe(1)
-        const valueChange = calls[0].find(c => c.atom === atom1)
-        expect(valueChange).toEqual({ kind: "set", atom: atom1, value: 2, scope: [] })
-        const deletion = calls[0].find(c => c.kind === "delete")
+        const valueChange = calls[0].find(c => c.state === atom1)
+        expect(valueChange).toEqual({
+            type: "atom",
+            kind: "set",
+            state: atom1,
+            value: 2,
+            scope: [],
+        })
+        const deletion = calls[0].find(
+            c => c.type === "atom" && c.kind === "delete",
+        )
         expect(deletion).toBeDefined()
-        expect(deletion!.atom).toBe(familyAtom)
+        expect(deletion!.state).toBe(familyAtom)
         unsub()
     })
 
@@ -528,9 +586,547 @@ describe("store.onChange", () => {
 
         expect(calls.length).toBe(1)
         expect(calls[0]).toEqual([
-            { kind: "set", atom: atom1, value: 10, scope: [] },
-            { kind: "set", atom: atom2, value: 20, scope: [] },
+            { type: "atom", kind: "set", state: atom1, value: 10, scope: [] },
+            { type: "atom", kind: "set", state: atom2, value: 20, scope: [] },
         ])
         unsub()
+    })
+})
+
+describe("store.onChange — selectors", () => {
+    test("reports a selector recompute when opted in, atom before selector", () => {
+        const store1 = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = store1.sub(double, () => {}) // make the selector live
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        store1.set(a, 5)
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 5, scope: [] },
+            { type: "selector", state: double, value: 10, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("does not report selectors to a listener that did not opt in", () => {
+        const store1 = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = store1.sub(double, () => {})
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes)) // no opt-in
+
+        store1.set(a, 5)
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 5, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("does not report a selector whose value did not change", () => {
+        const store1 = store()
+        const a = atom(1)
+        const isEven = selector(get => get(a) % 2 === 0)
+        const unsubSel = store1.sub(isEven, () => {})
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        store1.set(a, 3) // 1 → 3: both odd, isEven stays false
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 3, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("does not report a selector with no live consumer (orphaned)", () => {
+        const store1 = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        store1.get(double) // registers the dependency, but no subscriber → not live
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        store1.set(a, 2)
+
+        const all = calls.flat()
+        expect(all.some(c => c.type === "selector")).toBe(false)
+        expect(all.some(c => c.type === "atom" && c.state === a)).toBe(true)
+        unsub()
+    })
+
+    test("reports chained selectors in dependency order, after the atom", () => {
+        const store1 = store()
+        const a = atom(1)
+        const b = selector(get => get(a) * 2)
+        const c = selector(get => get(b) + 1)
+        const unsubSel = store1.sub(c, () => {}) // c live → b live (its dependency)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        store1.set(a, 10)
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 10, scope: [] },
+            { type: "selector", state: b, value: 20, scope: [] },
+            { type: "selector", state: c, value: 21, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("a transaction batches atom and selector changes into one callback", () => {
+        const store1 = store()
+        const a = atom(1)
+        const a2 = atom("x")
+        const double = selector(get => get(a) * 2)
+        const unsubSel = store1.sub(double, () => {})
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        store1.txn(({ set }) => {
+            set(a, 5)
+            set(a2, "y")
+        })
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 5, scope: [] },
+            { type: "atom", kind: "set", state: a2, value: "y", scope: [] },
+            { type: "selector", state: double, value: 10, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("reports a scoped selector recompute with its scope path, exactly once", () => {
+        const root = store("root")
+        const child = root.scope("child")
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = child.sub(double, () => {}) // live in the child scope
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        root.set(a, 5)
+
+        expect(calls.length).toBe(1)
+        const atomChange = calls[0].find(c => c.type === "atom")
+        expect(atomChange).toEqual({
+            type: "atom",
+            kind: "set",
+            state: a,
+            value: 5,
+            scope: [],
+        })
+        const selChange = calls[0].find(c => c.type === "selector")
+        expect(selChange).toEqual({
+            type: "selector",
+            state: double,
+            value: 10,
+            scope: ["child"],
+        })
+        unsub()
+        unsubSel()
+    })
+
+    test("only listeners that opted in receive selector changes", () => {
+        const store1 = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = store1.sub(double, () => {})
+        const withSel: (readonly StoreChange[])[] = []
+        const plain: (readonly StoreChange[])[] = []
+        const u1 = store1.onChange(c => withSel.push(c), { selectors: true })
+        const u2 = store1.onChange(c => plain.push(c))
+
+        store1.set(a, 2)
+
+        // opted-in listener sees both the atom and the selector
+        expect(
+            withSel.flat().some(c => c.type === "selector" && c.state === double),
+        ).toBe(true)
+        expect(withSel.flat().some(c => c.type === "atom" && c.state === a)).toBe(
+            true,
+        )
+        // plain listener sees only the atom
+        expect(plain.flat().some(c => c.type === "selector")).toBe(false)
+        expect(plain.flat().some(c => c.type === "atom" && c.state === a)).toBe(
+            true,
+        )
+        u1()
+        u2()
+        unsubSel()
+    })
+
+    test("{ atoms: false, selectors: true } delivers only selector changes", () => {
+        const store1 = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = store1.sub(double, () => {})
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            atoms: false,
+            selectors: true,
+        })
+
+        store1.set(a, 5)
+
+        // the atom set is filtered out; only the derived recompute is delivered
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "selector", state: double, value: 10, scope: [] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("{ atoms: false } listener does not fire for a pure atom change", () => {
+        const store1 = store()
+        const a = atom(1) // no dependent selector
+        const cb = mock()
+        const unsub = store1.onChange(cb, { atoms: false, selectors: true })
+
+        store1.set(a, 2)
+
+        expect(cb).not.toHaveBeenCalled()
+        unsub()
+    })
+
+    test("an async selector resolving reports a type:selector change with source 'async-set'", async () => {
+        const store1 = store()
+        const asyncSel = selector(() => Promise.resolve(42))
+        const calls: { changes: readonly StoreChange[]; meta: any }[] = []
+        const unsub = store1.onChange(
+            (changes, meta) => calls.push({ changes, meta }),
+            { selectors: true },
+        )
+        const unsubSel = store1.sub(asyncSel, () => {}) // live + triggers eval
+
+        await waitFor(() => {
+            const c = calls
+                .flatMap(x => x.changes)
+                .find(c => c.type === "selector")
+            expect(c).toBeDefined()
+        })
+
+        const entry = calls.find(x =>
+            x.changes.some(c => c.type === "selector"),
+        )!
+        expect(entry.meta.source).toBe("async-set")
+        const change = entry.changes.find(c => c.type === "selector")
+        expect(change).toMatchObject({
+            type: "selector",
+            state: asyncSel,
+            value: 42,
+        })
+        unsub()
+        unsubSel()
+    })
+
+    test("reports a selector that recomputes from a family-atom deletion", () => {
+        const store1 = store()
+        const family = atomFamily((_id: string) => 0)
+        const x = family("x")
+        store1.set(x, 5)
+        const double = selector(get => get(x) * 2)
+        const unsubSel = store1.sub(double, () => {}) // live
+        expect(store1.get(double)).toBe(10)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = store1.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        // del recomputes `double` (it reads the now-deleted member); the
+        // recomputed value differs, so it's reported. This exercises the
+        // delete-path selector reporting in propagateDeletedAtoms. (We don't
+        // assert the recomputed value: reading a deleted family member is a
+        // pre-existing valdres quirk, orthogonal to onChange.)
+        store1.del(x)
+
+        expect(calls.length).toBe(1)
+        expect(
+            calls[0].find(c => c.type === "atom" && c.kind === "delete"),
+        ).toMatchObject({
+            type: "atom",
+            kind: "delete",
+            state: x,
+        })
+        const sel = calls[0].find(c => c.type === "selector")
+        expect(sel?.state).toBe(double)
+        unsub()
+        unsubSel()
+    })
+
+    test("reports a selector recompute two scope levels deep, with its full path", () => {
+        const root = store("root")
+        const child = root.scope("child")
+        const grandchild = child.scope("grand")
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = grandchild.sub(double, () => {}) // live in the grandchild
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        root.set(a, 5)
+
+        expect(calls.length).toBe(1)
+        const sel = calls[0].find(c => c.type === "selector")
+        expect(sel).toEqual({
+            type: "selector",
+            state: double,
+            value: 10,
+            scope: ["child", "grand"],
+        })
+        unsub()
+        unsubSel()
+    })
+
+    test("a cross-scope change reports atoms before descendant-scope selectors (txn too)", () => {
+        const root = store("root")
+        const child = root.scope("child")
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        const unsubSel = child.sub(double, () => {}) // live in the child scope
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(changes => calls.push(changes), {
+            selectors: true,
+        })
+
+        // A transaction routes through a ChangeSink; the origin atom must still
+        // precede the descendant-scope selector (matching the immediate path).
+        root.txn(t => t.set(a, 5))
+
+        expect(calls.length).toBe(1)
+        expect(calls[0]).toEqual([
+            { type: "atom", kind: "set", state: a, value: 5, scope: [] },
+            { type: "selector", state: double, value: 10, scope: ["child"] },
+        ])
+        unsub()
+        unsubSel()
+    })
+
+    test("an unset reports a dependent selector's recompute", () => {
+        const s = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        s.set(a, 5) // a = 5 → double = 10
+        s.sub(double, () => {}) // live
+        expect(s.get(double)).toBe(10)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = s.onChange(c => calls.push(c), { selectors: true })
+
+        s.unset(a) // a reverts to default 1 → double recomputes 10 → 2
+
+        expect(calls.length).toBe(1)
+        expect(calls[0].find(c => c.type === "atom")).toMatchObject({
+            type: "atom",
+            kind: "unset",
+            state: a,
+            value: 1,
+        })
+        const sel = calls[0].find(c => c.type === "selector")
+        expect(sel).toEqual({
+            type: "selector",
+            state: double,
+            value: 2,
+            scope: [],
+        })
+        unsub()
+    })
+
+    test("an unset inside a transaction reports a dependent selector's recompute", () => {
+        const s = store()
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        s.set(a, 5)
+        s.sub(double, () => {})
+        const calls: { changes: readonly StoreChange[]; meta: any }[] = []
+        const unsub = s.onChange((c, meta) => calls.push({ changes: c, meta }), {
+            selectors: true,
+        })
+
+        s.txn(t => t.unset(a))
+
+        expect(calls.length).toBe(1)
+        expect(calls[0].meta.source).toBe("transaction")
+        const sel = calls[0].changes.find(c => c.type === "selector")
+        expect(sel).toEqual({
+            type: "selector",
+            state: double,
+            value: 2,
+            scope: [],
+        })
+        unsub()
+    })
+
+    test("an unset reports a descendant-scope selector recompute with its scope path", () => {
+        const root = store("root")
+        const child = root.scope("child")
+        const a = atom(1)
+        const double = selector(get => get(a) * 2)
+        root.set(a, 5)
+        child.sub(double, () => {}) // double live in the child, reads inherited a
+        expect(child.get(double)).toBe(10)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(c => calls.push(c), { selectors: true })
+
+        root.unset(a) // root a → default 1; child's double recomputes 10 → 2
+
+        expect(calls.length).toBe(1)
+        expect(calls[0].find(c => c.type === "atom")).toMatchObject({
+            type: "atom",
+            kind: "unset",
+            state: a,
+            value: 1,
+            scope: [],
+        })
+        const sel = calls[0].find(c => c.type === "selector")
+        expect(sel).toEqual({
+            type: "selector",
+            state: double,
+            value: 2,
+            scope: ["child"],
+        })
+        unsub()
+    })
+
+    test("an immediate del reports a descendant-scope selector recompute", () => {
+        // Synergy with the immediate-del scope cascade (#181): root.del now
+        // re-evaluates dependent selectors in descendant scopes, and selector
+        // reporting threads through that cascade — so the scoped recompute is
+        // reported, scope-tagged, in the same callback as the delete.
+        const root = store("root")
+        const child = root.scope("child")
+        const fam = atomFamily((_id: string) => 0)
+        const x = fam("x")
+        root.set(x, 5)
+        const sel = selector(get => get(x))
+        child.sub(sel, () => {}) // live in the child, reads inherited x = 5
+        expect(child.get(sel)).toBe(5)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(c => calls.push(c), { selectors: true })
+
+        root.del(x) // cascades to child; sel recomputes 5 → 0 (deleted → default)
+
+        expect(calls.length).toBe(1)
+        expect(
+            calls[0].find(c => c.type === "atom" && c.kind === "delete"),
+        ).toMatchObject({ type: "atom", kind: "delete", state: x, scope: [] })
+        const sc = calls[0].find(c => c.type === "selector")
+        expect(sc).toEqual({
+            type: "selector",
+            state: sel,
+            value: 0,
+            scope: ["child"],
+        })
+        unsub()
+    })
+
+    test("a multi-atom transaction reports a descendant-scope selector recompute", () => {
+        // Guards the multi-atom no-shadow branch of propagateToScopes (distinct
+        // from the single-atom fast path every other scope test exercises) — the
+        // exact path where report threading was once silently dropped.
+        const root = store("root")
+        const child = root.scope("child")
+        const a = atom(1)
+        const b = atom(2)
+        const sum = selector(get => get(a) + get(b))
+        child.sub(sum, () => {}) // live in the child; reads inherited a, b → 3
+        expect(child.get(sum)).toBe(3)
+        const calls: (readonly StoreChange[])[] = []
+        const unsub = root.onChange(c => calls.push(c), { selectors: true })
+
+        root.txn(t => {
+            t.set(a, 10)
+            t.set(b, 20)
+        })
+
+        expect(calls.length).toBe(1)
+        expect(calls[0].filter(c => c.type === "atom").length).toBe(2)
+        const sc = calls[0].find(c => c.type === "selector")
+        expect(sc).toEqual({
+            type: "selector",
+            state: sum,
+            value: 30,
+            scope: ["child"],
+        })
+        unsub()
+    })
+
+    // Compile-time contract: the callback's `changes` type follows the options.
+    // These listeners never fire (immediately unsubscribed) — the value is the
+    // type annotations below, which only mean something under a typecheck. NB:
+    // this is NOT gated in CI — `build:types` compiles only `src/index.ts` (not
+    // tests), and a repo-root `tsgo` carries many pre-existing errors. The
+    // contract holds today (verified by local typecheck); keep these in sync if
+    // the overloads change, and run `tsgo` on this file to re-verify.
+    test("callback change type follows the options (compile-time)", () => {
+        const s = store()
+        // default → AtomChange[]: `kind` is reachable without narrowing on type
+        s.onChange(changes => {
+            for (const c of changes) {
+                const kind: "set" | "unset" | "delete" = c.kind
+                void kind
+            }
+        })()
+        // { atoms: false, selectors: true } → SelectorChange[]: every entry is a selector
+        s.onChange(
+            changes => {
+                for (const c of changes) {
+                    const type: "selector" = c.type
+                    void type
+                }
+            },
+            { atoms: false, selectors: true },
+        )()
+        // { selectors: true } → StoreChange[]: discriminate on `type` first
+        s.onChange(
+            changes => {
+                for (const c of changes) {
+                    const type: "atom" | "selector" = c.type
+                    void type
+                }
+            },
+            { selectors: true },
+        )()
+        // { atoms: true, selectors: true } — the explicit "both" spelling — must
+        // also resolve to StoreChange[] (regression guard for the overload that
+        // previously rejected this literal).
+        s.onChange(
+            changes => {
+                for (const c of changes) {
+                    const type: "atom" | "selector" = c.type
+                    void type
+                }
+            },
+            { atoms: true, selectors: true },
+        )()
+        expect(true).toBe(true)
     })
 })

--- a/packages/valdres/src/lib/onStoreChange.ts
+++ b/packages/valdres/src/lib/onStoreChange.ts
@@ -3,28 +3,51 @@ import type { StoreData } from "../types/StoreData"
 import { changeListenerRegistry } from "./notifyChangeListeners"
 
 /** Register a store-wide change listener on `data`. The listener fires once per
- *  committed operation with every atom that changed in this store or any of its
- *  descendant scopes. Returns an unsubscribe function. */
+ *  committed operation with the changes in this store or any descendant scope.
+ *  Returns an unsubscribe function.
+ *
+ *  `options.atoms` (default true) and `options.selectors` (default false) select
+ *  which kinds the listener receives; delivery filters per listener so each gets
+ *  only what it asked for. The two global counters gate the change pipeline:
+ *  `count` for "anyone watching at all", `selectorCount` for "anyone wants
+ *  selectors" (so selector collection stays off the hot path otherwise). */
 export const onStoreChange = (
     callback: StoreChangeCallback,
     data: StoreData,
+    options?: { atoms?: boolean; selectors?: boolean },
 ): (() => void) => {
+    const atoms = options?.atoms ?? true
+    const selectors = options?.selectors ?? false
+
+    // A listener that opts out of everything would never fire, yet registering it
+    // would still flip the "is anyone watching" gates (count / changeListeners
+    // size) and force per-write collection for nothing. Treat it as a no-op.
+    // (The type overloads already reject this at compile time; this guards JS
+    // callers and dynamic options.)
+    if (!atoms && !selectors) return () => {}
+
     let listeners = data.changeListeners
     if (!listeners) {
-        listeners = new Set()
+        listeners = new Map()
         data.changeListeners = listeners
     }
-    const sizeBefore = listeners.size
-    listeners.add(callback)
-    // Only bump the global gate when the callback is genuinely new (Set.add is
-    // a no-op for a duplicate), so add/remove stay balanced.
-    if (listeners.size > sizeBefore) changeListenerRegistry.count++
+    // Re-registering the same callback replaces its flags; adjust the counters by
+    // the delta so they stay balanced regardless of registration order.
+    const prev = listeners.get(callback)
+    listeners.set(callback, { atoms, selectors })
+    if (!prev) changeListenerRegistry.count++
+    const prevSelectors = prev?.selectors ?? false
+    if (selectors && !prevSelectors) changeListenerRegistry.selectorCount++
+    else if (!selectors && prevSelectors) changeListenerRegistry.selectorCount--
+
     return () => {
         const current = data.changeListeners
         if (!current) return
-        if (current.delete(callback)) {
+        const flags = current.get(callback)
+        if (flags && current.delete(callback)) {
             changeListenerRegistry.count--
-            // Drop the set entirely when empty so the parent-chain walk in
+            if (flags.selectors) changeListenerRegistry.selectorCount--
+            // Drop the map entirely when empty so the parent-chain walk in
             // hasChangeListener stops at this store.
             if (current.size === 0) data.changeListeners = undefined
         }

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -28,9 +28,14 @@ import {
 } from "./mountAtom"
 import {
     changeListenerRegistry,
+    createChangeSink,
+    flushChangeSink,
+    hasSelectorChangeListener,
     reportAtomChanges,
     reportDeletedAtoms,
+    reportSelectorChanges,
     type ChangeReport,
+    type ChangeSink,
 } from "./notifyChangeListeners"
 import { setValueInData } from "./setValueInData"
 
@@ -291,31 +296,60 @@ export const propagateDeletedAtoms = (
             deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
         }
     }
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, deletedFamilyAtoms, false, notify)
+    // `selectorCount` is the cheap global short-circuit; `hasSelectorChangeListener`
+    // then confirms a selector listener actually exists on THIS store's ancestor
+    // chain, so an unrelated root store with a selector listener doesn't make this
+    // one pay for selector collection.
+    const selectorActive =
+        report !== undefined &&
+        changeListenerRegistry.selectorCount !== 0 &&
+        hasSelectorChangeListener(data)
+    const changedSelectors = selectorActive ? new Set<Selector>() : undefined
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, deletedFamilyAtoms, false, notify, changedSelectors)
     if (notifyEntry) collectFamilyAtomsForNotify(notifyEntry, deletedFamilyAtoms)
+    const hasScopeCascade = !!data.scopes && data.scopes.size > 0
+    const watching = report !== undefined && changeListenerRegistry.count !== 0
+
+    // When a selector listener is active and this delete cascades into scopes,
+    // the origin group + each scope's selector group must coalesce into one
+    // callback. On the immediate path (string report) buffer them into a
+    // transient sink tagged with the real source; the txn path already passes a
+    // sink. (Mirror of the wrap in propagateAtomUpdate.)
+    let localSink: ChangeSink | undefined
+    let effectiveReport: ChangeReport | undefined = report
+    if (selectorActive && hasScopeCascade && typeof report === "string") {
+        localSink = createChangeSink(undefined, report)
+        effectiveReport = localSink
+    }
+    // When buffering into a sink, report the origin deletes BEFORE cascading so
+    // they precede descendant-scope selectors in the single callback (the sink
+    // flushes at the end, so this only orders the batch). A bare string report
+    // fires immediately and stays AFTER the cascade to keep onChange last.
+    const reportIsSink =
+        effectiveReport !== undefined && typeof effectiveReport !== "string"
+    if (watching && reportIsSink)
+        reportDeletedAtoms(atoms, data, effectiveReport as ChangeReport, changedSelectors)
+
     // Cross-propagate the deletion into descendant scopes, mirroring the update
-    // path (propagateAtomUpdate → propagateToScopes). deleteFamilyAtomsFromSet
-    // already re-rendered each shadowing scope's family index via
-    // recursivelyUpdateIndexes; this re-evaluates the dependent selectors so
-    // their subscribers fire. Two kinds of scope dependent must be reached, and
-    // the old family-only cascade (keyed on scopeValueIndex.get(family)) missed
-    // both: a scope that merely INHERITS the deleted member (no family shadow)
-    // and reads it directly — e.g. get(family("a")) — and a non-shadowing scope
-    // whose selector reads the family list get(family). Walking the full scope
-    // tree with both the deleted member atoms and their families covers both:
-    // members skip scopes that shadow them (their visible value is unchanged),
-    // families always propagate (their rendered list shrank everywhere).
-    if (data.scopes && data.scopes.size > 0) {
+    // path (propagateAtomUpdate → propagateToScopes), and thread `effectiveReport`
+    // so the scoped selector recomputes are reported too. deleteFamilyAtomsFromSet
+    // already re-rendered each shadowing scope's family index; this re-evaluates
+    // the dependent selectors so their subscribers fire. Two kinds of scope
+    // dependent are reached: a scope that merely INHERITS the deleted member and
+    // reads it directly (get(family("a"))), and a non-shadowing scope whose
+    // selector reads the family list (get(family)). Members skip scopes that
+    // shadow them (visible value unchanged); families always propagate.
+    if (hasScopeCascade) {
         const scopeAtoms: AtomInput[] = atoms.slice()
         for (const family of deletedFamilyAtoms.keys()) {
             scopeAtoms.push(family)
         }
-        propagateToScopes(scopeAtoms, data, false, notify)
+        propagateToScopes(scopeAtoms, data, false, notify, effectiveReport)
     }
 
-    if (report !== undefined && changeListenerRegistry.count !== 0) {
-        reportDeletedAtoms(atoms, data, report)
-    }
+    if (watching && !reportIsSink)
+        reportDeletedAtoms(atoms, data, effectiveReport as ChangeReport, changedSelectors)
+    if (localSink) flushChangeSink(localSink)
 }
 
 // Top-level entry: notify direct atom subscribers, walk dependent selectors,
@@ -337,6 +371,11 @@ export const propagateAtomUpdate = (
     // value must reach dependents, but re-adding the member to the index would
     // resurrect a deleted member.
     skipFamilyIndexUpdate = false,
+    // When false, the trigger `atoms` are NOT reported to onChange here — only
+    // the selectors they cause to recompute are. The caller reports the atoms
+    // itself (the `unset` path emits them as `kind: "unset"` via reportUnsetAtom,
+    // so they must not also surface as a `"set"`).
+    reportAtoms = true,
 ) => {
     // Fast path: single non-family atom with no dependent selectors and no
     // scopes can skip the full graph walk entirely and just notify subscribers.
@@ -353,7 +392,9 @@ export const propagateAtomUpdate = (
                     if (notify) addSetToSet(subs, notifyEntryFor(notify, data).subscriptions)
                     else callSubscribers(subs)
                 }
-                if (report !== undefined && changeListenerRegistry.count !== 0 && !isInitOnly) {
+                // No dependents here, so there are no selectors to report; only
+                // the atom would be, and only when reportAtoms is set.
+                if (reportAtoms && report !== undefined && changeListenerRegistry.count !== 0 && !isInitOnly) {
                     reportAtomChanges(atoms, data, report)
                 }
                 return
@@ -413,16 +454,59 @@ export const propagateAtomUpdate = (
         }
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, updatedFamilyAtoms, isInitOnly, notify)
+    // selectorCount is the O(1) global gate; hasSelectorChangeListener then
+    // confirms a selector listener exists on this store's ancestor chain, so a
+    // selector listener on an unrelated root store adds no overhead here.
+    const selectorActive =
+        report !== undefined &&
+        !isInitOnly &&
+        changeListenerRegistry.selectorCount !== 0 &&
+        hasSelectorChangeListener(data)
+    const changedSelectors = selectorActive ? new Set<Selector>() : undefined
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, updatedFamilyAtoms, isInitOnly, notify, changedSelectors)
     if (notifyEntry) collectFamilyAtomsForNotify(notifyEntry, updatedFamilyAtoms)
 
-    if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly, notify)
-    }
+    const hasScopes = !!data.scopes && data.scopes.size > 0
+    const watching =
+        report !== undefined && changeListenerRegistry.count !== 0 && !isInitOnly
 
-    if (report !== undefined && changeListenerRegistry.count !== 0 && !isInitOnly) {
-        reportAtomChanges(atoms, data, report)
+    // When a selector listener is active and this update cascades into scopes,
+    // the origin group (atoms + its selectors) and each descendant scope's
+    // selector group must coalesce into a single onChange callback. On the
+    // immediate path (string report) that means buffering into a transient sink
+    // tagged with the real source and flushing once; the txn path already passes
+    // a sink. With no selector listener there's only ever the one origin group,
+    // so the string report fires it inline exactly as before.
+    let localSink: ChangeSink | undefined
+    let effectiveReport: ChangeReport | undefined = report
+    if (selectorActive && hasScopes && typeof report === "string") {
+        localSink = createChangeSink(undefined, report)
+        effectiveReport = localSink
     }
+    // When buffering into a sink (the txn sink, or the transient localSink
+    // above), buffer the origin group BEFORE cascading into scopes so the origin
+    // atoms precede descendant-scope selectors in the single callback. The sink
+    // flushes at the end regardless, so this only orders the batch — it does not
+    // change when onChange fires. A bare string report (no sink) fires
+    // immediately, so it stays AFTER the scope cascade to keep onChange last
+    // (after subscribers); that path never carries selector entries anyway.
+    const reportIsSink =
+        effectiveReport !== undefined && typeof effectiveReport !== "string"
+    // reportAtoms=false: emit only the recomputed selectors (the caller reports
+    // the trigger atoms — e.g. as `kind: "unset"`).
+    const emitOrigin = (rpt: ChangeReport) => {
+        if (reportAtoms) {
+            reportAtomChanges(atoms, data, rpt, changedSelectors)
+        } else if (changedSelectors && changedSelectors.size > 0) {
+            reportSelectorChanges(changedSelectors, data, rpt)
+        }
+    }
+    if (watching && reportIsSink) emitOrigin(effectiveReport as ChangeReport)
+    if (hasScopes) {
+        propagateToScopes(atoms, data, isInitOnly, notify, effectiveReport)
+    }
+    if (watching && !reportIsSink) emitOrigin(effectiveReport as ChangeReport)
+    if (localSink) flushChangeSink(localSink)
 }
 
 // Scope-recursive entry: re-evaluate selectors that depend on these atoms in
@@ -434,6 +518,7 @@ export const propagateInScope = (
     data: StoreData,
     isInitOnly = false,
     notify?: NotifyTarget,
+    report?: ChangeReport,
 ) => {
     // Selector subscribers must accumulate into THIS store's notify entry (so
     // they fire once at the end); `families` is unused here (this entry skips
@@ -448,10 +533,25 @@ export const propagateInScope = (
         addSetToSet(data.stateDependents.get(atom), selectors)
     }
 
-    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, notify)
+    // No atom value changes in a cascaded scope (the atom is inherited) — only
+    // dependent selectors recompute, so we report just those as this scope's own
+    // selector-only group (carrying its scope path) into the same report/sink.
+    const changedSelectors =
+        report !== undefined &&
+        !isInitOnly &&
+        changeListenerRegistry.selectorCount !== 0 &&
+        hasSelectorChangeListener(data)
+            ? new Set<Selector>()
+            : undefined
+
+    propagateDirtySelectors(atoms, selectors, data, subscriptions, families, isInitOnly, notify, changedSelectors)
+
+    if (changedSelectors && changedSelectors.size > 0) {
+        reportSelectorChanges(changedSelectors, data, report as ChangeReport)
+    }
 
     if (data.scopes && data.scopes.size > 0) {
-        propagateToScopes(atoms, data, isInitOnly, notify)
+        propagateToScopes(atoms, data, isInitOnly, notify, report)
     }
 }
 
@@ -460,6 +560,7 @@ const propagateToScopes = (
     data: StoreData,
     isInitOnly: boolean,
     notify?: NotifyTarget,
+    report?: ChangeReport,
 ) => {
     if (atoms.length === 1) {
         // Fast path for single-atom updates (most common case)
@@ -469,7 +570,7 @@ const propagateToScopes = (
             : data.scopeValueIndex.get(atom)
         for (const [, scope] of data.scopes) {
             if (!shadowingScopes || !shadowingScopes.has(scope)) {
-                propagateInScope(atoms, scope, isInitOnly, notify)
+                propagateInScope(atoms, scope, isInitOnly, notify, report)
             }
         }
         return
@@ -491,7 +592,7 @@ const propagateToScopes = (
 
     if (!anyShadowed) {
         for (const [, scope] of data.scopes) {
-            propagateInScope(atoms, scope, isInitOnly, notify)
+            propagateInScope(atoms, scope, isInitOnly, notify, report)
         }
         return
     }
@@ -514,7 +615,7 @@ const propagateToScopes = (
             }
         }
         if (atomsToUpdateInScope.length > 0) {
-            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, notify)
+            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, notify, report)
         }
     }
 }
@@ -527,6 +628,10 @@ export const propagateDirtySelectors = (
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
     isInitOnly = false,
     notify?: NotifyTarget,
+    // When a selector listener is active, collects every selector whose value
+    // actually changed this pass, so the caller can report it via onChange.
+    // Undefined on the hot path (no selector listener) — zero overhead.
+    changedSelectors?: Set<Selector>,
 ) => {
     const updatedInitializedAtoms = new Set<Atom>(updatedAtoms)
     if (selectors.size > 0) {
@@ -539,6 +644,7 @@ export const propagateDirtySelectors = (
             subscriptions,
             updatedInitializedAtoms,
             isInitOnly,
+            changedSelectors,
         )
     }
     // When deferring (multi-pass commit), the caller owns `subscriptions` /
@@ -562,6 +668,7 @@ const propagateDownstreamTopo = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
+    changedSelectors?: Set<Selector>,
 ) => {
     const closure = new Set<Selector>(seeds)
     {
@@ -710,8 +817,9 @@ const propagateDownstreamTopo = (
         }
 
         advance(selector, wasValueUpdated)
-        if (wasValueUpdated && subscribers) {
-            addSetToSet(subscribers, collectedSubscribers)
+        if (wasValueUpdated) {
+            if (changedSelectors) changedSelectors.add(selector)
+            if (subscribers) addSetToSet(subscribers, collectedSubscribers)
         }
     }
 
@@ -781,6 +889,7 @@ const propagateDownstreamTopo = (
                 }
             }
             if (wasValueUpdated) {
+                if (changedSelectors) changedSelectors.add(selector)
                 if (subscribers) addSetToSet(subscribers, collectedSubscribers)
                 // Re-fetch dependents — eval may have changed them.
                 const downstream = data.stateDependents.get(selector)
@@ -818,6 +927,7 @@ const propagateSelectorUpdates = (
     collectedSubscribers: Set<any>,
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly = false,
+    changedSelectors?: Set<Selector>,
 ) => {
     if (selectors.size === 0) return
 
@@ -867,6 +977,7 @@ const propagateSelectorUpdates = (
             }
         }
         if (!wasValueUpdated) continue
+        if (changedSelectors) changedSelectors.add(selector)
         if (subscribers) addSetToSet(subscribers, collectedSubscribers)
         // Re-fetch dependents — eval may have changed them.
         const downstream = data.stateDependents.get(selector)
@@ -883,6 +994,7 @@ const propagateSelectorUpdates = (
             collectedSubscribers,
             updatedInitializedAtoms,
             isInitOnly,
+            changedSelectors,
         )
     }
 }

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -5,7 +5,6 @@ import type { GetValue } from "../types/GetValue"
 import type { SetAtom } from "../types/SetAtom"
 import type { State } from "../types/State"
 import type { ScopedStore, ScopeFn, Store } from "../types/Store"
-import type { StoreChangeCallback } from "../types/StoreChangeCallback"
 import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
 import { isAtom } from "../utils/isAtom"
@@ -197,8 +196,12 @@ export function storeFromStoreData(
         return transaction(callback, data, name)
     }
 
-    const onChange = (callback: StoreChangeCallback) =>
-        onStoreChange(callback, data)
+    // Implementation signature is permissive; the precise per-option callback
+    // types live on the overloaded `Store["onChange"]`, which this satisfies.
+    const onChange = ((
+        callback: any,
+        options?: { atoms?: boolean; selectors?: boolean },
+    ) => onStoreChange(callback, data, options)) as Store["onChange"]
 
     const scope: ScopeFn = ((scopeId: string, callback?: any) => {
         if (callback) {

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -402,7 +402,10 @@ export class Transaction {
                 }
                 const unsetAtoms = this.applyUnsets(this._unsetSet, this.data)
                 if (unsetAtoms.length > 0) {
-                    propagateAtomUpdate(unsetAtoms, this.data, false, notify, undefined)
+                    // Atoms first (emitted as "unset"), then propagate with
+                    // reportAtoms=false so dependent-selector recomputes are
+                    // reported too (the atom value is gone from data.values, so it
+                    // must not also surface as a "set").
                     if (sink) {
                         for (const atom of unsetAtoms) {
                             reportUnsetAtom(
@@ -413,6 +416,7 @@ export class Transaction {
                             )
                         }
                     }
+                    propagateAtomUpdate(unsetAtoms, this.data, false, notify, sink, false, false)
                 }
                 notifyDeferred(notify)
                 // Re-delegate AFTER firing: the deferred notify fires the
@@ -544,9 +548,10 @@ export class Transaction {
                 )
             }
             if (unsetAtoms && unsetAtoms.length > 0) {
-                // report undefined: the unset atom value is gone from
-                // data.values; emit the reverted value via reportUnsetAtom.
-                propagateAtomUpdate(unsetAtoms, data, false, notify, undefined)
+                // Atoms first (emitted as "unset" via reportUnsetAtom), then
+                // propagate with reportAtoms=false so dependent-selector recomputes
+                // are reported too — without re-surfacing the atom (its value is
+                // gone from data.values) as a "set".
                 if (sink) {
                     for (const atom of unsetAtoms) {
                         reportUnsetAtom(
@@ -557,6 +562,7 @@ export class Transaction {
                         )
                     }
                 }
+                propagateAtomUpdate(unsetAtoms, data, false, notify, sink, false, false)
             }
         }
         notifyDeferred(notify)

--- a/packages/valdres/src/lib/unsetValue.test.ts
+++ b/packages/valdres/src/lib/unsetValue.test.ts
@@ -270,7 +270,7 @@ describe("unset — root store", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes).toEqual([
-            { kind: "unset", atom: a, value: 1, scope: [] },
+            { type: "atom", kind: "unset", state: a, value: 1, scope: [] },
         ])
         expect(root.get(a)).toBe(1)
     })
@@ -404,7 +404,7 @@ describe("scope.unset — onChange", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes).toEqual([
-            { kind: "unset", atom: a, value: 10, scope: ["child"] },
+            { type: "atom", kind: "unset", state: a, value: 10, scope: ["child"] },
         ])
     })
 
@@ -423,8 +423,9 @@ describe("scope.unset — onChange", () => {
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("unset")
         expect(calls[0]!.changes[0]).toEqual({
+            type: "atom",
             kind: "unset",
-            atom: a,
+            state: a,
             value: 10,
             scope: ["child"],
         })
@@ -440,7 +441,7 @@ describe("scope.unset — onChange", () => {
         let received: readonly StoreChange[] = []
         scoped.onChange(changes => (received = changes))
         scoped.unset(a)
-        expect(received[0]!.kind).toBe("unset")
+        expect(received[0]).toMatchObject({ type: "atom", kind: "unset" })
     })
 })
 
@@ -484,17 +485,19 @@ describe("scope.unset — transaction form", () => {
 
         expect(calls.length).toBe(1)
         expect(calls[0]!.meta.source).toBe("transaction")
-        const aChange = calls[0]!.changes.find(c => c.atom === a)
-        const bChange = calls[0]!.changes.find(c => c.atom === b)
+        const aChange = calls[0]!.changes.find(c => c.state === a)
+        const bChange = calls[0]!.changes.find(c => c.state === b)
         expect(aChange).toEqual({
+            type: "atom",
             kind: "unset",
-            atom: a,
+            state: a,
             value: 10,
             scope: ["child"],
         })
         expect(bChange).toEqual({
+            type: "atom",
             kind: "set",
-            atom: b,
+            state: b,
             value: 5,
             scope: ["child"],
         })

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -3,7 +3,12 @@ import type { StoreData } from "../types/StoreData"
 import { isAtom } from "../utils/isAtom"
 import { getState } from "./getState"
 import { getAtomInitValue } from "./initAtom"
-import { hasChangeListener, reportUnsetAtom } from "./notifyChangeListeners"
+import {
+    createChangeSink,
+    flushChangeSink,
+    hasChangeListener,
+    reportUnsetAtom,
+} from "./notifyChangeListeners"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 
 const InvalidStateError = "unset() expects an atom."
@@ -108,17 +113,22 @@ export const unsetValue = <V>(atom: Atom<V>, data: StoreData): void => {
     // dropped value IS the event a dev-tools `onChange` observer needs to see:
     // suppressing it on value-equality would lose the very signal `source:
     // "unset"` exists to carry.
-    //
-    // `report` is left undefined here: the standard reporter reads `data.values`
-    // (now empty for this atom) — the unset change, with the reverted value, is
-    // emitted separately below.
-    propagateAtomUpdate([atom], data, false)
-
-    // Resume parent delegation AFTER the on-unset notification, so the callback's
-    // own (idempotent, now no-op) delegate drop doesn't undo the fresh delegate.
-    reDelegateScopeSubscriptions(atom, data)
-
     if (hasChangeListener(data)) {
-        reportUnsetAtom(atom, data, effectiveValueAfterUnset(atom, data), "unset")
+        // Coalesce the atom unset and any dependent-selector recomputes into one
+        // onChange callback. Buffer the atom first (atoms precede selectors), then
+        // propagate with reportAtoms=false: the propagation reports only the
+        // selectors it recomputes, never the atom (already emitted as "unset").
+        const sink = createChangeSink(undefined, "unset")
+        reportUnsetAtom(atom, data, effectiveValueAfterUnset(atom, data), sink)
+        // skipFamilyIndexUpdate=false (default), reportAtoms=false (atom already
+        // emitted as "unset"; only report the selectors it recomputes).
+        propagateAtomUpdate([atom], data, false, undefined, sink, false, false)
+        // Resume parent delegation AFTER subscribers fire (during propagation),
+        // so a scope subscriber's idempotent delegate drop doesn't undo it.
+        reDelegateScopeSubscriptions(atom, data)
+        flushChangeSink(sink)
+    } else {
+        propagateAtomUpdate([atom], data, false)
+        reDelegateScopeSubscriptions(atom, data)
     }
 }

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -2,7 +2,8 @@ import type { Atom } from "./Atom"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { GetValue } from "./GetValue"
 import type { ResetAtom } from "./ResetAtom"
-import type { StoreChangeCallback } from "./StoreChangeCallback"
+import type { AtomChange, SelectorChange, StoreChange } from "./StoreChange"
+import type { StoreChangeMeta } from "./StoreChangeMeta"
 import type { StoreData } from "./StoreData"
 import type { SetAtomValue } from "./SetAtomValue"
 import type { SubscribeFn } from "./SubscribeFn"
@@ -56,11 +57,48 @@ export type Store<T = StoreData> = {
      *  of `store.onChange` callbacks for this commit (useful for dev tools). */
     txn: (callback: TransactionFn, name?: string) => void
     scope: ScopeFn
-    /** Subscribe to every atom value change in this store and its descendant
-     *  scopes. The callback fires once per committed operation with all changed
-     *  atoms, their new values, and the scope each change occurred in. Returns
-     *  an unsubscribe function. Intended for dev tools and debugging. */
-    onChange: (callback: StoreChangeCallback) => () => void
+    /** Subscribe to changes in this store and its descendant scopes. The callback
+     *  fires once per committed operation with the changes, the scope each
+     *  occurred in, and `meta` (source / txn name). Returns an unsubscribe
+     *  function. Intended for dev tools and debugging.
+     *
+     *  Two independent toggles select what's reported:
+     *  - `atoms` (default `true`) — atom set/unset/delete changes (`AtomChange`).
+     *  - `selectors` (default `false`) — derived selectors that recomputed to a
+     *    new value (`SelectorChange`). Only *live* selectors (a subscriber or
+     *    downstream dependent, i.e. recomputed anyway) and only genuine value
+     *    changes are reported; selector reporting forces no extra evaluation.
+     *
+     *  The callback's `changes` type follows the options: atoms-only by default,
+     *  `StoreChange[]` with `{ selectors: true }`, or `SelectorChange[]` with
+     *  `{ atoms: false, selectors: true }`. Within a store's slice, atom entries
+     *  precede that store's selector entries. */
+    onChange: {
+        (
+            callback: (
+                changes: readonly SelectorChange[],
+                meta: StoreChangeMeta,
+            ) => void,
+            options: { atoms: false; selectors: true },
+        ): () => void
+        (
+            callback: (
+                changes: readonly StoreChange[],
+                meta: StoreChangeMeta,
+            ) => void,
+            options: { atoms?: true; selectors: true },
+        ): () => void
+        (
+            callback: (
+                changes: readonly AtomChange[],
+                meta: StoreChangeMeta,
+            ) => void,
+            // `atoms?: true` (not `boolean`): `{ atoms: false }` without
+            // `selectors: true` would subscribe to nothing, so it's rejected
+            // rather than typed as an atoms-only listener that never fires.
+            options?: { atoms?: true; selectors?: false },
+        ): () => void
+    }
 }
 
 export type ScopedStore = Store & {

--- a/packages/valdres/src/types/StoreChange.ts
+++ b/packages/valdres/src/types/StoreChange.ts
@@ -1,43 +1,68 @@
 import type { Atom } from "./Atom"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
+import type { Selector } from "./Selector"
 
-/** A single atom change reported to a store change listener — a discriminated
- *  union on `kind`.
+/** A change to an atom, reported to a `store.onChange` listener. Discriminated on
+ *  `kind` (the operation):
  *
  *  - `"set"`    — the atom now holds `value` (a direct `set`/`reset`, an async
  *                 atom resolving, a cache revalidation, …; the originating
  *                 operation is on `StoreChangeMeta.source`).
  *  - `"unset"`  — the store dropped its own value for the atom (`store.unset` /
- *                 `txn.unset`); the atom now reverts to what it otherwise reads,
- *                 carried as `value` (the inherited parent value on a scope, the
- *                 default on a root). The atom still exists — this is NOT a
- *                 `"delete"`. A flat value-mirror can read `value`; an
- *                 inheritance-aware consumer switches on the kind to drop the
- *                 override. `"unset"` is also on `StoreChangeMeta.source` for a
- *                 standalone unset, but inside a transaction the source is
- *                 `"transaction"`, so this per-change kind is the only signal
- *                 distinguishing it from a set.
+ *                 `txn.unset`); it now reverts to what it otherwise reads, carried
+ *                 as `value` (the inherited parent value on a scope, the default
+ *                 on a root). The atom still exists — NOT a `"delete"`. A flat
+ *                 value-mirror can read `value`; an inheritance-aware consumer
+ *                 switches on the kind to drop the override. `"unset"` is also on
+ *                 `StoreChangeMeta.source` for a standalone unset, but inside a
+ *                 transaction the source is `"transaction"`, so this per-change
+ *                 kind is the only signal distinguishing it from a set.
  *  - `"delete"` — the (family) atom was removed (`store.del` / `txn.del`). There
  *                 is no value: the entry is gone from the store.
  *
- *  `scope` is the chain of scope ids from the outermost scope down to where the
- *  change occurred — the ids you'd pass to `.scope()` to reach it — empty (`[]`)
- *  for a root store. Unambiguous for nested scopes that share a leaf name. */
-export type StoreChange =
+ *  `state` is the changed atom. `scope` is the chain of scope ids from the
+ *  outermost scope down to where the change occurred — the ids you'd pass to
+ *  `.scope()` to reach it — empty (`[]`) for a root store. Unambiguous for nested
+ *  scopes that share a leaf name. */
+export type AtomChange =
     | {
+          type: "atom"
           kind: "set"
-          atom: Atom<any> | AtomFamilyAtom<any, any>
+          state: Atom<any> | AtomFamilyAtom<any, any>
           value: unknown
           scope: string[]
       }
     | {
+          type: "atom"
           kind: "unset"
-          atom: Atom<any> | AtomFamilyAtom<any, any>
+          state: Atom<any> | AtomFamilyAtom<any, any>
           value: unknown
           scope: string[]
       }
     | {
+          type: "atom"
           kind: "delete"
-          atom: Atom<any> | AtomFamilyAtom<any, any>
+          state: Atom<any> | AtomFamilyAtom<any, any>
           scope: string[]
       }
+
+/** A derived selector that recomputed to a new `value` as a consequence of an
+ *  operation. Only reported to listeners that opted in via
+ *  `onChange(cb, { selectors: true })`, and only for live selectors (a subscriber
+ *  or downstream dependent) whose value actually changed (see `Store.onChange`).
+ *
+ *  Unlike `AtomChange`, there is **no `kind`**: a selector has no operation — it
+ *  is never set/unset/deleted, it just holds a value that follows from its deps.
+ *  `type: "selector"` is the whole discrimination; `value` is the recomputed
+ *  value, `scope` the scope it recomputed in. */
+export type SelectorChange = {
+    type: "selector"
+    state: Selector<any>
+    value: unknown
+    scope: string[]
+}
+
+/** A single change reported to a `store.onChange` listener. Discriminate first on
+ *  `type` (`"atom" | "selector"`): atom changes additionally carry a `kind`
+ *  (`"set" | "unset" | "delete"`); selector changes do not. */
+export type StoreChange = AtomChange | SelectorChange

--- a/packages/valdres/src/types/StoreChangeCallback.ts
+++ b/packages/valdres/src/types/StoreChangeCallback.ts
@@ -1,13 +1,19 @@
 import type { StoreChange } from "./StoreChange"
 import type { StoreChangeMeta } from "./StoreChangeMeta"
 
-/** Callback registered via `store.onChange`. Invoked once per committed
- *  operation with every atom that changed: a single `set`/`reset` delivers a
- *  one-element array, a transaction delivers one array with all its changes.
- *  `meta` carries operation metadata such as a transaction's `name`.
+/** The broad callback shape for `store.onChange` — receives the full
+ *  `StoreChange` union (atoms, and for opted-in listeners selectors). The precise
+ *  per-option callback types (atoms-only by default, selectors-only, or both) are
+ *  expressed by the overloads on `Store["onChange"]`; this is the internal
+ *  storage / implementation shape.
  *
- *  `changes` is `readonly`: the same array instance is handed to every listener
- *  for the operation, so it must not be mutated. */
+ *  Fires once per committed operation with all of that operation's changes (a
+ *  transaction batches them; a single `set`/`reset` typically delivers one atom
+ *  change, but a `{ selectors: true }` listener may also receive the selectors
+ *  that recomputed as a result). `meta` carries operation metadata such as a
+ *  transaction's `name`. `changes` is `readonly` — listeners sharing the same
+ *  opt-in are handed one array instance per operation, so it must not be
+ *  mutated. */
 export type StoreChangeCallback = (
     changes: readonly StoreChange[],
     meta: StoreChangeMeta,

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -50,9 +50,13 @@ export type StoreData = {
     /** Present iff this is a scoped store. Records keys this scope registered
      *  in its parent's `scopeValueIndex`, used for cleanup on detach. */
     scopeIndexKeys?: Set<WeakKey>
-    /** Store-wide change listeners registered via `store.onChange`. Absent
-     *  (undefined) until the first listener is added and reset to undefined
-     *  when the last one leaves, so the write hot path stays allocation-free
-     *  when nobody is watching. */
-    changeListeners?: Set<StoreChangeCallback>
+    /** Store-wide change listeners registered via `store.onChange`, each mapped
+     *  to the kinds of change it opted into: `atoms` (default true) and
+     *  `selectors` (default false). Absent (undefined) until the first listener
+     *  is added and reset to undefined when the last one leaves, so the write hot
+     *  path stays allocation-free when nobody is watching. */
+    changeListeners?: Map<
+        StoreChangeCallback,
+        { atoms: boolean; selectors: boolean }
+    >
 }


### PR DESCRIPTION
## What & why

`store.onChange` only reported **atom** changes. Selectors (derived state) recompute during the same propagation pass but were invisible to dev-tools / observability consumers. This adds **opt-in selector reporting**, and reworks the `StoreChange` shape so atoms and selectors are modeled honestly.

## API

`onChange` takes two independent toggles — `atoms` (default `true`), `selectors` (default `false`):

```ts
store.onChange(cb)                                    // atoms only (default)
store.onChange(cb, { selectors: true })               // atoms + selectors
store.onChange(cb, { atoms: false, selectors: true }) // selectors only
```

A selector that recomputes to a new value is reported as `{ type: "selector", state, value, scope }` — **no `kind`**. `kind` (`set`/`unset`/`delete`) is an atom operation; a selector has no operation, just a recomputed value, so it's discriminated purely on `type`.

The changed atom/selector is on `state` — matching valdres's existing vocabulary (the `State` type = `Atom | Selector | AtomFamily`, and the `store.get`/`store.sub` parameter), so `store.get(change.state)` reads naturally.

The callback's `changes` type **follows the options** (overloaded): `AtomChange[]` by default, `StoreChange[]` with `{ selectors: true }`, `SelectorChange[]` with `{ atoms: false, selectors: true }`.

### Semantics
- **Live + changed only**: a selector is reported only if it was already recomputing (subscriber or downstream dependent) *and* its value actually changed (respects `equal`) — zero extra evaluation. Orphaned/evicted/errored selectors aren't reported.
- **Every operation**: selector recomputes are reported for `set`/`reset`/`del`/`unset`/async-resolution/transactions, **including cascades into descendant scopes** (scope-tagged).
- **One callback per op**, atoms before selectors; coalesced via a transient sink on the immediate path (the txn path already coalesces).
- Async selector resolution surfaces with `meta.source: "async-set"`.
- Gated on `selectorCount` + a per-ancestor-chain `hasSelectorChangeListener` check — the no-listener (and unrelated-store) propagation hot path is unchanged.

## ⚠️ Breaking (`StoreChange`, unreleased beta)
- `atom` field renamed to `state`; added a `type: "atom" | "selector"` discriminator.
- Selector changes carry **no `kind`**.
- New exported types `AtomChange` / `SelectorChange` (`StoreChange = AtomChange | SelectorChange`).

## Rebased on #180 + #181

This branch surfaced two **pre-existing** family-delete bugs (reading a deleted member returned the default-value *function*; immediate `del` didn't cascade into descendant scopes). Both were fixed separately and merged to main — **#180** and **#181** — and this branch is rebased on top. With #181's del-scope cascade in place, selector reporting threads through it, so an immediate `del` now also reports dependent-selector recomputes in descendant scopes (covered by a test). Earlier built on #178 (`kind: "unset"`), folded into the unified shape as `{ type: "atom", kind: "unset", state, value, scope }`.

## Reviews addressed

Two independent staff reviews + a self-pass + GitHub Copilot, all addressed. Highlights:
- Fixed an overload that rejected `{ atoms: true, selectors: true }`; opting out of everything is now a compile error (+ runtime no-op).
- Cross-scope ordering so the txn path also emits atoms before descendant-scope selectors.
- Per-ancestor-chain gating so a selector listener on one root store adds no overhead to unrelated stores.
- Renamed the change field `node` → `state` to match valdres's own term.
- Completed `unset` selector reporting (own-store + descendant-scope), TDD'd red-first.

## Verification
- `bun test` (valdres): **506 pass, 0 fail, 1 todo**.
- `bunx tsgo` (`build:types`): clean; touched files type-clean under a full repo-root `tsgo` too.
- `changeset status --since=origin/main`: `valdres` → minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
