### PR TITLE
feat(@valdres/redux-devtools): Redux DevTools adapter for valdres

### DIFF
--- a/.changeset/redux-devtools-adapter.md
+++ b/.changeset/redux-devtools-adapter.md
@@ -1,0 +1,38 @@
+---
+"@valdres/redux-devtools": minor
+---
+
+Add `@valdres/redux-devtools` — connect a valdres store to the Redux DevTools
+browser extension for live action logging and time-travel, built on
+`store.onChange`.
+
+`connectReduxDevtools(store, options?)` mirrors every committed change to a
+named atom (in the store or any scope) into the extension as an action, and
+wires the extension's jump / commit / reset controls back onto the store via
+time-travel. Atoms that only appeared after the target point are `unset` on
+jump-back so nothing stale lingers — a scope override re-inherits the parent, a
+root atom reverts to its default. A `store.unset` surfaces as an
+`unset`-sourced action and drops the override from `@scopes`.
+
+- A transaction — including one spanning scopes — arrives as a single action;
+  `store.txn(fn, name)` names it, otherwise it's labelled `txn (N atoms · …)`.
+- `meta.source` distinguishes resets, deletes, and cache revalidations from
+  plain sets in the timeline; deletions remove the atom from the snapshot.
+- Scope state nests under a reserved `@scopes` key with `@scope:<path>` labels.
+- Atoms without a `name` are tracked as `unnamed_atom_N` by default (a one-time
+  hint suggests naming them, since the labels aren't stable across reloads);
+  pass `unnamed: "ignore"` to leave them out.
+- `serialize` shapes non-cloneable values before they're posted to the
+  extension. Reducer-only controls (skip / reorder) surface an in-panel error
+  when dispatched, without wiping history. `disconnect()` is per-connection (it
+  does not call the global `ext.disconnect()`).
+- `{ selectors: true }` additionally mirrors named selector (derived) values
+  under a reserved `@computed` key — display-only, excluded from time-travel.
+  Root selectors live at the top level; scope selectors nest under
+  `@scopes.<scope>.@computed`.
+- Honors the extension's **Pause recording** (timeline pauses, model stays
+  current) and **Import** (restores the imported session's current state).
+- For an **enumerable store** (`store(id, { enumerable: true })`), seeds the
+  initial timeline from `store.snapshot()` so it opens with state that already
+  exists instead of empty; a default store starts empty and fills via
+  `onChange`.

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ junit*.xml
 packages/*/src/**/*.d.ts
 packages/@valdres/*/src/**/*.d.ts
 packages/@valdres-react/*/src/**/*.d.ts
+.gstack/

--- a/bun.lock
+++ b/bun.lock
@@ -17,9 +17,9 @@
     },
     "packages/@valdres-react/color-mode": {
       "name": "@valdres-react/color-mode",
-      "version": "0.3.0-beta.0",
+      "version": "0.3.0-beta.1",
       "dependencies": {
-        "@valdres/color-mode": "^0.3.0-beta.0",
+        "@valdres/color-mode": "^1.0.0-beta.1",
       },
       "devDependencies": {
         "typescript": "5.9.2",
@@ -42,9 +42,9 @@
     },
     "packages/@valdres-react/hotkeys": {
       "name": "@valdres-react/hotkeys",
-      "version": "0.3.0-beta.0",
+      "version": "1.0.0-beta.2",
       "dependencies": {
-        "@valdres/hotkeys": "^0.3.0-beta.0",
+        "@valdres/hotkeys": "^1.0.0-beta.2",
       },
       "devDependencies": {
         "@testing-library/react": "16.3.0",
@@ -55,7 +55,7 @@
       },
       "peerDependencies": {
         "react": ">=18",
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
         "valdres-react": "^1.0.0-beta.1",
       },
     },
@@ -108,19 +108,19 @@
     },
     "packages/@valdres/bandwidth": {
       "name": "@valdres/bandwidth",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@valdres/public-ip": "workspace:^",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-color-scheme": {
       "name": "@valdres/browser-color-scheme",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -133,12 +133,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-contrast": {
       "name": "@valdres/browser-contrast",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -151,12 +151,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-device-motion": {
       "name": "@valdres/browser-device-motion",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@react-three/drei": "10.7.7",
@@ -173,12 +173,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-device-orientation": {
       "name": "@valdres/browser-device-orientation",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@react-three/drei": "10.7.7",
@@ -195,12 +195,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-focus": {
       "name": "@valdres/browser-focus",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -213,12 +213,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-geolocation": {
       "name": "@valdres/browser-geolocation",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -226,23 +226,23 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-keyboard": {
       "name": "@valdres/browser-keyboard",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-online": {
       "name": "@valdres/browser-online",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -250,15 +250,15 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-presence": {
       "name": "@valdres/browser-presence",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "dependencies": {
-        "@valdres/browser-focus": "^1.0.0-beta.1",
-        "@valdres/browser-visibility": "^1.0.0-beta.1",
+        "@valdres/browser-focus": "^1.0.0-beta.3",
+        "@valdres/browser-visibility": "^1.0.0-beta.3",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -272,12 +272,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-reduced-data": {
       "name": "@valdres/browser-reduced-data",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -290,12 +290,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-reduced-motion": {
       "name": "@valdres/browser-reduced-motion",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -308,12 +308,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-reduced-transparency": {
       "name": "@valdres/browser-reduced-transparency",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -326,12 +326,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-screen": {
       "name": "@valdres/browser-screen",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -339,12 +339,12 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-screen-details": {
       "name": "@valdres/browser-screen-details",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -352,12 +352,12 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-visibility": {
       "name": "@valdres/browser-visibility",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -370,12 +370,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/browser-window": {
       "name": "@valdres/browser-window",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -383,37 +383,37 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/color-mode": {
       "name": "@valdres/color-mode",
-      "version": "0.3.0-beta.0",
+      "version": "1.0.0-beta.2",
       "devDependencies": {
         "happy-dom": "18.0.1",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/hotkeys": {
       "name": "@valdres/hotkeys",
-      "version": "0.3.0-beta.0",
+      "version": "1.0.0-beta.2",
       "devDependencies": {
         "@valdres/browser-keyboard": "workspace:^",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "@valdres/browser-keyboard": "^1.0.0-beta.1",
-        "valdres": "^1.0.0-beta.1",
+        "@valdres/browser-keyboard": "^1.0.0-beta.3",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/@valdres/public-ip": {
       "name": "@valdres/public-ip",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "18.3.8",
@@ -426,7 +426,20 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
+      },
+    },
+    "packages/@valdres/redux-devtools": {
+      "name": "@valdres/redux-devtools",
+      "version": "1.0.0-beta.0",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "workspace:^",
+      },
+      "peerDependencies": {
+        "valdres": "^1.0.0-beta.4",
       },
     },
     "packages/documentation": {
@@ -452,7 +465,7 @@
     },
     "packages/valdres": {
       "name": "valdres",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@testing-library/react": "16.3.0",
         "jotai": "2.19.0",
@@ -466,7 +479,7 @@
     },
     "packages/valdres-angular": {
       "name": "valdres-angular",
-      "version": "0.1.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@angular/core": "19.2.0",
         "typescript": "5.9.2",
@@ -474,7 +487,7 @@
       },
       "peerDependencies": {
         "@angular/core": ">=17",
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/valdres-react": {
@@ -502,7 +515,7 @@
     },
     "packages/valdres-solid": {
       "name": "valdres-solid",
-      "version": "0.1.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "solid-js": "1.9.5",
         "typescript": "5.9.2",
@@ -510,12 +523,12 @@
       },
       "peerDependencies": {
         "solid-js": ">=1.8",
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/valdres-svelte": {
       "name": "valdres-svelte",
-      "version": "0.1.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@valdres/test": "workspace:^",
         "svelte": "5.28.2",
@@ -524,12 +537,12 @@
       },
       "peerDependencies": {
         "svelte": ">=5",
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
       },
     },
     "packages/valdres-vue": {
       "name": "valdres-vue",
-      "version": "0.1.0-beta.1",
+      "version": "1.0.0-beta.3",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@vue/test-utils": "2.4.6",
@@ -539,7 +552,7 @@
         "vue": "3.5.13",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.5",
         "vue": ">=3.3",
       },
     },
@@ -1234,6 +1247,8 @@
     "@valdres/hotkeys": ["@valdres/hotkeys@workspace:packages/@valdres/hotkeys"],
 
     "@valdres/public-ip": ["@valdres/public-ip@workspace:packages/@valdres/public-ip"],
+
+    "@valdres/redux-devtools": ["@valdres/redux-devtools@workspace:packages/@valdres/redux-devtools"],
 
     "@valdres/test": ["@valdres/test@workspace:packages/test"],
 
@@ -2682,6 +2697,10 @@
     "@valdres/public-ip/@types/react-dom": ["@types/react-dom@18.3.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg=="],
 
     "@valdres/public-ip/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/redux-devtools/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/redux-devtools/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@vanilla-extract/css/picocolors": ["picocolors@1.1.0", "", {}, "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="],
 

