### PR TITLE
fix(valdres): unnamed atomFamily/selectorFamily .name is undefined, not the intrinsic function name

### DIFF
--- a/.changeset/unnamed-atomfamily-name-undefined.md
+++ b/.changeset/unnamed-atomfamily-name-undefined.md
@@ -1,0 +1,17 @@
+---
+"valdres": patch
+---
+
+Unnamed `atomFamily.name` is now `undefined` instead of the intrinsic JS function
+name `"atomFamily"`. Previously a family created without `{ name }` reported the
+declaring function's name, so consumers that use `name` as an identity/address
+(devtools, sync/persistence adapters) had to treat the literal string
+`"atomFamily"` as a reserved "unnamed" sentinel. That heuristic broke under
+minification (bundlers mangle the intrinsic name, so an unnamed family slipped
+unnamed-detection in production builds) and wrongly flagged a family a user
+legitimately named `"atomFamily"`.
+
+Unnamed families now mirror unnamed atoms (`atom()` without options has `name`
+undefined): `atomFamily(x).name === undefined`. A family explicitly named
+`"atomFamily"` keeps that name and is now distinguishable from an unnamed one.
+Named-family member naming (`name + "_" + key`) is unchanged.

--- a/.changeset/unnamed-atomfamily-name-undefined.md
+++ b/.changeset/unnamed-atomfamily-name-undefined.md
@@ -2,16 +2,16 @@
 "valdres": patch
 ---
 
-Unnamed `atomFamily.name` is now `undefined` instead of the intrinsic JS function
-name `"atomFamily"`. Previously a family created without `{ name }` reported the
-declaring function's name, so consumers that use `name` as an identity/address
-(devtools, sync/persistence adapters) had to treat the literal string
-`"atomFamily"` as a reserved "unnamed" sentinel. That heuristic broke under
-minification (bundlers mangle the intrinsic name, so an unnamed family slipped
-unnamed-detection in production builds) and wrongly flagged a family a user
-legitimately named `"atomFamily"`.
+Unnamed `atomFamily.name` / `selectorFamily.name` are now `undefined` instead of
+the intrinsic JS function names `"atomFamily"` / `"selectorFamily"`. Previously a
+family created without `{ name }` reported the declaring function's name, so
+consumers that use `name` as an identity/address (devtools, sync/persistence
+adapters) had to treat those literal strings as reserved "unnamed" sentinels.
+That heuristic broke under minification (bundlers mangle the intrinsic name, so
+an unnamed family slipped unnamed-detection in production builds) and wrongly
+flagged a family a user legitimately named `"atomFamily"` / `"selectorFamily"`.
 
-Unnamed families now mirror unnamed atoms (`atom()` without options has `name`
-undefined): `atomFamily(x).name === undefined`. A family explicitly named
-`"atomFamily"` keeps that name and is now distinguishable from an unnamed one.
-Named-family member naming (`name + "_" + key`) is unchanged.
+Unnamed families now mirror unnamed atoms/selectors (`atom()` / `selector()`
+without options have `name` undefined): `atomFamily(x).name === undefined`. A
+family explicitly named `"atomFamily"` keeps that name and is now distinguishable
+from an unnamed one. Named-family member naming (`name + "_" + key`) is unchanged.

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -33,6 +33,21 @@ describe("atomFamily", () => {
         expect(user3.name).toBe("familyName_[1,2]")
     })
 
+    test("unnamed family has name undefined (not the intrinsic 'atomFamily')", () => {
+        const family = atomFamily(null)
+        expect(family.name).toBeUndefined()
+        // Members of an unnamed family keep name undefined too.
+        expect(family(1).name).toBeUndefined()
+        expect(family("foo").name).toBeUndefined()
+    })
+
+    test("a family legitimately named 'atomFamily' is distinguishable", () => {
+        const family = atomFamily(null, { name: "atomFamily" })
+        expect(family.name).toBe("atomFamily")
+        // Members are still named <familyName>_<key>.
+        expect(family(1).name).toBe("atomFamily_1")
+    })
+
     // test("Allow default override first time atom is created in family", () => {
     //     const store1 = store()
     //     const family = atomFamily<{ id: number; name: string }, number>(id => ({

--- a/packages/valdres/src/lib/createAtomFamily.ts
+++ b/packages/valdres/src/lib/createAtomFamily.ts
@@ -87,11 +87,16 @@ export const createAtomFamily = <
         return build(args, key)
     }
 
-    if (hasName)
-        Object.defineProperty(atomFamily, "name", {
-            value: options!.name,
-            writable: false,
-        })
+    // Define `name` explicitly. When named, expose the user's name. When unnamed,
+    // override the intrinsic JS function name ("atomFamily") with `undefined` so
+    // an unnamed family mirrors an unnamed atom — consumers (devtools, sync,
+    // persistence) can detect "unnamed" via `name === undefined` instead of
+    // matching the literal string "atomFamily", which breaks under minification
+    // and wrongly flags a family a user legitimately named "atomFamily".
+    Object.defineProperty(atomFamily, "name", {
+        value: hasName ? options!.name : undefined,
+        writable: false,
+    })
 
     // The single-positional-param + `arguments` shape isn't structurally a
     // `(...args: Args)` signature, so the callable needs an unchecked assertion.

