### PR TITLE
fix(valdres): cascade immediate del of a family member into descendant scopes

### DIFF
--- a/.changeset/del-scope-cascade.md
+++ b/.changeset/del-scope-cascade.md
@@ -1,0 +1,21 @@
+---
+"valdres": patch
+---
+
+Fix `store.del(familyMember)` (and `txn.del`) not re-evaluating dependent
+selectors in descendant scopes. When a family member was made live in both the
+root and a child scope — the scope inheriting the member rather than shadowing it
+— deleting it at the root fired the root's subscriber and updated the root's
+selector, but the child scope's subscriber never fired and its selector stayed
+stale.
+
+The delete-time scope cascade only re-evaluated scopes that *shadowed* the family
+(keyed on `scopeValueIndex.get(family)`), so it missed two kinds of descendant
+dependent: a scope that merely inherits the deleted member and reads it directly
+(e.g. `get(family("a"))`), and a non-shadowing scope whose selector reads the
+family list (`get(family)`). `propagateDeletedAtoms` now cross-propagates the
+deleted member atoms *and* their families through the full scope tree via the
+same `propagateToScopes` path the `set`/update flow already uses — members skip
+scopes that shadow them (their visible value is unchanged), families always
+propagate (their rendered list shrank everywhere) — so descendant-scope
+dependents re-evaluate and their subscribers fire, matching the update path.

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -293,28 +293,24 @@ export const propagateDeletedAtoms = (
     }
     propagateDirtySelectors(atoms, selectors, data, subscriptions, deletedFamilyAtoms, false, notify)
     if (notifyEntry) collectFamilyAtomsForNotify(notifyEntry, deletedFamilyAtoms)