--- a/packages/@valdres/redux-devtools/bunfig.toml
+++ b/packages/@valdres/redux-devtools/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/redux-devtools/dev/index.html
+++ b/packages/@valdres/redux-devtools/dev/index.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/redux-devtools playground</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family: ui-sans-serif, system-ui, sans-serif;
+            }
+            body {
+                max-width: 56rem;
+                margin: 2.5rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0.25rem;
+            }
+            .sub {
+                color: color-mix(in srgb, currentColor 60%, transparent);
+                margin-top: 0;
+            }
+            .banner {
+                border: 1px solid color-mix(in srgb, #eab308 50%, transparent);
+                background: color-mix(in srgb, #eab308 12%, transparent);
+                border-radius: 0.5rem;
+                padding: 0.75rem 1rem;
+                margin: 1rem 0;
+                font-size: 0.9rem;
+            }
+            .banner.ok {
+                border-color: color-mix(in srgb, #22c55e 50%, transparent);
+                background: color-mix(in srgb, #22c55e 12%, transparent);
+            }
+            .grid {
+                display: grid;
+                grid-template-columns: 1fr 1fr;
+                gap: 1rem;
+            }
+            @media (max-width: 48rem) {
+                .grid {
+                    grid-template-columns: 1fr;
+                }
+            }
+            .card {
+                border: 1px solid
+                    color-mix(in srgb, currentColor 20%, transparent);
+                border-radius: 0.5rem;
+                padding: 1rem 1.25rem;
+            }
+            .card h2 {
+                margin: 0 0 0.5rem;
+                font-size: 1rem;
+            }
+            button {
+                font: inherit;
+                padding: 0.4rem 0.8rem;
+                margin: 0.2rem 0.3rem 0.2rem 0;
+                border: 1px solid color-mix(in srgb, currentColor 25%, transparent);
+                border-radius: 0.4rem;
+                background: color-mix(in srgb, currentColor 6%, transparent);
+                color: inherit;
+                cursor: pointer;
+            }
+            button:hover {
+                background: color-mix(in srgb, currentColor 14%, transparent);
+            }
+            input[type="text"] {
+                font: inherit;
+                padding: 0.35rem 0.5rem;
+                border: 1px solid
+                    color-mix(in srgb, currentColor 25%, transparent);
+                border-radius: 0.3rem;
+                background: transparent;
+                color: inherit;
+            }
+            .big {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-size: 1.4rem;
+            }
+            pre {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                font-size: 0.85rem;
+                white-space: pre-wrap;
+                word-break: break-all;
+                margin: 0;
+            }
+            code {
+                font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+                background: color-mix(in srgb, currentColor 10%, transparent);
+                padding: 0.05rem 0.3rem;
+                border-radius: 0.25rem;
+            }
+            .pill {
+                display: inline-block;
+                padding: 0.1rem 0.55rem;
+                border-radius: 999px;
+                font-size: 0.75rem;
+                margin-top: 0.4rem;
+                background: color-mix(in srgb, currentColor 12%, transparent);
+            }
+            .pill.own {
+                background: color-mix(in srgb, #3b82f6 28%, transparent);
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/redux-devtools</h1>
+        <p class="sub">
+            Drive a valdres store and watch every change flow into the Redux
+            DevTools extension — including scopes and time-travel.
+        </p>
+
+        <div id="status" class="banner">Checking for the Redux DevTools extension…</div>
+
+        <p class="sub" style="font-size: 0.85rem">
+            Open the <strong>Redux DevTools</strong> panel (browser devtools →
+            Redux tab), pick the <code>valdres-playground</code> instance, then
+            click around. Use the panel's slider / "Jump" to time-travel — the
+            page reflects the restored state live. The store is
+            <code>enumerable</code>, so the timeline opens already seeded with
+            the initial state (<code>count: 3</code>, a message, a todo) rather
+            than empty.
+        </p>
+
+        <div class="grid">
+            <div class="card">
+                <h2>counter <span class="sub">(root, named)</span></h2>
+                <div class="big" id="count">0</div>
+                <button id="inc">+1</button>
+                <button id="dec">−1</button>
+                <button id="reset-count">reset</button>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    Drives several selectors (see “derived state” below).
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>message <span class="sub">(root, named)</span></h2>
+                <input id="msg" type="text" placeholder="type something…" />
+            </div>
+
+            <div class="card">
+                <h2>todos <span class="sub">(root, named)</span></h2>
+                <button id="add-todo">add todo</button>
+                <button id="clear-todos">clear</button>
+                <pre id="todos">[]</pre>
+            </div>
+
+            <div class="card">
+                <h2>user/theme <span class="sub">(root, named)</span></h2>
+                <div class="big" id="theme-root">light</div>
+                <button id="toggle-theme-root">toggle root theme</button>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    The scope below inherits this until it's written.
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>user/theme <span class="sub">(scope: sessionA)</span></h2>
+                <div class="big" id="theme-scope">light</div>
+                <div id="theme-scope-badge" class="pill inherited">
+                    inherited from root
+                </div>
+                <div style="margin-top: 0.5rem">
+                    <button id="toggle-theme-scope">toggle (copy-on-write)</button>
+                    <button id="unset-theme-scope">unset → re-inherit</button>
+                </div>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    The first scope write copies-on-write into
+                    <code>@scopes.sessionA</code>; after that, root changes no
+                    longer affect it. <code>unset</code> drops the override so it
+                    re-inherits the root's current value again.
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>anonymous <span class="sub">(no name)</span></h2>
+                <button id="bump-anon">bump anonymous atom</button>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    Appears as <code>unnamed_atom_N</code> (one-time console
+                    hint). Stable this session, but name it for reload-safe
+                    time-travel.
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>transaction <span class="sub">(named commit)</span></h2>
+                <button id="run-txn">run transaction</button>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    Sets <code>count</code>, <code>message</code> and
+                    <code>todos</code> in one named
+                    <code>store.txn(fn, "seed demo data")</code> — DevTools shows
+                    a <strong>single</strong> action labelled
+                    <code>seed demo data</code>, and time-travel jumps all three
+                    together.
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>cross-scope txn <span class="sub">(root + scope)</span></h2>
+                <button id="run-xscope-txn">run cross-scope transaction</button>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    One <code>store.txn()</code> writing root atoms
+                    <em>and</em> <code>sessionA</code>. It coalesces into a
+                    <strong>single</strong> action —
+                    <code>txn (3 atoms · root, sessionA)</code> — and
+                    time-travel jumps the whole thing at once.
+                </p>
+            </div>
+
+            <div class="card">
+                <h2>derived state <span class="sub">(selectors)</span></h2>
+                <pre id="computed">{}</pre>
+                <p class="sub" style="font-size: 0.8rem; margin: 0.4rem 0 0">
+                    <code>doubleCount</code>, <code>countParity</code>,
+                    <code>todoCount</code>, <code>messageLength</code>, and
+                    <code>summary</code> are <strong>selectors</strong> — pure
+                    values derived from the atoms above. They recompute
+                    automatically (no setter) and appear under
+                    <code>@computed</code> in DevTools. <code>summary</code>
+                    derives from other selectors, so changing
+                    <code>count</code> cascades through both.
+                    <code>user/isDark</code> is subscribed inside
+                    <code>sessionA</code>, so it lands under that scope:
+                    <code>@scopes.sessionA.@computed.user/isDark</code>
+                    (root selectors stay in the top-level <code>@computed</code>).
+                    Display-only — selectors aren't restored by time-travel.
+                </p>
+            </div>
+        </div>
+
+        <div class="card" style="margin-top: 1rem">
+            <h2>live snapshot</h2>
+            <pre id="snapshot">{}</pre>
+        </div>
+
+        <script>
+            window.process = { env: { NODE_ENV: "development" } }
+        </script>
+        <script type="module" src="./main.ts"></script>
+    </body>
+</html>

--- a/packages/@valdres/redux-devtools/dev/main.ts
+++ b/packages/@valdres/redux-devtools/dev/main.ts
@@ -1,0 +1,241 @@
+import { atom, selector, store } from "valdres"
+import { connectReduxDevtools } from "../src"
+
+// `enumerable: true` lets the adapter seed the DevTools timeline with state
+// that already exists at connect time (via store.snapshot()), instead of
+// starting empty.
+const s = store("playground-root", { enumerable: true })
+
+// --- named atoms (tracked) -------------------------------------------------
+const countAtom = atom(0, { name: "count" })
+const messageAtom = atom("", { name: "message" })
+const todosAtom = atom<string[]>([], { name: "todos" })
+// scoped atom — written inside the "sessionA" scope below
+const themeAtom = atom<"light" | "dark">("light", { name: "user/theme" })
+// anonymous atom — intentionally NOT tracked, to demo the warning
+const anonAtom = atom(0)
+// derived state (selectors) — pure values computed from atoms. They recompute
+// automatically when a dependency changes, and appear under @computed when
+// connected with { selectors: true }. `summary` derives from other selectors,
+// showing a cascade (changing count recomputes doubleCount AND summary).
+const doubleCount = selector(get => get(countAtom) * 2, { name: "doubleCount" })
+const countParity = selector(
+    get => (get(countAtom) % 2 === 0 ? "even" : "odd"),
+    { name: "countParity" },
+)
+const todoCount = selector(get => get(todosAtom).length, { name: "todoCount" })
+const messageLength = selector(get => get(messageAtom).length, {
+    name: "messageLength",
+})
+const summary = selector(
+    get =>
+        `count=${get(countAtom)} (×2=${get(doubleCount)}), ${get(todoCount)} todo(s)`,
+    { name: "summary" },
+)
+// A selector over the *scoped* theme atom. Subscribed inside sessionA (below),
+// so it recomputes IN the scope and lands under @computed keyed by its scope
+// path: `sessionA/user/isDark` — flat, NOT nested under @scopes.
+const isDarkTheme = selector(get => get(themeAtom) === "dark", {
+    name: "user/isDark",
+})
+const derivedSelectors = [
+    doubleCount,
+    countParity,
+    todoCount,
+    messageLength,
+    summary,
+] as const
+
+const sessionA = s.scope("sessionA")
+
+// Seed a little state BEFORE connecting. On an enumerable store these are
+// captured by the initial snapshot, so the timeline opens already populated
+// (rather than empty) — the difference store.snapshot() makes.
+s.set(countAtom, 3)
+s.set(messageAtom, "hello from initial state")
+s.set(todosAtom, ["welcome"])
+
+// --- connect ----------------------------------------------------------------
+const hasExtension =
+    typeof window !== "undefined" && !!window.__REDUX_DEVTOOLS_EXTENSION__
+
+connectReduxDevtools(s, { name: "valdres-playground", selectors: true })
+
+const statusEl = document.getElementById("status")!
+if (hasExtension) {
+    statusEl.textContent =
+        "✓ Redux DevTools connected — open the Redux panel and pick “valdres-playground”."
+    statusEl.className = "banner ok"
+} else {
+    statusEl.textContent =
+        "⚠ Redux DevTools extension not detected. Install it (and reload) to see the timeline; the page still works."
+}
+
+// --- DOM wiring -------------------------------------------------------------
+const $ = (id: string) => document.getElementById(id)!
+
+const countEl = $("count")
+const msgEl = $("msg") as HTMLInputElement
+const todosEl = $("todos")
+const themeRootEl = $("theme-root")
+const themeScopeEl = $("theme-scope")
+const themeBadgeEl = $("theme-scope-badge")
+const snapshotEl = $("snapshot")
+const computedEl = $("computed")
+
+// The scope owns its own value (copy-on-write) only after it's been written;
+// until then it inherits the root. `data.values` is where the shadow lives.
+const scopeHasOwnTheme = () => sessionA.data.values.has(themeAtom)
+
+const renderCount = () => (countEl.textContent = String(s.get(countAtom)))
+const renderMessage = () => {
+    const v = s.get(messageAtom)
+    if (msgEl.value !== v) msgEl.value = v
+}
+const renderTodos = () =>
+    (todosEl.textContent = JSON.stringify(s.get(todosAtom), null, 2))
+const renderTheme = () => {
+    themeRootEl.textContent = s.get(themeAtom)
+    themeScopeEl.textContent = sessionA.get(themeAtom)
+    const own = scopeHasOwnTheme()
+    themeBadgeEl.textContent = own ? "own (copy-on-write)" : "inherited from root"
+    themeBadgeEl.className = `pill ${own ? "own" : "inherited"}`
+}
+const renderComputed = () => {
+    computedEl.textContent = JSON.stringify(
+        {
+            // Root selectors (top-level @computed). The scoped `user/isDark`
+            // selector lives under @scopes.sessionA.@computed — see the
+            // snapshot below.
+            doubleCount: s.get(doubleCount),
+            countParity: s.get(countParity),
+            todoCount: s.get(todoCount),
+            messageLength: s.get(messageLength),
+            summary: s.get(summary),
+        },
+        null,
+        2,
+    )
+}
+const renderSnapshot = () => {
+    const snapshot: Record<string, unknown> = {
+        count: s.get(countAtom),
+        message: s.get(messageAtom),
+        todos: s.get(todosAtom),
+        // anonymous atom — shown under the label DevTools assigns it
+        unnamed_atom_1: s.get(anonAtom),
+        "user/theme": s.get(themeAtom),
+        // Root derived state, mirrored under the top-level @computed.
+        "@computed": {
+            doubleCount: s.get(doubleCount),
+            countParity: s.get(countParity),
+            todoCount: s.get(todoCount),
+            messageLength: s.get(messageLength),
+            summary: s.get(summary),
+        },
+    }
+    // sessionA's bucket: its scoped selector lives under
+    // @scopes.sessionA.@computed; the `user/theme` override key only appears
+    // once it's copied-on-write.
+    const sessionBucket: Record<string, unknown> = {
+        "@computed": { "user/isDark": sessionA.get(isDarkTheme) },
+    }
+    if (scopeHasOwnTheme()) {
+        sessionBucket["user/theme"] = sessionA.get(themeAtom)
+    }
+    snapshot["@scopes"] = { sessionA: sessionBucket }
+    snapshotEl.textContent = JSON.stringify(snapshot, null, 2)
+}
+
+const renderAll = () => {
+    renderCount()
+    renderMessage()
+    renderTodos()
+    renderTheme()
+    renderComputed()
+    renderSnapshot()
+}
+
+// Re-render on every change (incl. time-travel restores).
+s.sub(countAtom, renderAll)
+// Keep the selectors live (a subscriber) so valdres reports their recomputes.
+for (const sel of derivedSelectors) s.sub(sel, renderAll)
+s.sub(messageAtom, renderAll)
+s.sub(todosAtom, renderAll)
+s.sub(anonAtom, renderAll)
+s.sub(themeAtom, renderAll)
+sessionA.sub(themeAtom, renderAll)
+// Subscribe the scoped selector IN the scope so it recomputes there → its
+// changes report with scope ["sessionA"] and land under @computed as
+// "sessionA/user/isDark".
+sessionA.sub(isDarkTheme, renderAll)
+
+$("inc").addEventListener("click", () =>
+    s.set(countAtom, c => c + 1),
+)
+$("dec").addEventListener("click", () =>
+    s.set(countAtom, c => c - 1),
+)
+$("reset-count").addEventListener("click", () => s.set(countAtom, 0))
+
+msgEl.addEventListener("input", () => s.set(messageAtom, msgEl.value))
+
+let todoN = 1
+$("add-todo").addEventListener("click", () =>
+    s.set(todosAtom, list => [...list, `task ${todoN++}`]),
+)
+$("clear-todos").addEventListener("click", () => s.set(todosAtom, []))
+
+// Root write — the scope reflects this while still inheriting.
+$("toggle-theme-root").addEventListener("click", () => {
+    s.set(themeAtom, t => (t === "light" ? "dark" : "light"))
+    renderAll()
+})
+
+// Scope write — copies-on-write into @scopes.sessionA; from now on the scope
+// diverges and root changes no longer affect it.
+$("toggle-theme-scope").addEventListener("click", () => {
+    sessionA.set(themeAtom, t => (t === "light" ? "dark" : "light"))
+    renderAll()
+})
+
+// Drop the scope's own value so it re-inherits the root's current value
+// (`unset`, the inverse of `set` — not `reset`, which would pin it to the
+// atom's default). The badge flips back to "inherited from root".
+$("unset-theme-scope").addEventListener("click", () => {
+    sessionA.unset(themeAtom)
+    renderAll()
+})
+
+$("bump-anon").addEventListener("click", () => {
+    s.set(anonAtom, n => n + 1)
+    renderAll()
+})
+
+// Multiple atoms changed in one named commit. The adapter fires once for the
+// whole batch and uses the transaction name as the action label, so DevTools
+// shows a single "seed demo data" action, not three.
+$("run-txn").addEventListener("click", () => {
+    s.txn(t => {
+        t.set(countAtom, t.get(countAtom) + 5)
+        t.set(messageAtom, "hello from a transaction")
+        t.set(todosAtom, [...t.get(todosAtom), "from a transaction"])
+    }, "seed demo data")
+    renderAll()
+})
+
+// A transaction spanning the root and the sessionA scope. `store.onChange`
+// delivers the whole commit as one batch, so DevTools shows a single action —
+// `txn (3 atoms · root, sessionA)` — and time-travel jumps all of it at once.
+$("run-xscope-txn").addEventListener("click", () => {
+    s.txn(t => {
+        t.set(countAtom, t.get(countAtom) + 1)
+        t.set(messageAtom, "from a cross-scope transaction")
+        t.scope("sessionA", st => {
+            st.set(themeAtom, st.get(themeAtom) === "light" ? "dark" : "light")
+        })
+    })
+    renderAll()
+})
+
+renderAll()

--- a/packages/@valdres/redux-devtools/package.json
+++ b/packages/@valdres/redux-devtools/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@valdres/redux-devtools",
+    "version": "1.0.0-beta.0",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bunx tsgo",
+        "test": "bun test",
+        "test:ci": "bun test",
+        "dev": "PORT=3020 bun --hot dev/index.html"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "workspace:^"
+    },
+    "peerDependencies": {
+        "valdres": "^1.0.0-beta.6"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
@@ -1,0 +1,586 @@
+import { afterEach, describe, expect, mock, test } from "bun:test"
+import { atom, atomFamily, selector, store } from "valdres"
+import { connectReduxDevtools } from "./connectReduxDevtools"
+import type {
+    ReduxDevtoolsConnection,
+    ReduxDevtoolsExtension,
+    ReduxDevtoolsMessage,
+} from "./types/ReduxDevtools"
+
+const makeFakeExtension = () => {
+    const inits: unknown[] = []
+    const sent: {
+        action: ({ type: string } & Record<string, unknown>) | null
+        state: any
+    }[] = []
+    const errors: string[] = []
+    let messageListener: ((m: ReduxDevtoolsMessage) => void) | undefined
+    let connectOptions: { name?: string; features?: any } | undefined
+    let disconnected = false
+
+    const connection: ReduxDevtoolsConnection = {
+        init: state => inits.push(state),
+        send: (action, state) => sent.push({ action, state }),
+        subscribe: listener => {
+            messageListener = listener
+            return () => {
+                messageListener = undefined
+            }
+        },
+        unsubscribe: () => {},
+        error: message => errors.push(message),
+    }
+
+    const ext: ReduxDevtoolsExtension = {
+        connect: options => {
+            connectOptions = options
+            return connection
+        },
+        disconnect: () => {
+            disconnected = true
+        },
+    }
+
+    return {
+        ext,
+        inits,
+        sent,
+        errors,
+        dispatch: (message: ReduxDevtoolsMessage) => messageListener?.(message),
+        connectOptions: () => connectOptions,
+        wasDisconnected: () => disconnected,
+    }
+}
+
+const install = (ext?: ReduxDevtoolsExtension) => {
+    ;(window as any).__REDUX_DEVTOOLS_EXTENSION__ = ext
+}
+
+afterEach(() => {
+    delete (window as any).__REDUX_DEVTOOLS_EXTENSION__
+})
+
+describe("connectReduxDevtools", () => {
+    test("a non-enumerable store seeds an empty timeline", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store() // default: not enumerable
+        const a = atom(0, { name: "empty_a" })
+        s.set(a, 1) // pre-existing, but not enumerable → not seeded
+        const handle = connectReduxDevtools(s, { name: "my-app" })
+
+        expect(fake.connectOptions()?.name).toBe("my-app")
+        expect(fake.inits).toHaveLength(1)
+        expect(Object.keys(fake.inits[0] as object)).toHaveLength(0)
+        handle.disconnect()
+    })
+
+    test("seeds the initial snapshot from an enumerable store", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("seed_root", { enumerable: true })
+        const a = atom(0, { name: "seed_a" })
+        const b = atom("x", { name: "seed_b" })
+        s.set(a, 5)
+        s.set(b, "y")
+        const scoped = s.scope("sess")
+        const c = atom(0, { name: "seed_c" })
+        scoped.set(c, 9)
+
+        const handle = connectReduxDevtools(s)
+
+        const init = fake.inits[0] as any
+        expect(init.seed_a).toBe(5)
+        expect(init.seed_b).toBe("y")
+        expect(init["@scopes"].sess.seed_c).toBe(9)
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("seeds derived state from an enumerable store when selectors are on", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("seed_sel_root", { enumerable: true })
+        const a = atom(2, { name: "ssa" })
+        const double = selector(get => get(a) * 2, { name: "ssDouble" })
+        s.sub(double, () => {}) // live + materialized
+        s.set(a, 3)
+
+        const handle = connectReduxDevtools(s, { selectors: true })
+
+        const init = fake.inits[0] as any
+        expect(init.ssa).toBe(3)
+        expect(init["@computed"].ssDouble).toBe(6)
+        handle.disconnect()
+    })
+
+    test("sends an action with the new value when a named atom is set", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "ct_set_count" })
+        const handle = connectReduxDevtools(s)
+
+        s.set(a, 42)
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("ct_set_count")
+        expect(last.action.source).toBe("set")
+        expect(last.state.ct_set_count).toBe(42)
+        handle.disconnect()
+    })
+
+    test("reset is tagged distinctly from a set", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(7, { name: "ct_reset" })
+        const handle = connectReduxDevtools(s)
+
+        s.set(a, 1)
+        s.reset(a)
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("ct_reset (reset)")
+        expect(last.state.ct_reset).toBe(7)
+        handle.disconnect()
+    })
+
+    test("a named transaction uses its name as the action label", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "tx_a" })
+        const b = atom(0, { name: "tx_b" })
+        const handle = connectReduxDevtools(s)
+
+        s.txn(t => {
+            t.set(a, 1)
+            t.set(b, 2)
+        }, "init-user")
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("init-user")
+        expect(last.action.name).toBe("init-user")
+        expect(last.state.tx_a).toBe(1)
+        expect(last.state.tx_b).toBe(2)
+        handle.disconnect()
+    })
+
+    test("an unnamed transaction reads txn (N atoms)", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "ut_a" })
+        const b = atom(0, { name: "ut_b" })
+        const handle = connectReduxDevtools(s)
+
+        s.txn(t => {
+            t.set(a, 1)
+            t.set(b, 2)
+        })
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("txn (2 atoms)")
+        expect(last.action.atoms).toEqual(["ut_a", "ut_b"])
+        handle.disconnect()
+    })
+
+    test("scope writes read @scope:path and nest under @scopes", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("scope_root")
+        const a = atom(0, { name: "sc_atom" })
+        const handle = connectReduxDevtools(s)
+
+        const scoped = s.scope("sessionA")
+        scoped.set(a, 7)
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("@scope:sessionA sc_atom")
+        expect(last.action.atoms).toEqual(["sessionA/sc_atom"])
+        expect(last.state["@scopes"].sessionA.sc_atom).toBe(7)
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("a cross-scope txn coalesces into a single action", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("xs_root")
+        const r = atom(0, { name: "xs_r" })
+        const sc = atom(0, { name: "xs_sc" })
+        const handle = connectReduxDevtools(s)
+        const scoped = s.scope("sessionC")
+
+        const before = fake.sent.length
+        s.txn(t => {
+            t.set(r, 1)
+            t.scope("sessionC", st => st.set(sc, 2))
+        })
+
+        const newActions = fake.sent.slice(before)
+        expect(newActions).toHaveLength(1)
+        expect(newActions[0].action.type).toBe("txn (2 atoms · root, sessionC)")
+        expect(newActions[0].state.xs_r).toBe(1)
+        expect(newActions[0].state["@scopes"].sessionC.xs_sc).toBe(2)
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("unset drops a scope override and the scope re-inherits", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("un_root")
+        const a = atom("light", { name: "un_theme" })
+        const handle = connectReduxDevtools(s)
+        const scoped = s.scope("sess")
+
+        scoped.set(a, "dark")
+        expect(fake.sent.at(-1)!.state["@scopes"].sess.un_theme).toBe("dark")
+
+        scoped.unset(a)
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.source).toBe("unset")
+        expect(last.action.type).toBe("@scope:sess un_theme (reverted)")
+        // Override is gone from the snapshot; the scope re-inherits the root.
+        expect(last.state["@scopes"].sess?.un_theme).toBeUndefined()
+        expect(scoped.get(a)).toBe("light")
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("unset inside a transaction still drops the scope override", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("untx_root")
+        const a = atom("light", { name: "untx_theme" })
+        const handle = connectReduxDevtools(s)
+        const scoped = s.scope("sess")
+
+        scoped.set(a, "dark")
+        expect(fake.sent.at(-1)!.state["@scopes"].sess.untx_theme).toBe("dark")
+
+        // Inside a txn the batch source is "transaction", so the per-change
+        // `kind: "unset"` is the only signal — the override must still drop.
+        s.txn(t => {
+            t.scope("sess", st => st.unset(a))
+        })
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.source).toBe("transaction")
+        expect(last.state["@scopes"].sess?.untx_theme).toBeUndefined()
+        expect(scoped.get(a)).toBe("light")
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("jumping back before a scope override re-inherits (not default)", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("rib_root")
+        const a = atom(0, { name: "rib_a" })
+        const handle = connectReduxDevtools(s)
+        const scoped = s.scope("sess")
+
+        s.set(a, 1) // root = 1; scope inherits
+        const beforeOverride = fake.sent.at(-1)!.state
+        scoped.set(a, 99) // scope override
+        expect(scoped.get(a)).toBe(99)
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "JUMP_TO_ACTION" },
+            state: JSON.stringify(beforeOverride),
+        })
+
+        // unset, not reset: re-inherits the root's 1, not the atom default 0.
+        expect(scoped.get(a)).toBe(1)
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("a family-atom deletion is tagged and removed from state", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const items = atomFamily(0, { name: "items" })
+        const x = items("x")
+        const handle = connectReduxDevtools(s)
+
+        s.set(x, 5)
+        expect(fake.sent.at(-1)!.state.items_x).toBe(5)
+
+        s.del(x)
+        const last = fake.sent.at(-1)!
+        expect(last.action.type).toBe("items_x (deleted)")
+        expect(last.action.source).toBe("delete")
+        expect("items_x" in last.state).toBe(false)
+        handle.disconnect()
+    })
+
+    test("tracks unnamed atoms as unnamed_atom_N with a one-time hint", () => {
+        const warn = mock(() => {})
+        const original = console.warn
+        console.warn = warn
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const anon = atom(0)
+        const handle = connectReduxDevtools(s)
+
+        s.set(anon, 1)
+        s.set(anon, 2)
+
+        const labels = fake.sent.map(e => e.action.type)
+        expect(labels).toEqual(["unnamed_atom_1", "unnamed_atom_1"])
+        expect(fake.sent.at(-1)!.state.unnamed_atom_1).toBe(2)
+        expect(warn).toHaveBeenCalledTimes(1)
+        console.warn = original
+        handle.disconnect()
+    })
+
+    test('unnamed: "ignore" leaves unnamed atoms out entirely', () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const anon = atom(0)
+        const handle = connectReduxDevtools(s, { unnamed: "ignore" })
+
+        s.set(anon, 1)
+
+        expect(fake.sent).toHaveLength(0)
+        handle.disconnect()
+    })
+
+    test("selectors: true reports named derived values under @computed", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(1, { name: "sel_a" })
+        const double = selector(get => get(a) * 2, { name: "double" })
+        s.sub(double, () => {}) // make the selector live
+        const handle = connectReduxDevtools(s, { selectors: true })
+
+        s.set(a, 5)
+
+        const last = fake.sent.at(-1)!
+        expect(last.state.sel_a).toBe(5)
+        expect(last.state["@computed"].double).toBe(10)
+        handle.disconnect()
+    })
+
+    test("a scope selector lands under @scopes.<scope>.@computed", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("scsel_root")
+        const a = atom<"light" | "dark">("light", { name: "scsel_theme" })
+        const isDark = selector(get => get(a) === "dark", {
+            name: "scsel_isDark",
+        })
+        const scoped = s.scope("sess")
+        scoped.sub(isDark, () => {}) // live in the scope
+        const handle = connectReduxDevtools(s, { selectors: true })
+
+        scoped.set(a, "dark") // scope override → isDark recomputes in scope
+
+        const last = fake.sent.at(-1)!
+        expect(last.state["@scopes"].sess["@computed"].scsel_isDark).toBe(true)
+        expect(last.state["@scopes"].sess.scsel_theme).toBe("dark")
+        // It is NOT in the top-level @computed.
+        expect(last.state["@computed"]?.scsel_isDark).toBeUndefined()
+        handle.disconnect()
+        scoped.detach()
+    })
+
+    test("selectors are not reported by default", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(1, { name: "nosel_a" })
+        const double = selector(get => get(a) * 2, { name: "nosel_double" })
+        s.sub(double, () => {})
+        const handle = connectReduxDevtools(s)
+
+        s.set(a, 5)
+
+        const last = fake.sent.at(-1)!
+        expect(last.state.nosel_a).toBe(5)
+        expect(last.state["@computed"]).toBeUndefined()
+        handle.disconnect()
+    })
+
+    test("PAUSE_RECORDING stops and resumes adding timeline entries", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "pause_a" })
+        const handle = connectReduxDevtools(s)
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "PAUSE_RECORDING", status: true },
+        })
+        const sentWhilePaused = fake.sent.length
+        s.set(a, 1)
+        expect(fake.sent.length).toBe(sentWhilePaused) // nothing recorded
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "PAUSE_RECORDING", status: false },
+        })
+        s.set(a, 2)
+        const last = fake.sent.at(-1)!
+        expect(last.state.pause_a).toBe(2) // model stayed current through pause
+        handle.disconnect()
+    })
+
+    test("IMPORT_STATE restores current state and hands the lifted history back", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "imp_a" })
+        const handle = connectReduxDevtools(s)
+        s.set(a, 1) // register the name so restore can resolve it
+
+        const lifted = {
+            computedStates: [{ state: { imp_a: 1 } }, { state: { imp_a: 9 } }],
+            currentStateIndex: 1,
+        }
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "IMPORT_STATE", nextLiftedState: lifted },
+        })
+
+        // Store restored to the imported current state...
+        expect(s.get(a)).toBe(9)
+        // ...and the lifted history handed back via send(null, lifted).
+        const last = fake.sent.at(-1)!
+        expect(last.action).toBeNull()
+        expect(last.state).toBe(lifted)
+        handle.disconnect()
+    })
+
+    test("time-travel JUMP_TO_ACTION restores values onto the store", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "jump_count" })
+        const handle = connectReduxDevtools(s)
+
+        s.set(a, 1)
+        s.set(a, 2)
+        expect(s.get(a)).toBe(2)
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "JUMP_TO_ACTION" },
+            state: JSON.stringify({ jump_count: 1 }),
+        })
+
+        expect(s.get(a)).toBe(1)
+        handle.disconnect()
+    })
+
+    test("jumping back resets atoms that first appeared after that point", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "re_a" })
+        const b = atom(0, { name: "re_b" })
+        const handle = connectReduxDevtools(s)
+
+        s.set(a, 1)
+        const stateBeforeB = fake.sent.at(-1)!.state
+        s.set(b, 99)
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "JUMP_TO_ACTION" },
+            state: JSON.stringify(stateBeforeB),
+        })
+
+        expect(s.get(a)).toBe(1)
+        expect(s.get(b)).toBe(0)
+        handle.disconnect()
+    })
+
+    test("restoring does not echo back as a new action", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "echo_count" })
+        const handle = connectReduxDevtools(s)
+        s.set(a, 1)
+        const sentBefore = fake.sent.length
+
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "JUMP_TO_ACTION" },
+            state: JSON.stringify({ echo_count: 0 }),
+        })
+
+        expect(fake.sent.length).toBe(sentBefore)
+        handle.disconnect()
+    })
+
+    test("skip/reorder surface an error without touching state or history", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "skip_count" })
+        const handle = connectReduxDevtools(s)
+        s.set(a, 1)
+        const initsBefore = fake.inits.length
+        const sentBefore = fake.sent.length
+
+        fake.dispatch({ type: "DISPATCH", payload: { type: "TOGGLE_ACTION" } })
+
+        expect(fake.errors).toHaveLength(1)
+        expect(fake.errors[0]).toContain("TOGGLE_ACTION")
+        expect(s.get(a)).toBe(1)
+        expect(fake.inits.length).toBe(initsBefore)
+        expect(fake.sent.length).toBe(sentBefore)
+        handle.disconnect()
+    })
+
+    test("disconnect stops sends and detaches our listener (not the extension)", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "disc_count" })
+        const handle = connectReduxDevtools(s)
+
+        handle.disconnect()
+        // Per-connection teardown only — the global ext.disconnect() must NOT
+        // be called (it would kill other connected stores).
+        expect(fake.wasDisconnected()).toBe(false)
+        // No more sends, and an incoming message is ignored (listener removed).
+        const sentAfterDisconnect = fake.sent.length
+        s.set(a, 99)
+        fake.dispatch({
+            type: "DISPATCH",
+            payload: { type: "JUMP_TO_ACTION" },
+            state: JSON.stringify({ disc_count: 7 }),
+        })
+        expect(fake.sent.length).toBe(sentAfterDisconnect)
+        expect(s.get(a)).toBe(99) // jump after disconnect did nothing
+    })
+
+    test("returns a no-op and warns when the extension is absent", () => {
+        const warn = mock(() => {})
+        const original = console.warn
+        console.warn = warn
+        install(undefined)
+        const s = store()
+        const a = atom(0, { name: "noext_count" })
+
+        const handle = connectReduxDevtools(s)
+        s.set(a, 1) // must not throw
+
+        expect(warn).toHaveBeenCalledTimes(1)
+        expect(() => handle.disconnect()).not.toThrow()
+        console.warn = original
+    })
+})

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
@@ -1,0 +1,338 @@
+import type {
+    Atom,
+    Store,
+    StoreChange,
+    StoreChangeMeta,
+    StoreChangeSource,
+} from "valdres"
+import type {
+    ConnectReduxDevtoolsOptions,
+    ReduxDevtoolsHandle,
+} from "./types/ConnectReduxDevtoolsOptions"
+import type { DevtoolsSnapshot } from "./types/DevtoolsSnapshot"
+import { createNameRegistry } from "./lib/nameRegistry"
+import { restoreSnapshot } from "./lib/restoreSnapshot"
+import { atomBucket, cloneSnapshot, computedBucket } from "./lib/snapshot"
+
+const noop: ReduxDevtoolsHandle = { disconnect() {} }
+
+/** Suffix tag for automatic / non-`set` operations, so the timeline can tell
+ *  a reset/delete/revalidation apart from a plain assignment. */
+const SOURCE_TAG: Record<StoreChangeSource, string> = {
+    set: "",
+    transaction: "",
+    reset: "reset",
+    delete: "deleted",
+    unset: "reverted",
+    revalidate: "revalidate",
+    "async-set": "resolved",
+}
+
+/** Build the Redux action label for one committed operation. A named
+ *  transaction uses its name verbatim; otherwise we synthesize from the changed
+ *  atoms, the scopes they touched, and the operation source. */
+const buildLabel = (
+    meta: StoreChangeMeta,
+    qualified: string[],
+    scopesTouched: Set<string>,
+    lastBareName: string,
+): string => {
+    if (meta.name) return meta.name
+    const scopes = [...scopesTouched]
+    const count = qualified.length
+    let base: string
+    if (scopes.length === 1) {
+        const scope = scopes[0]
+        const prefix = scope === "root" ? "" : `@scope:${scope} `
+        const core =
+            count === 1
+                ? lastBareName
+                : meta.source === "transaction"
+                  ? `txn (${count} atoms)`
+                  : `${count} atoms`
+        base = prefix + core
+    } else {
+        base = `txn (${count} atoms · ${scopes.join(", ")})`
+    }
+    const tag = SOURCE_TAG[meta.source]
+    return tag ? `${base} (${tag})` : base
+}
+
+/**
+ * Connect a valdres store to the Redux DevTools browser extension.
+ *
+ * Every committed change to a named atom (in the store or any scope) is sent as
+ * an action, and the extension's time-travel / commit / reset controls restore
+ * state back onto the store. Built on `store.onChange`, so a transaction —
+ * including one spanning scopes — arrives as a single action (named via
+ * `store.txn(fn, name)` when you provide one).
+ *
+ * Unnamed atoms are tracked as `unnamed_atom_N` by default; pass
+ * `unnamed: "ignore"` to leave them out. Returns a handle whose `disconnect()`
+ * detaches everything; a no-op handle (with a warning) when the extension isn't
+ * installed.
+ */
+export const connectReduxDevtools = (
+    store: Store,
+    options: ConnectReduxDevtoolsOptions = {},
+): ReduxDevtoolsHandle => {
+    const ext =
+        typeof window !== "undefined"
+            ? window.__REDUX_DEVTOOLS_EXTENSION__
+            : undefined
+    if (!ext) {
+        console.warn(
+            "[@valdres/redux-devtools] Redux DevTools extension not found — connectReduxDevtools() is a no-op. Install the extension and reload.",
+        )
+        return noop
+    }
+
+    const {
+        name = "valdres",
+        serialize = (_atom, value) => value,
+        scopes: includeScopes = true,
+        unnamed = "track",
+        selectors: includeSelectors = false,
+    } = options
+
+    // NB: we intentionally do NOT pass a `features` object to disable the
+    // reducer-only controls (skip/reorder/dispatch). In practice the extension
+    // couples the action-row toolbar to those flags and hides the Jump button
+    // when skip/reorder are disabled — even with `jump: true`. So we leave the
+    // monitor's defaults intact (Jump/slider work) and instead surface an
+    // in-panel error if skip/reorder is actually dispatched (see below).
+    const connection = ext.connect({ name })
+    const names = createNameRegistry(unnamed)
+
+    const model: DevtoolsSnapshot = {}
+
+    // Seed the timeline with state that already exists. Only enumerable stores
+    // (`store(id, { enumerable: true })`) can be enumerated — a default store's
+    // values live in a WeakMap, so we skip (no `snapshot()` call, no warning)
+    // and the model fills in via onChange as state first changes.
+    if (store.data.enumerable) {
+        for (const entry of store.snapshot()) {
+            if (entry.scope.length > 0 && !includeScopes) continue
+            const scopeKey =
+                entry.scope.length === 0 ? null : entry.scope.join("/")
+            if (entry.type === "selector") {
+                if (!includeSelectors) continue
+                const selName = entry.state.name
+                if (!selName) continue
+                // Root selectors → top-level @computed; scope selectors →
+                // @scopes.<scope>.@computed, keyed by bare selector name.
+                computedBucket(model, scopeKey)[selName] = serialize(
+                    entry.state,
+                    entry.value,
+                )
+                continue
+            }
+            const atomName = names.nameFor(entry.state)
+            if (!atomName) continue
+            atomBucket(model, scopeKey)[atomName] = serialize(
+                entry.state,
+                entry.value,
+            )
+        }
+    }
+
+    // Captured after seeding, so RESET returns to the connect-time state.
+    const initial = cloneSnapshot(model)
+    connection.init(cloneSnapshot(model))
+
+    let isRestoring = false
+    let paused = false
+
+    const overwriteModel = (target: DevtoolsSnapshot) => {
+        for (const key of Object.keys(model)) delete model[key]
+        const clone = cloneSnapshot(target)
+        for (const key of Object.keys(clone)) model[key] = clone[key]
+    }
+
+    const resolveAtom = (atomName: string): Atom<any> | undefined =>
+        names.resolve(atomName) as Atom<any> | undefined
+
+    const handleChanges = (
+        changes: readonly StoreChange[],
+        meta: StoreChangeMeta,
+    ) => {
+        if (isRestoring) return
+
+        const qualified: string[] = []
+        const scopesTouched = new Set<string>()
+        let lastBareName = ""
+        let computedTouched = false
+
+        for (const change of changes) {
+            if (change.scope.length > 0 && !includeScopes) continue
+            const scopeKey =
+                change.scope.length === 0 ? null : change.scope.join("/")
+
+            // Derived (selector) values: display-only, under @computed, keyed by
+            // scope-qualified selector name. Unnamed selectors are skipped.
+            if (change.type === "selector") {
+                const selName = change.state.name
+                if (!selName) continue
+                // Root selectors → top-level @computed; scope selectors →
+                // @scopes.<scope>.@computed, keyed by bare selector name.
+                computedBucket(model, scopeKey)[selName] = serialize(
+                    change.state,
+                    change.value,
+                )
+                computedTouched = true
+                continue
+            }
+
+            const atomName = names.nameFor(change.state)
+            if (!atomName) continue // unnamed atom + unnamed: "ignore"
+            const bucket = atomBucket(model, scopeKey)
+
+            // `kind` is authoritative (it distinguishes an unset from a set even
+            // inside a transaction, where meta.source is "transaction"):
+            //  - delete        → the atom is gone, remove it.
+            //  - unset + scope → the override is gone and the scope re-inherits,
+            //                    so drop it from `@scopes` rather than showing
+            //                    the inherited value as if it were an override.
+            //  - unset + root  → reverted to default; that IS the root's value.
+            //  - set           → the new value.
+            if (
+                change.kind === "delete" ||
+                (change.kind === "unset" && scopeKey !== null)
+            ) {
+                delete bucket[atomName]
+            } else {
+                bucket[atomName] = serialize(change.state, change.value)
+            }
+
+            scopesTouched.add(scopeKey === null ? "root" : scopeKey)
+            lastBareName = atomName
+            qualified.push(scopeKey === null ? atomName : `${scopeKey}/${atomName}`)
+        }
+        if (qualified.length === 0 && !computedTouched) return
+        // Recording paused from the monitor: keep the model current (so the next
+        // recorded action carries up-to-date state) but don't add a timeline
+        // entry.
+        if (paused) return
+
+        const type =
+            qualified.length > 0
+                ? buildLabel(meta, qualified, scopesTouched, lastBareName)
+                : "(derived)"
+        connection.send(
+            {
+                type,
+                atoms: qualified,
+                source: meta.source,
+                ...(meta.name ? { name: meta.name } : {}),
+            },
+            cloneSnapshot(model),
+        )
+    }
+
+    const unsubscribeStore = includeSelectors
+        ? store.onChange(handleChanges, { selectors: true })
+        : store.onChange(handleChanges)
+
+    const unsubscribeConnection = connection.subscribe(message => {
+        if (message.type !== "DISPATCH" || !message.payload) return
+        const dispatchType = message.payload.type
+        const jumpTo = (raw: string | undefined) => {
+            if (!raw) return
+            let target: DevtoolsSnapshot
+            try {
+                target = JSON.parse(raw)
+            } catch {
+                return
+            }
+            isRestoring = true
+            try {
+                restoreSnapshot(store, target, model, resolveAtom, includeScopes)
+                overwriteModel(target)
+            } finally {
+                isRestoring = false
+            }
+        }
+
+        switch (dispatchType) {
+            case "JUMP_TO_ACTION":
+            case "JUMP_TO_STATE":
+                jumpTo(message.state)
+                break
+            case "ROLLBACK":
+                jumpTo(message.state)
+                connection.init(cloneSnapshot(model))
+                break
+            case "RESET":
+                jumpTo(JSON.stringify(initial))
+                connection.init(cloneSnapshot(model))
+                break
+            case "COMMIT":
+                connection.init(cloneSnapshot(model))
+                break
+            case "PAUSE_RECORDING": {
+                // Stop / resume adding timeline entries. `status` is the desired
+                // paused state; toggle if absent.
+                const status = (message.payload as { status?: unknown }).status
+                paused = typeof status === "boolean" ? status : !paused
+                break
+            }
+            case "IMPORT_STATE": {
+                // Load a previously exported session: restore the store to the
+                // imported *current* state, then hand the imported lifted
+                // history back via `send(null, lifted)` so the monitor shows it.
+                // (We can't replay the history action-by-action — valdres has no
+                // reducer — but the store + timeline end up consistent.)
+                const lifted = (
+                    message.payload as { nextLiftedState?: any }
+                ).nextLiftedState
+                const states = lifted?.computedStates
+                if (!Array.isArray(states) || states.length === 0) break
+                const idx =
+                    typeof lifted.currentStateIndex === "number"
+                        ? lifted.currentStateIndex
+                        : states.length - 1
+                const target = states[idx]?.state
+                if (target && typeof target === "object") {
+                    isRestoring = true
+                    try {
+                        restoreSnapshot(
+                            store,
+                            target,
+                            model,
+                            resolveAtom,
+                            includeScopes,
+                        )
+                        overwriteModel(target)
+                    } finally {
+                        isRestoring = false
+                    }
+                }
+                connection.send(null, lifted)
+                break
+            }
+            case "TOGGLE_ACTION":
+            case "REORDER_ACTION":
+                // Skip/reorder recompute state by replaying actions through a
+                // reducer — valdres has no reducer, only per-operation changes,
+                // so these can't be honored. Surface it in the panel and leave
+                // both the store and the action history untouched. (Do NOT
+                // re-init here — init re-seeds the monitor and wipes history.)
+                connection.error(
+                    `[@valdres/redux-devtools] "${dispatchType}" (skip/reorder) is not supported — valdres reports state changes, not replayable actions. Use jump / commit / reset instead.`,
+                )
+                break
+        }
+    })
+
+    return {
+        disconnect() {
+            // Per-connection teardown only: stop observing the store and remove
+            // our message listener. NOT `ext.disconnect()` — that's global and
+            // would tear down any other connected store instances too.
+            unsubscribeStore()
+            if (typeof unsubscribeConnection === "function") {
+                unsubscribeConnection()
+            }
+        },
+    }
+}