--- a/packages/valdres/src/selectorFamily.test.ts
+++ b/packages/valdres/src/selectorFamily.test.ts
@@ -14,6 +14,29 @@ describe("selectorFamily", () => {
         expect(nameSelectorFamily(1)).toEqual(nameSelectorFamily(1))
     })
 
+    test("name", () => {
+        const family = selectorFamily(() => () => null, { name: "familyName" })
+        expect(family.name).toBe("familyName")
+        expect(family(1).name).toBe("familyName_1")
+        expect(family("2").name).toBe("familyName_2")
+    })
+
+    test("unnamed family has name undefined (not the intrinsic 'selectorFamily')", () => {
+        const family = selectorFamily(() => () => null)
+        expect(family.name).toBeUndefined()
+        // Members of an unnamed family keep name undefined too.
+        expect(family(1).name).toBeUndefined()
+        expect(family("foo").name).toBeUndefined()
+    })
+
+    test("a family legitimately named 'selectorFamily' is distinguishable", () => {
+        const family = selectorFamily(() => () => null, {
+            name: "selectorFamily",
+        })
+        expect(family.name).toBe("selectorFamily")
+        expect(family(1).name).toBe("selectorFamily_1")
+    })
+
     test("defaultValue", () => {
         const store1 = store()
         const usersAtom = atom(["Foo", "Bar"])

--- a/packages/valdres/src/selectorFamily.ts
+++ b/packages/valdres/src/selectorFamily.ts
@@ -46,10 +46,16 @@ export const selectorFamily = <
     // a consumer can read a family's schema without materializing a member.
     selectorFamily.schema = options?.schema
     selectorFamily.schemaValidation = options?.schemaValidation
-    if (hasName)
-        Object.defineProperty(selectorFamily, "name", {
-            value: options!.name,
-            writable: false,
-        })
+    // Define `name` explicitly. When named, expose the user's name. When unnamed,
+    // override the intrinsic JS function name ("selectorFamily") with `undefined`
+    // so an unnamed family mirrors an unnamed selector — consumers (devtools,
+    // sync, persistence) can detect "unnamed" via `name === undefined` instead of
+    // matching the literal string "selectorFamily", which breaks under
+    // minification and wrongly flags a family a user legitimately named
+    // "selectorFamily".
+    Object.defineProperty(selectorFamily, "name", {
+        value: hasName ? options!.name : undefined,
+        writable: false,
+    })
     return selectorFamily
 }

--- a/packages/valdres/src/types/SelectorFamily.ts
+++ b/packages/valdres/src/types/SelectorFamily.ts
@@ -5,6 +5,7 @@ import type { Selector } from "./Selector"
 export type SelectorFamily<Value extends any, Args extends [any, ...any[]]> = {
     (...args: Args): Selector<Value, Args>
     release: (...args: Args) => boolean
+    name?: string
     /** The schema members validate against, readable from the family itself —
      *  members carry the same reference via their options. */
     schema?: Schema<Value>


### PR DESCRIPTION
## What

An **unnamed** `atomFamily` / `selectorFamily` reported the intrinsic JS function name (`"atomFamily"` / `"selectorFamily"`) as its `.name`, because `Object.defineProperty(family, "name", …)` only ran when `options.name` was set. This change defines `name` explicitly in both family constructors:

- **Unnamed** → `name: undefined` (mirrors an unnamed `atom()` / `selector()`).
- **Named** → the user's name, unchanged.

## Why

Consumers that use `name` as an identity/address (devtools, sync/persistence adapters) had to treat the literal strings `"atomFamily"` / `"selectorFamily"` as reserved "unnamed" sentinels. That heuristic:

- **breaks under minification** — bundlers mangle the intrinsic function name, so an unnamed family slips unnamed-detection in production builds and registers under a mangled, per-bundle name; and
- **wrongly flags** a family a user legitimately names `"atomFamily"` / `"selectorFamily"`.

After this change, `family(x).name === undefined` for unnamed families, and a family explicitly named `"atomFamily"` is distinguishable from an unnamed one.

## Scope

Pure core fix — **no** sync-specific logic. Both family constructors are fixed symmetrically so they stay in lockstep. Surveyed all in-repo readers of a family's/member's `.name` (`@valdres/redux-devtools` `nameRegistry`/`connectReduxDevtools`, error types, `indexConstructor`): all already handle `undefined` (guards or `??`). Member-atom/selector names for unnamed families were already `undefined` before this change.

Descriptor semantics verified: `defineProperty` on the existing `name` inherits the unspecified attributes, so the property stays `configurable: true` (re-definable downstream) and `enumerable: false` (not picked up by spreads / `JSON.stringify`).

## Tests

- `atomFamily(null).name === undefined` / `selectorFamily(…).name === undefined`; members keep `name === undefined`.
- `…(null, { name: "atomFamily" }).name === "atomFamily"` (now distinguishable); member named `atomFamily_1`.
- Existing named-family member naming (`name + "_" + key`) unchanged.
- Full repo suite (`bun --filter '*' test`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)