### PR TITLE
docs: restore PostHog analytics on the new docs site

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,6 +18,7 @@ jobs:
               run: bun run docs:build
               env:
                   NODE_ENV: production
+                  PUBLIC_POSTHOG_KEY: ${{ vars.PUBLIC_POSTHOG_KEY }}
             - name: Upload website artifact
               uses: actions/upload-pages-artifact@v5
               with:

--- a/docs/src/layout/Analytics.tsx
+++ b/docs/src/layout/Analytics.tsx
@@ -1,0 +1,14 @@
+// PostHog analytics. The project key is injected at build time from the
+// PUBLIC_POSTHOG_KEY env var (set as a GitHub Actions secret/variable), so it's
+// not committed to the repo and is absent during local `docs:dev` — meaning
+// analytics never loads in development and your own sessions stay out of the data.
+//
+// Renders nothing when the key is unset.
+export function Analytics() {
+    const key = process.env.PUBLIC_POSTHOG_KEY
+    if (!key) return null
+
+    const snippet = `!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init(${JSON.stringify(key)},{api_host:'https://us.i.posthog.com', person_profiles: 'identified_only'})`
+
+    return <script dangerouslySetInnerHTML={{ __html: snippet }} />
+}

--- a/docs/src/layout/Analytics.tsx
+++ b/docs/src/layout/Analytics.tsx
@@ -1,7 +1,7 @@
 // PostHog analytics. The project key is injected at build time from the
-// PUBLIC_POSTHOG_KEY env var (set as a GitHub Actions secret/variable), so it's
-// not committed to the repo and is absent during local `docs:dev` — meaning
-// analytics never loads in development and your own sessions stay out of the data.
+// PUBLIC_POSTHOG_KEY env var (a GitHub Actions repo variable in CI), so it's not
+// committed to the repo. The var is unset for local `docs:dev` unless you opt in,
+// so analytics stays out of the data during normal development.
 //
 // Renders nothing when the key is unset.
 export function Analytics() {

--- a/docs/src/layout/LandingPage.tsx
+++ b/docs/src/layout/LandingPage.tsx
@@ -1,3 +1,5 @@
+import { Analytics } from "./Analytics"
+
 type BenchProps = {
     jscAverage: number | null
     v8Average: number | null
@@ -55,6 +57,8 @@ export function LandingPage({ bench }: { bench?: BenchProps }) {
                     href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
                     rel="stylesheet"
                 />
+
+                <Analytics />
             </head>
             <body className="bg-surface dark:bg-surface-dark text-zinc-800 dark:text-zinc-200 antialiased">
                 <div className="min-h-screen flex flex-col">

--- a/docs/src/layout/RootLayout.tsx
+++ b/docs/src/layout/RootLayout.tsx
@@ -6,6 +6,7 @@ import { MobileSidebar } from "./MobileSidebar"
 import { Footer } from "./Footer"
 import { PrevNext } from "./PrevNext"
 import { TableOfContents, type TocItem } from "./TableOfContents"
+import { Analytics } from "./Analytics"
 import type { NavGroup } from "../../content/nav"
 import type { Framework } from "../frameworks"
 
@@ -90,6 +91,8 @@ export function RootLayout({
                         __html: `(function(){var t=localStorage.getItem('theme');if(t==='light')document.documentElement.classList.remove('dark');else if(t==='dark'||!t)document.documentElement.classList.add('dark');else if(window.matchMedia('(prefers-color-scheme: light)').matches)document.documentElement.classList.remove('dark')})()`,
                     }}
                 />
+
+                <Analytics />
             </head>
             <body className="bg-surface dark:bg-surface-dark text-zinc-800 dark:text-zinc-200 antialiased">
                 <div className="flex min-h-screen">


### PR DESCRIPTION
## What

PostHog analytics went dark on the docs site when the vocs → custom-site rewrite (#78) landed — the old `vocs.config.tsx` `head()` hook carried the PostHog snippet, and the rewrite didn't bring it over. This restores it.

## Changes

- **`docs/src/layout/Analytics.tsx`** (new) — shared component that injects the PostHog snippet at build time, reading the project key from `process.env.PUBLIC_POSTHOG_KEY`. Renders nothing when the key is unset.
- **`RootLayout.tsx`** + **`LandingPage.tsx`** — both `<head>`s now include `<Analytics />`. The landing page renders outside `RootLayout`, so it needs it separately (the old vocs site covered every page through a single `head()` hook).
- **`.github/workflows/publish-docs.yaml`** — passes `PUBLIC_POSTHOG_KEY: ${{ vars.PUBLIC_POSTHOG_KEY }}` into the build step. The repo variable is already set to the existing `phc_…` key.

## Differences from the old config

- **Key is no longer hardcoded** — it comes from the env var, so it's not in the repo and **doesn't load during local `docs:dev`**. Dev sessions stop polluting the data.
- **`person_profiles: 'always'` → `'identified_only'`** — the docs site never calls `identify()`, so `'always'` only ever created unusable anonymous profiles at higher cost. Same pageview data, lower cost, better privacy.
- Kept the US host (`us.i.posthog.com`) to match the existing PostHog project.

The `phc_` key is a public client-side key (ships in HTML by design), so it's stored as a GitHub repo **variable**, not a secret.

## Verification

- `bun run docs:build` with the key set → snippet present on landing + doc pages, key correctly interpolated.
- Build without the key → zero `posthog` references anywhere (dev safety confirmed).
- `gen-readmes --check` clean; no changeset needed (touches `docs/` + CI only, no publishable package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)