--- a/packages/@valdres/redux-devtools/src/index.ts
+++ b/packages/@valdres/redux-devtools/src/index.ts
@@ -1,0 +1,12 @@
+export { connectReduxDevtools } from "./connectReduxDevtools"
+
+export type {
+    ConnectReduxDevtoolsOptions,
+    ReduxDevtoolsHandle,
+} from "./types/ConnectReduxDevtoolsOptions"
+export type { DevtoolsSnapshot } from "./types/DevtoolsSnapshot"
+export type {
+    ReduxDevtoolsConnection,
+    ReduxDevtoolsExtension,
+    ReduxDevtoolsMessage,
+} from "./types/ReduxDevtools"

--- a/packages/@valdres/redux-devtools/src/lib/nameRegistry.ts
+++ b/packages/@valdres/redux-devtools/src/lib/nameRegistry.ts
@@ -1,0 +1,63 @@
+export type UnnamedMode = "track" | "ignore"
+
+export interface NameRegistry {
+    /**
+     * The label for an atom: its declared `name`, or a synthetic
+     * `unnamed_atom_N` in `"track"` mode. `null` for an unnamed atom when the
+     * mode is `"ignore"`. Registers the name → atom mapping so time-travel can
+     * resolve it back.
+     */
+    nameFor(atom: { name?: string }): string | null
+    /** Reverse lookup (name → atom) used by time-travel restore. */
+    resolve(name: string): object | undefined
+}
+
+/**
+ * Per-connection atom ↔ name map. valdres core has no name registry, so the
+ * adapter builds its own as atoms flow through `store.onChange`: named atoms map
+ * by their `name`, unnamed ones get a synthetic `unnamed_atom_N` (in `"track"`
+ * mode) assigned in encounter order. Synthetic labels are stable for the
+ * session but NOT across reloads, so the first one logs a one-time hint. The
+ * reverse map holds atoms strongly only for the connection's lifetime (dropped
+ * on `disconnect()`).
+ */
+export const createNameRegistry = (mode: UnnamedMode): NameRegistry => {
+    const reverse = new Map<string, object>()
+    const synthetic = new WeakMap<object, string>()
+    let counter = 0
+    let hintShown = false
+    let collisionWarned = false
+
+    return {
+        nameFor(atom) {
+            const declared = atom.name
+            if (declared) {
+                const existing = reverse.get(declared)
+                if (existing && existing !== atom && !collisionWarned) {
+                    collisionWarned = true
+                    console.warn(
+                        `[@valdres/redux-devtools] Two different atoms share the name "${declared}". Time-travel may restore the wrong one — give them distinct names.`,
+                    )
+                }
+                reverse.set(declared, atom)
+                return declared
+            }
+            const cached = synthetic.get(atom)
+            if (cached) return cached
+            if (mode === "ignore") return null
+            const name = `unnamed_atom_${++counter}`
+            synthetic.set(atom, name)
+            reverse.set(name, atom)
+            if (!hintShown) {
+                hintShown = true
+                console.warn(
+                    '[@valdres/redux-devtools] Some atoms have no `name` and are tracked as `unnamed_atom_N`. These labels are not stable across reloads — add { name: "…" } to the atoms you want meaningful, restorable time-travel for.',
+                )
+            }
+            return name
+        },
+        resolve(name) {
+            return reverse.get(name)
+        },
+    }
+}

