### PR TITLE
feat(valdres): machine-readable meta.origin provenance tag for store.txn

### DIFF
--- a/.changeset/txn-meta-origin.md
+++ b/.changeset/txn-meta-origin.md
@@ -1,0 +1,16 @@
+---
+"valdres": minor
+---
+
+Add a machine-readable provenance tag to `store.txn`. The second argument now
+accepts an options object — `store.txn(callback, { name?, origin? })` — alongside
+the existing plain-string `name`. The `origin` is threaded through the commit and
+surfaced as `meta.origin` on `store.onChange` callbacks for that transaction.
+
+This gives middleware (state-sync layers, persistence, undo) a dedicated channel
+to tag the transactions it applies so its own `onChange` listener can recognize
+them (e.g. echo suppression) — without overloading `name`, which stays the
+human-facing dev-tools label. Plain-string `name` behavior is unchanged, and
+non-transaction paths (plain `set`/`reset`) leave `origin` undefined. The change
+is additive and stays off the no-listener fast path (no new allocations when
+nothing is watching).

--- a/packages/valdres/src/lib/notifyChangeListeners.ts
+++ b/packages/valdres/src/lib/notifyChangeListeners.ts
@@ -27,6 +27,7 @@ export type ChangeGroup = {
 export type ChangeSink = {
     source: StoreChangeSource
     name: string | undefined
+    origin: string | undefined
     groups: ChangeGroup[]
 }
 
@@ -343,19 +344,27 @@ export const reportSelectorChanges = (
 /** Create a change sink. `source` defaults to `"transaction"` (the txn commit
  *  path); the immediate path passes the operation's real source so a cascaded,
  *  buffered batch still reports its true origin. `name` is the optional
- *  `store.txn(fn, name)` label. */
+ *  `store.txn(fn, name)` dev-tools label; `origin` is the optional
+ *  machine-readable provenance tag (`store.txn(fn, { origin })`). The immediate
+ *  (non-transaction) path passes neither. */
 export const createChangeSink = (
     name: string | undefined,
     source: StoreChangeSource = "transaction",
+    origin: string | undefined = undefined,
 ): ChangeSink => ({
     source,
     name,
+    origin,
     groups: [],
 })
 
 /** Flush a sink's accumulated changes as a single callback. */
 export const flushChangeSink = (sink: ChangeSink) => {
     if (sink.groups.length > 0) {
-        notifyChangeListeners(sink.groups, { source: sink.source, name: sink.name })
+        notifyChangeListeners(sink.groups, {
+            source: sink.source,
+            name: sink.name,
+            origin: sink.origin,
+        })
     }
 }

--- a/packages/valdres/src/lib/onStoreChange.test.ts
+++ b/packages/valdres/src/lib/onStoreChange.test.ts
@@ -131,6 +131,138 @@ describe("store.onChange", () => {
         unsub()
     })
 
+    // `meta.origin` is a machine-readable provenance tag for middleware (state
+    // sync, persistence, undo) that needs to recognize the transactions it
+    // applied — e.g. echo suppression. This contract is load-bearing: it must
+    // arrive verbatim on the commit it tags and be absent everywhere else.
+    describe("meta.origin", () => {
+        test("a txn tagged with origin surfaces it verbatim on meta", () => {
+            const store1 = store()
+            const atom1 = atom(1)
+            const metas: any[] = []
+            const unsub = store1.onChange((_changes, meta) => metas.push(meta))
+
+            store1.txn(({ set }) => set(atom1, 2), { origin: "sync:peer-a" })
+
+            expect(metas).toEqual([
+                { source: "transaction", origin: "sync:peer-a" },
+            ])
+            unsub()
+        })
+
+        test("origin and name coexist on the same txn", () => {
+            const store1 = store()
+            const atom1 = atom(1)
+            const metas: any[] = []
+            const unsub = store1.onChange((_changes, meta) => metas.push(meta))
+
+            store1.txn(({ set }) => set(atom1, 2), {
+                name: "rename-user",
+                origin: "sync:peer-a",
+            })
+
+            expect(metas).toEqual([
+                {
+                    source: "transaction",
+                    name: "rename-user",
+                    origin: "sync:peer-a",
+                },
+            ])
+            unsub()
+        })
+
+        test("origin is absent on an untagged txn", () => {
+            const store1 = store()
+            const atom1 = atom(1)
+            let receivedMeta: any
+            const unsub = store1.onChange((_changes, meta) => {
+                receivedMeta = meta
+            })
+
+            store1.txn(({ set }) => set(atom1, 2))
+
+            expect(receivedMeta.source).toBe("transaction")
+            expect(receivedMeta.origin).toBeUndefined()
+            unsub()
+        })
+
+        test("a plain-string second arg sets name but not origin", () => {
+            const store1 = store()
+            const atom1 = atom(1)
+            const metas: any[] = []
+            const unsub = store1.onChange((_changes, meta) => metas.push(meta))
+
+            store1.txn(({ set }) => set(atom1, 2), "rename-user")
+
+            expect(metas).toEqual([
+                { source: "transaction", name: "rename-user" },
+            ])
+            expect(metas[0].origin).toBeUndefined()
+            unsub()
+        })
+
+        test("origin is absent on a plain set/reset (non-transaction path)", () => {
+            const store1 = store()
+            const atom1 = atom(1)
+            const metas: any[] = []
+            const unsub = store1.onChange((_changes, meta) => metas.push(meta))
+
+            store1.set(atom1, 2)
+            store1.reset(atom1)
+
+            expect(metas.length).toBe(2)
+            expect(metas[0].origin).toBeUndefined()
+            expect(metas[1].origin).toBeUndefined()
+            unsub()
+        })
+
+        test("origin tags a txn committed inside a scope", () => {
+            const root = store("root")
+            const child = root.scope("child")
+            const atom1 = atom(1)
+            const metas: any[] = []
+            const unsub = child.onChange((_changes, meta) => metas.push(meta))
+
+            child.txn(({ set }) => set(atom1, 2), { origin: "sync:peer-a" })
+
+            expect(metas).toEqual([
+                { source: "transaction", origin: "sync:peer-a" },
+            ])
+            unsub()
+        })
+
+        test("origin tags a txn that spans root and a scope", () => {
+            // A cross-scope commit produces one onChange per watched store, all
+            // from the same sink — so every notified store must see the same
+            // origin tag.
+            const root = store("root")
+            const child = root.scope("child")
+            const atomRoot = atom(1)
+            const atomChild = atom(2)
+            const rootMetas: any[] = []
+            const childMetas: any[] = []
+            const unsubRoot = root.onChange((_c, meta) => rootMetas.push(meta))
+            const unsubChild = child.onChange((_c, meta) => childMetas.push(meta))
+
+            root.txn(
+                t => {
+                    t.set(atomRoot, 9)
+                    t.scope("child", s => s.set(atomChild, 9))
+                },
+                { origin: "sync:peer-a" },
+            )
+
+            expect(rootMetas).toEqual([
+                { source: "transaction", origin: "sync:peer-a" },
+            ])
+            expect(childMetas).toEqual([
+                { source: "transaction", origin: "sync:peer-a" },
+            ])
+            unsubRoot()
+            unsubChild()
+        })
+    })
+
     test("reset, delete and revalidation report their source", async () => {
         const store1 = store()
         const atom1 = atom(1)

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -192,9 +192,12 @@ export function storeFromStoreData(
         deepEqualCheckBeforeCallback: boolean = true,
     ) => subscribe(state, callback, deepEqualCheckBeforeCallback, data)
 
-    const txn = (callback: TransactionFn, name?: string) => {
+    const txn = (
+        callback: TransactionFn,
+        nameOrOptions?: string | { name?: string; origin?: string },
+    ) => {
         if (data.batchUpdates) flushPendingTxn()
-        return transaction(callback, data, name)
+        return transaction(callback, data, nameOrOptions)
     }
 
     // Implementation signature is permissive; the precise per-option callback

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -82,10 +82,15 @@ export class Transaction {
     data: StoreData
     parentTransaction: Transaction | undefined
     dirty: boolean
-    /** Optional name from `store.txn(callback, name)`, surfaced on the
-     *  `store.onChange` meta for this commit. Only meaningful on the root
+    /** Optional human-facing name from `store.txn(callback, name)`, surfaced on
+     *  the `store.onChange` meta for this commit. Only meaningful on the root
      *  transaction (the one that commits). */
     name: string | undefined
+    /** Optional machine-readable provenance tag from
+     *  `store.txn(callback, { origin })`, surfaced as `meta.origin` for this
+     *  commit so middleware can recognize the transactions it applied (echo
+     *  suppression). Only meaningful on the root transaction. */
+    origin: string | undefined
     private _scopedTransactions: undefined | Map<string, Transaction>
     private _initializedAtomsSet: any
     private _deleteSet: any
@@ -102,6 +107,7 @@ export class Transaction {
         this.parentTransaction = parentTransaction
         this.dirty = false
         this.name = undefined
+        this.origin = undefined
         this._atomMap = new Map()
         if (childTransaction) {
             this._scopedTransactions = new Map([
@@ -359,12 +365,12 @@ export class Transaction {
         }
         // Otherwise thread a change sink through the commit's per-store
         // propagation passes so they collapse into a single store.onChange
-        // callback, tagged "transaction" with this txn's name. The sink is a
-        // local (not global state), so a transaction started inside an onSet hook
-        // simply owns its own sink — no save/restore. Flush in `finally` so
-        // observers still see the (already-applied) changes if a subscriber
-        // throws during commit.
-        const sink = createChangeSink(this.name)
+        // callback, tagged "transaction" with this txn's name and origin. The
+        // sink is a local (not global state), so a transaction started inside an
+        // onSet hook simply owns its own sink — no save/restore. Flush in
+        // `finally` so observers still see the (already-applied) changes if a
+        // subscriber throws during commit.
+        const sink = createChangeSink(this.name, "transaction", this.origin)
         try {
             this.commitWork(sink)
         } catch (error) {
@@ -725,9 +731,14 @@ export class Transaction {
 export const transaction = (
     callback: TransactionFn,
     data: StoreData,
-    name?: string,
+    nameOrOptions?: string | { name?: string; origin?: string },
 ) => {
     const txn = new Transaction(data)
-    txn.name = name
+    if (typeof nameOrOptions === "string") {
+        txn.name = nameOrOptions
+    } else if (nameOrOptions) {
+        txn.name = nameOrOptions.name
+        txn.origin = nameOrOptions.origin
+    }
     return txn.execute(callback)
 }

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -54,9 +54,16 @@ export type Store<T = StoreData> = {
      *  on a scope, reverts to the default on a root); no-op when the store holds
      *  no own value. See `UnsetAtom`. */
     unset: UnsetAtom
-    /** Run a transaction. An optional `name` is surfaced on the `meta` argument
-     *  of `store.onChange` callbacks for this commit (useful for dev tools). */
-    txn: (callback: TransactionFn, name?: string) => void
+    /** Run a transaction. The second argument may be a plain `name` string — a
+     *  human-facing label surfaced as `meta.name` on `store.onChange` callbacks
+     *  for this commit (useful for dev tools) — or an options object
+     *  `{ name?, origin? }`. `origin` is a machine-readable provenance tag
+     *  surfaced as `meta.origin`, for middleware that needs to recognize the
+     *  transactions it applied (e.g. echo suppression). */
+    txn: (
+        callback: TransactionFn,
+        nameOrOptions?: string | { name?: string; origin?: string },
+    ) => void
     scope: ScopeFn
     /** Subscribe to changes in this store and its descendant scopes. The callback
      *  fires once per committed operation with the changes, the scope each

--- a/packages/valdres/src/types/StoreChangeMeta.ts
+++ b/packages/valdres/src/types/StoreChangeMeta.ts
@@ -6,7 +6,16 @@ export type StoreChangeMeta = {
     /** What kind of operation produced this batch (`"set"`, `"transaction"`,
      *  `"revalidate"`, …). */
     source: StoreChangeSource
-    /** The name passed to `store.txn(callback, name)`, if any. Only present for
-     *  named transactions. */
+    /** The human-facing label passed to `store.txn(callback, name)`, if any.
+     *  Only present for named transactions; meant for dev-tools timelines, not
+     *  for programmatic dispatch — use `origin` for that. */
     name?: string
+    /** Machine-readable provenance tag for the transaction, set via
+     *  `store.txn(callback, { origin })`. Middleware (state-sync layers,
+     *  persistence, undo) tags the transactions it applies so its own
+     *  `onChange` listener can recognize them — e.g. echo suppression: ignore
+     *  changes carrying its own `origin`. Unlike `name`, it never appears in
+     *  dev-tools labels. Absent for non-transaction paths (plain set/reset) and
+     *  for transactions that don't set it. */
+    origin?: string
 }


### PR DESCRIPTION
## What

Adds a machine-readable provenance field to store change notifications: `meta.origin`.

`store.txn`'s second argument now accepts an options object alongside the existing plain-string `name`:

```ts
store.txn(cb, name?: string | { name?: string; origin?: string })
```

`origin` is threaded through `Transaction → ChangeSink → notifyChangeListeners → StoreChangeMeta`, so `onChange` receives `meta: { source, name?, origin? }`.

## Why

`store.txn(cb, name)` is documented as a human-facing dev-tools label. But middleware (state-sync layers, persistence, undo) needs to **tag** the transactions it applies so its own `onChange` listener can recognize them (echo suppression). Today the only carrier is `name`, which (a) pollutes dev-tools timelines with synthetic labels and (b) is an undocumented, test-unpinned contract. `origin` is a dedicated machine-readable channel; `name` stays the human label.

## Details

- Plain-string `name` behavior is unchanged; the options form is additive.
- Non-transaction paths (plain `set`/`reset`) leave `origin` undefined.
- Documented on `StoreChangeMeta`: `origin` is machine-readable provenance for middleware; `name` is the human label.
- Core tests pin the contract (`src/lib/onStoreChange.test.ts`, `describe("meta.origin")`): origin arrives verbatim for a tagged commit — root store, inside a scope, and for a txn spanning root + scope — and is absent otherwise.
- `@valdres/redux-devtools` reads only `meta.name`/`meta.source`, so it ignores `origin` gracefully (no migration; additive).
- Off the Bencher-gated hot path: `origin` is one extra field on the already-allocated `Transaction`; the no-listener fast path (`changeListenerRegistry.count === 0`) never allocates a sink, so no new allocations.

No consumer is migrated to `origin` in this PR — additive core change only.

## Checks

- `bun test` (valdres): 599 pass · redux-devtools: 26 pass
- `bun run docs:build`: clean · `gen-readmes --check`: up to date
- Changeset: minor for `valdres`

🤖 Generated with [Claude Code](https://claude.com/claude-code)