-    // Propagate family changes into child scopes. deleteFamilyAtomsFromSet
-    // already updated each scope's family index via recursivelyUpdateIndexes;
-    // selectors in those scopes that depend on the family still need to be
-    // re-evaluated so their subscribers get notified.
-    if (deletedFamilyAtoms.size > 0 && data.scopes && data.scopes.size > 0) {
-        const scopeFamilies = new Map<StoreData, AtomFamily<any>[]>()
+    // Cross-propagate the deletion into descendant scopes, mirroring the update
+    // path (propagateAtomUpdate → propagateToScopes). deleteFamilyAtomsFromSet
+    // already re-rendered each shadowing scope's family index via
+    // recursivelyUpdateIndexes; this re-evaluates the dependent selectors so
+    // their subscribers fire. Two kinds of scope dependent must be reached, and
+    // the old family-only cascade (keyed on scopeValueIndex.get(family)) missed
+    // both: a scope that merely INHERITS the deleted member (no family shadow)
+    // and reads it directly — e.g. get(family("a")) — and a non-shadowing scope
+    // whose selector reads the family list get(family). Walking the full scope
+    // tree with both the deleted member atoms and their families covers both:
+    // members skip scopes that shadow them (their visible value is unchanged),
+    // families always propagate (their rendered list shrank everywhere).
+    if (data.scopes && data.scopes.size > 0) {
+        const scopeAtoms: AtomInput[] = atoms.slice()
         for (const family of deletedFamilyAtoms.keys()) {
-            const scopesWithFamily = data.scopeValueIndex.get(family)
-            if (scopesWithFamily) {
-                for (const scope of scopesWithFamily) {
-                    let list = scopeFamilies.get(scope)
-                    if (!list) {
-                        list = []
-                        scopeFamilies.set(scope, list)
-                    }
-                    list.push(family)
-                }
-            }
+            scopeAtoms.push(family)
         }
-        for (const [scope, familiesInScope] of scopeFamilies) {
-            propagateInScope(familiesInScope, scope, false, notify)
-        }
+        propagateToScopes(scopeAtoms, data, false, notify)
     }
 
     if (report !== undefined && changeListenerRegistry.count !== 0) {

--- a/packages/valdres/src/lib/scope.test.ts
+++ b/packages/valdres/src/lib/scope.test.ts
@@ -186,6 +186,120 @@ describe("family deletion across scope levels", () => {
         expect(bCallback).toHaveBeenCalledTimes(0)
     })
 
+    test("root del of a member re-evaluates a descendant scope's selector that reads the member directly", () => {
+        const A = store("A")
+        const family = atomFamily<string, [string]>("DEFAULT", {
+            name: "memberFam",
+        })
+        const member = family("a")
+        A.set(member, "root-val")
+
+        const B = A.scope("B")
+
+        // The selector reads the FAMILY MEMBER directly (not get(family)).
+        const sel = selector(get => `sel:${get(member)}`, { name: "memberSel" })
+
+        const aCb = mock(() => {})
+        const bCb = mock(() => {})
+        A.sub(sel, aCb)
+        B.sub(sel, bCb) // B inherits member from A — no shadow
+
+        expect(A.get(sel)).toBe("sel:root-val")
+        expect(B.get(sel)).toBe("sel:root-val")
+
+        A.del(member)
+
+        // Root subscriber fires and its value updates.
+        expect(aCb).toHaveBeenCalledTimes(1)
+        expect(A.get(sel)).toBe("sel:DEFAULT")
+
+        // Descendant scope: its selector must re-evaluate and its subscriber fire.
+        expect(bCb).toHaveBeenCalledTimes(1)
+        expect(B.get(sel)).toBe("sel:DEFAULT")
+    })
+
+    test("txn del of a member re-evaluates a descendant scope's selector that reads the member directly", () => {
+        const A = store("A")
+        const family = atomFamily<string, [string]>("DEFAULT", {
+            name: "memberFamTxn",
+        })
+        const member = family("a")
+        A.set(member, "root-val")
+
+        const B = A.scope("B")
+
+        const sel = selector(get => `sel:${get(member)}`, {
+            name: "memberSelTxn",
+        })
+
+        const aCb = mock(() => {})
+        const bCb = mock(() => {})
+        A.sub(sel, aCb)
+        B.sub(sel, bCb)
+
+        expect(A.get(sel)).toBe("sel:root-val")
+        expect(B.get(sel)).toBe("sel:root-val")
+
+        A.txn(({ del }) => del(member))
+
+        expect(aCb).toHaveBeenCalledTimes(1)
+        expect(A.get(sel)).toBe("sel:DEFAULT")
+        expect(bCb).toHaveBeenCalledTimes(1)
+        expect(B.get(sel)).toBe("sel:DEFAULT")
+    })
+
+    test("root del of a member re-evaluates an inheriting selector 3 scopes deep", () => {
+        const A = store("A")
+        const family = atomFamily<string, [string]>("DEFAULT", {
+            name: "deepMemberFam",
+        })
+        const member = family("a")
+        A.set(member, "root-val")
+
+        const B = A.scope("B")
+        const C = B.scope("C")
+        const D = C.scope("D")
+
+        const sel = selector(get => `sel:${get(member)}`, {
+            name: "deepMemberSel",
+        })
+        const dCb = mock(() => {})
+        D.sub(sel, dCb) // D inherits member through B and C — no shadow anywhere
+
+        expect(D.get(sel)).toBe("sel:root-val")
+
+        A.del(member)
+
+        expect(dCb).toHaveBeenCalledTimes(1)
+        expect(D.get(sel)).toBe("sel:DEFAULT")
+    })
+
+    test("member shadowed at an intermediate scope masks a root del from deeper scopes", () => {
+        const A = store("A")
+        const family = atomFamily<string, [string]>("DEFAULT", {
+            name: "maskMemberFam",
+        })
+        const member = family("a")
+        A.set(member, "root-val")
+
+        const B = A.scope("B")
+        const C = B.scope("C")
+        B.set(member, "B-val") // B shadows — C reads B's value, not root's
+
+        const sel = selector(get => `sel:${get(member)}`, {
+            name: "maskMemberSel",
+        })
+        const cCb = mock(() => {})
+        C.sub(sel, cCb)
+        expect(C.get(sel)).toBe("sel:B-val")
+
+        A.del(member)
+
+        // C's visible value comes from B's shadow, unchanged — no notification.
+        expect(cCb).toHaveBeenCalledTimes(0)
+        expect(C.get(sel)).toBe("sel:B-val")
+    })
+
     test("delete from mid-scope does not affect siblings", () => {
         const A = store("A")
         const family = atomFamily<string>(undefined, { name: "sibFam" })

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -679,11 +679,17 @@ describe("cross-scope transactions are atomically observable", () => {
             expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
 
-        test("cross-scope: scope selector spanning a root atom + a root-deleted family runs once", () => {
+        test("cross-scope: scope selector spanning a root atom + a root-deleted family recomputes per reaching pass, notified once", () => {
             // A selector in S depends on a root atom (updated) and a root family
-            // (member deleted), with S NOT shadowing the family. Both reach S in
-            // a single propagateToScopes pass, so the selector evaluates once and
-            // ends at the fully-applied state.
+            // (member deleted), with S NOT shadowing the family. Both the update
+            // pass (propagateAtomUpdate, via the root atom) and the delete pass
+            // (propagateDeletedAtoms, via the family) cross-propagate into S, so
+            // the selector recomputes once per reaching pass — the same
+            // recompute-in-each-pass behavior the single-store root case above
+            // exhibits. Both passes read the fully-written state (writeAtoms has
+            // already rendered the deleted member out), so each lands on the
+            // final value and the equality check prunes the redundant result;
+            // deferred notification fires the subscriber exactly once.
             const root = store()
             const fam = atomFamily<string>(undefined, { name: "cud-fam" })
             const m1 = fam("1")
@@ -712,8 +718,8 @@ describe("cross-scope transactions are atomically observable", () => {
             })
 
             expect(S.get(span)).toBe("1:9")
-            expect(evals - before).toBe(1)
-            expect(cb).toHaveBeenCalledTimes(1)
+            expect(evals - before).toBe(2) // recomputed in the update and delete passes
+            expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
     })
 


### PR DESCRIPTION
## Problem

A selector reading a family **member** directly (e.g. `get(family(\"a\"))`), made live in both the root store and a child scope that *inherits* the member, went stale in the child scope after `root.del(member)`:

- the root's subscriber fired and its selector updated ✅
- the descendant scope's subscriber never fired and its selector stayed stale ❌

The bug was present in both the immediate `store.del()` path and `store.txn(t => t.del(...))` (both route through `propagateDeletedAtoms`).

## Root cause

The delete-time scope cascade in `propagateDeletedAtoms` (`packages/valdres/src/lib/propagateUpdatedAtoms.ts`) only re-evaluated scopes that **shadowed** the family, keyed on `scopeValueIndex.get(family)`. That missed two kinds of descendant dependent:

1. a scope that merely **inherits** the deleted member and reads it directly — `get(family(\"a\"))`
2. a non-shadowing scope whose selector reads the family list — `get(family)`

The `set`/update path (`propagateAtomUpdate` → `propagateToScopes`) already walks the full scope tree correctly, which is why `set` propagated to inheriting scopes but `del` did not.

## Fix

`propagateDeletedAtoms` now cross-propagates the deleted **member atoms** *and* their **families** through the full scope tree via the same `propagateToScopes` the update path uses:

- **members** skip scopes that shadow them (their visible value is unchanged)
- **families** always propagate (their rendered list shrank everywhere)

This also fixes a latent variant of the same bug — a non-shadowing scope with a `get(family)` selector — and reaches deeply-nested shadowing scopes *through* non-shadowing intermediates, which the old `scopeValueIndex`-keyed cascade could miss.

## Behavior change in one existing test

`transaction.atomicScope.test.ts` — "scope selector spanning a root atom + a root-deleted family" previously asserted the scope selector evaluated **once**. That `1` was an artifact of the bug: the old delete pass never reached the (non-shadowing) scope, so only the update pass (via the root atom) re-evaluated it.

Now both the update pass and the delete pass cross-propagate into the scope, so the spanning selector recomputes **once per reaching pass (2)** — identical to the sibling single-store root-selector test, and consistent with the file's documented \"deliberately dumb and robust: recompute in each reaching pass, the equality check prunes the redundant result\" design. The subscriber is still notified **exactly once** with the correct final value (deferred notification), so observable behavior is unchanged.

## Tests

New tests in `scope.test.ts`:
- root `del` re-evaluates a descendant scope's selector reading the member directly (immediate + txn variants)
- same, 3 scopes deep through inheriting intermediates
- intermediate-scope shadow correctly **masks** a root `del` from deeper scopes (no spurious notification)

All red before the fix, green after. Full core suite: **479 pass, 0 fail**. `tsgo --noEmit` clean. Changeset added (`valdres`: patch).

> Note: an independent `codex review` pass was attempted but the codex CLI returned 401 Unauthorized (not logged in), so this PR carries only the in-repo review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)