--- a/packages/@valdres/redux-devtools/src/lib/restoreSnapshot.ts
+++ b/packages/@valdres/redux-devtools/src/lib/restoreSnapshot.ts
@@ -1,0 +1,120 @@
+import type { Atom, Store, StoreData } from "valdres"
+import type { DevtoolsSnapshot } from "../types/DevtoolsSnapshot"
+import { COMPUTED_KEY, SCOPES_KEY } from "./snapshot"
+
+/** Resolve a scope's StoreData by walking the path, or null if it's gone. */
+const resolveScopeData = (
+    rootData: StoreData,
+    ids: string[],
+): StoreData | null => {
+    let cur: StoreData = rootData
+    for (const id of ids) {
+        const next = cur.scopes.get(id)
+        if (!next) return null
+        cur = next
+    }
+    return cur
+}
+
+/** Run `fn` against an existing nested scope using the side-effect-free
+ *  callback form of `scope()` (it doesn't register a detach consumer). */
+const withScope = (
+    store: { scope: Store["scope"] },
+    ids: string[],
+    fn: (scoped: any) => void,
+): void => {
+    if (ids.length === 0) {
+        fn(store)
+        return
+    }
+    const [head, ...rest] = ids
+    store.scope(head, scoped => withScope(scoped, rest, fn))
+}
+
+type ResolveAtom = (name: string) => Atom<any> | undefined
+
+const rootValuesOf = (snapshot: DevtoolsSnapshot): Record<string, unknown> => {
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(snapshot)) {
+        // @computed is derived/display-only and @scopes is handled separately.
+        if (key !== SCOPES_KEY && key !== COMPUTED_KEY) out[key] = snapshot[key]
+    }
+    return out
+}
+
+/**
+ * Reconcile one store/scope to `target`: set every atom the target names, and
+ * `unset` every atom that's tracked *now* (`current`) but absent from the
+ * target — i.e. atoms that first got a value after the point we're jumping to.
+ * Without the second pass those would "stick" at their later value. `unset`
+ * drops the store's own value, which is exactly "revert to before it was set":
+ * a scope re-inherits the parent's current value, a root reverts to the default.
+ * All in one `txn` so selectors recompute once.
+ */
+const reconcileInto = (
+    txnStore: { txn: Store["txn"] },
+    target: Record<string, unknown>,
+    current: Record<string, unknown>,
+    resolveAtom: ResolveAtom,
+) => {
+    txnStore.txn(t => {
+        for (const name of Object.keys(target)) {
+            if (name === COMPUTED_KEY) continue // derived, never restored
+            const atom = resolveAtom(name)
+            if (atom) t.set(atom, target[name])
+        }
+        for (const name of Object.keys(current)) {
+            if (name === COMPUTED_KEY || name in target) continue
+            const atom = resolveAtom(name)
+            if (atom) t.unset(atom)
+        }
+    })
+}
+
+/**
+ * Apply a DevTools snapshot back onto the store (time-travel). Restores all
+ * tracked atoms to their values at the target point — including resetting
+ * atoms that only gained a value *after* it, so jumping back doesn't leave
+ * later state behind. Only atoms resolvable by name are touched; scopes that
+ * no longer exist are skipped with a warning rather than resurrected.
+ *
+ * `current` is the live model before this restore — its keys are how we know
+ * which atoms exist "now" and may need reverting. A scope override present now
+ * but absent at the target was *inherited* at that point, and `unset`
+ * faithfully drops the shadow so the scope re-inherits the parent again. Scopes
+ * that no longer exist are skipped with a warning rather than resurrected.
+ */
+export const restoreSnapshot = (
+    store: Store,
+    target: DevtoolsSnapshot,
+    current: DevtoolsSnapshot,
+    resolveAtom: ResolveAtom,
+    includeScopes: boolean,
+): void => {
+    reconcileInto(store, rootValuesOf(target), rootValuesOf(current), resolveAtom)
+
+    if (!includeScopes) return
+    const targetScopes = target[SCOPES_KEY] ?? {}
+    const currentScopes = current[SCOPES_KEY] ?? {}
+    const paths = new Set([
+        ...Object.keys(targetScopes),
+        ...Object.keys(currentScopes),
+    ])
+    for (const path of paths) {
+        const ids = path.split("/")
+        if (!resolveScopeData(store.data, ids)) {
+            console.warn(
+                `[@valdres/redux-devtools] Cannot restore scope "${path}" — it no longer exists. Skipping.`,
+            )
+            continue
+        }
+        withScope(store, ids, scoped =>
+            reconcileInto(
+                scoped,
+                targetScopes[path] ?? {},
+                currentScopes[path] ?? {},
+                resolveAtom,
+            ),
+        )
+    }
+}

--- a/packages/@valdres/redux-devtools/src/lib/snapshot.ts
+++ b/packages/@valdres/redux-devtools/src/lib/snapshot.ts
@@ -1,0 +1,61 @@
+import type { DevtoolsSnapshot } from "../types/DevtoolsSnapshot"
+
+/** Reserved top-level key under which scope overrides are nested. */
+export const SCOPES_KEY = "@scopes"
+
+/** Reserved key under which derived (selector) values live — at the top level
+ *  for root selectors, and under `@scopes.<path>.@computed` for scope ones.
+ *  Display-only; never restored. */
+export const COMPUTED_KEY = "@computed"
+
+/** The object an atom value lives in: the model itself for the root, or the
+ *  per-scope bucket under `@scopes` (created on demand). */
+export const atomBucket = (
+    model: DevtoolsSnapshot,
+    scopeKey: string | null,
+): Record<string, unknown> =>
+    scopeKey === null
+        ? model
+        : ((model[SCOPES_KEY] ??= {})[scopeKey] ??= {})
+
+/** The `@computed` object a selector value lives in (created on demand): the
+ *  top-level one for a root selector, or one nested inside the scope's bucket
+ *  (`@scopes.<scope>.@computed`) for a scoped selector. */
+export const computedBucket = (
+    model: DevtoolsSnapshot,
+    scopeKey: string | null,
+): Record<string, unknown> => {
+    const parent = scopeKey === null ? model : atomBucket(model, scopeKey)
+    return ((parent as Record<string, any>)[COMPUTED_KEY] ??= {})
+}
+
+/**
+ * Shallow structural copy so each action gets an immutable snapshot — the
+ * extension may read the state asynchronously after we've mutated the live
+ * model. Atom values themselves are shared by reference (not deep-cloned).
+ */
+export const cloneSnapshot = (model: DevtoolsSnapshot): DevtoolsSnapshot => {
+    const copy: DevtoolsSnapshot = {}
+    for (const key of Object.keys(model)) {
+        if (key === SCOPES_KEY || key === COMPUTED_KEY) continue
+        copy[key] = model[key]
+    }
+    const scopes = model[SCOPES_KEY]
+    if (scopes) {
+        const scopesCopy: Record<string, Record<string, unknown>> = {}
+        for (const path of Object.keys(scopes)) {
+            const bucket: Record<string, unknown> = { ...scopes[path] }
+            // The scope's nested @computed needs its own copy too, else later
+            // selector recomputes would mutate an already-sent snapshot.
+            const nested = bucket[COMPUTED_KEY]
+            if (nested) {
+                bucket[COMPUTED_KEY] = { ...(nested as Record<string, unknown>) }
+            }
+            scopesCopy[path] = bucket
+        }
+        copy[SCOPES_KEY] = scopesCopy
+    }
+    const computed = model[COMPUTED_KEY]
+    if (computed) copy[COMPUTED_KEY] = { ...computed }
+    return copy
+}

--- a/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
+++ b/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
@@ -1,0 +1,40 @@
+import type { SnapshotEntry } from "valdres"
+
+export interface ConnectReduxDevtoolsOptions {
+    /** Instance name shown in the Redux DevTools extension dropdown. */
+    name?: string
+    /**
+     * Transform a value before it's sent to the extension (which serializes
+     * over `postMessage`). Use this to strip or shape values that aren't
+     * structured-cloneable (DOM nodes, class instances, functions). The first
+     * argument is the state the value belongs to — an atom, a family-member
+     * atom, or (with `selectors: true`) a selector. Defaults to identity.
+     */
+    serialize?: (state: SnapshotEntry["state"], value: unknown) => unknown
+    /**
+     * Include scope state under the `@scopes` key and react to scope writes.
+     * Defaults to `true`.
+     */
+    scopes?: boolean
+    /**
+     * How to handle atoms declared without a `name`:
+     * - `"track"` (default): auto-label them `unnamed_atom_N` so they appear
+     *   in the timeline and can be restored within the session. These labels
+     *   are assigned in encounter order and are NOT stable across reloads, so
+     *   a one-time hint suggests naming the atoms you want stable time-travel
+     *   for.
+     * - `"ignore"`: leave them out of DevTools entirely.
+     */
+    unnamed?: "track" | "ignore"
+    /**
+     * Also report named selector (derived) values under a `@computed` key.
+     * Display-only — selectors aren't settable, so they're excluded from
+     * time-travel restore. Unnamed selectors are skipped. Defaults to `false`.
+     */
+    selectors?: boolean
+}
+
+export interface ReduxDevtoolsHandle {
+    /** Detach the store listener and the extension connection. */
+    disconnect(): void
+}

--- a/packages/@valdres/redux-devtools/src/types/DevtoolsSnapshot.ts
+++ b/packages/@valdres/redux-devtools/src/types/DevtoolsSnapshot.ts
@@ -1,0 +1,14 @@
+/**
+ * The serialized state shape sent to the Redux DevTools extension.
+ *
+ * Root-store atoms live at the top level keyed by their `name`. Scope
+ * overrides live under the reserved `@scopes` key, keyed by a `/`-joined
+ * scope path (e.g. `"sessionA"` or `"sessionA/nested"`). Derived selector
+ * values (with `{ selectors: true }`) live under the reserved `@computed` key,
+ * keyed by scope-qualified selector name — display-only, never restored. Only
+ * states that have an explicit/materialized value appear.
+ */
+export type DevtoolsSnapshot = Record<string, unknown> & {
+    "@scopes"?: Record<string, Record<string, unknown>>
+    "@computed"?: Record<string, unknown>
+}

--- a/packages/@valdres/redux-devtools/src/types/ReduxDevtools.ts
+++ b/packages/@valdres/redux-devtools/src/types/ReduxDevtools.ts
@@ -1,0 +1,49 @@
+/**
+ * Minimal surface of the Redux DevTools browser extension that this adapter
+ * relies on. The real extension injects `window.__REDUX_DEVTOOLS_EXTENSION__`.
+ */
+
+export interface ReduxDevtoolsConnection {
+    /** Seed the timeline with the initial state. */
+    init(state: unknown): void
+    /**
+     * Append an action + the resulting state to the timeline. A `null` action
+     * replaces the monitor's whole lifted state instead — used to load an
+     * imported session (`state` is then the full lifted state).
+     */
+    send(
+        action: ({ type: string } & Record<string, unknown>) | null,
+        state: unknown,
+    ): void
+    /** Listen for messages from the extension (time-travel, commit, reset). */
+    subscribe(listener: (message: ReduxDevtoolsMessage) => void): () => void
+    unsubscribe(): void
+    error(message: string): void
+}
+
+export interface ReduxDevtoolsExtension {
+    connect(options?: {
+        name?: string
+        [key: string]: unknown
+    }): ReduxDevtoolsConnection
+    disconnect?(): void
+}
+
+export interface ReduxDevtoolsMessage {
+    /** "DISPATCH" | "ACTION" | "START" | "STOP" | ... */
+    type: string
+    payload?: {
+        /** "JUMP_TO_ACTION" | "JUMP_TO_STATE" | "COMMIT" | "ROLLBACK" | "RESET" | ... */
+        type?: string
+        [key: string]: unknown
+    }
+    /** JSON-encoded snapshot the extension wants us to jump/roll back to. */
+    state?: string
+    id?: string
+}
+
+declare global {
+    interface Window {
+        __REDUX_DEVTOOLS_EXTENSION__?: ReduxDevtoolsExtension
+    }
+}

--- a/packages/@valdres/redux-devtools/test/setup/happyDom.ts
+++ b/packages/@valdres/redux-devtools/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/redux-devtools/tsconfig.json
+++ b/packages/@valdres/redux-devtools/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -31,6 +31,7 @@ PUBLIC_PACKAGES=(
   packages/@valdres/color-mode
   packages/@valdres/hotkeys
   packages/@valdres/public-ip
+  packages/@valdres/redux-devtools
   packages/@valdres-react/color-mode
   packages/@valdres-react/draggable
   packages/@valdres-react/hotkeys

--- a/scripts/verify-publish.ts
+++ b/scripts/verify-publish.ts
@@ -47,6 +47,7 @@ const PUBLIC_PACKAGES = [
     "packages/@valdres/color-mode",
     "packages/@valdres/hotkeys",
     "packages/@valdres/public-ip",
+    "packages/@valdres/redux-devtools",
     "packages/@valdres-react/color-mode",
     "packages/@valdres-react/draggable",
     "packages/@valdres-react/hotkeys",


### PR DESCRIPTION
## What

A new package, **`@valdres/redux-devtools`**, connecting a valdres store to the Redux DevTools browser extension for live action logging and time-travel. Built entirely on the core observation primitives that landed recently — `store.onChange` (#175), `store.unset` (#177), `StoreChange kind: "unset"` (#178), selector reporting (#179), and `store.snapshot()` (#182). **No core changes in this PR.**

```ts
import { connectReduxDevtools } from "@valdres/redux-devtools"

const handle = connectReduxDevtools(store, { name: "my-app" })
// … handle.disconnect() to detach
```

## How it maps onto valdres

- **One `store.onChange` subscription** drives everything. Each committed operation becomes a Redux action; the full state snapshot is sent per action, so the extension's tree view and per-action diff work for free.
- **Action labels** come from `meta`: a named transaction (`store.txn(fn, name)`) uses its name; otherwise we synthesize from the changed atoms/scopes. `meta.source` tags resets/deletes/revalidations/unsets distinctly from plain sets.
- **Atom changes key on `kind`** (`set`/`unset`/`delete`) — authoritative even inside a transaction (where `meta.source` is `"transaction"`).
- **Transactions** — including cross-scope — coalesce into a **single** action and time-travel as one step.
- **Scopes** are first-class: state nests under `@scopes` with `@scope:<path>` labels; the `scope` id path comes straight from the feed.
- **Time-travel** (jump / commit / reset / rollback) restores via `txn`, and uses **`unset`** for atoms that only appeared after the target point — so a scope override re-inherits its parent (exact) and a root reverts to default. No stale state lingers on jump-back.
- **Initial snapshot:** for an enumerable store (`store(id, { enumerable: true })`) the timeline is seeded from `store.snapshot()` so it opens populated; a default store starts empty and fills via `onChange`.
- **Selectors:** `{ selectors: true }` mirrors named selector values under `@computed` — display-only, excluded from restore.
- **Naming** is adapter-side: named atoms by `name`, unnamed get `unnamed_atom_N` (`unnamed: "track" | "ignore"`), with a name→atom map for restore and a collision warning.
- **Extension controls:** honors `PAUSE_RECORDING` (timeline pauses, model stays current) and `IMPORT_STATE` (restores the imported session's current state). Skip / reorder are reducer-only and can't map to a snapshot model, so they surface an in-panel **error** rather than failing silently or wiping history.
- **`serialize`** shapes non-cloneable values (DOM nodes, class instances, …) before they're posted.

## Playground

`dev/` (`bun run dev`) exercises the lot: counter / message / todos, root↔scope copy-on-write theme with `unset → re-inherit`, an anonymous atom, single + named + cross-scope transactions, five selectors under `@computed` (incl. a selector-of-selectors), and an enumerable store seeded with initial state.

## Tests

25 tests in `connectReduxDevtools.test.ts` (driven through a fake extension): action labels & sources, scopes, named/coalesced/cross-scope transactions, unset (standalone, in-txn, time-travel re-inherit), deletions, time-travel + extra-atom reconciliation + no-echo, skip/reorder error, pause, import, selectors on/off, snapshot seeding (atoms + scope + derived), and the no-extension no-op. Typecheck clean; deterministic across 3 runs.

## Known limitations (by design)

- **Skip / reorder / custom-dispatch** are unsupported — they require Redux's replay-through-a-reducer model, which an imperative atom store doesn't have. They error in-panel.
- **`unnamed_atom_N`** labels are stable within a session but not across reloads; name atoms you want reload-stable time-travel for.
- **`IMPORT_STATE`** restores the imported *current* state (no action-by-action history replay).
- A scope whose last override is removed leaves an empty `@scopes.<path>: {}` in the snapshot (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)