### PR TITLE
core: snapshot subscriber list at dispatch start on single-atom notify path

### DIFF
--- a/.changeset/snapshot-subscriber-set.md
+++ b/.changeset/snapshot-subscriber-set.md
@@ -1,0 +1,24 @@
+---
+"valdres": patch
+---
+
+Snapshot the subscriber list at dispatch start on the immediate single-atom
+notify path, matching the React/Redux contract.
+
+Previously the non-batched single-atom fast path iterated the LIVE
+`data.subscriptions` set, so subscription churn from inside a subscriber's
+callback leaked into the in-flight dispatch: a listener subscribed during
+dispatch fired for the same change, and a listener unsubscribed mid-dispatch was
+order-dependently skipped. The list is now copied before firing (`[...subs]`),
+so it's fixed at dispatch start — a listener added during dispatch does not fire
+for the in-flight change (it fires on the next one), and a listener that was
+present at dispatch start still fires even if another subscriber removes it
+mid-dispatch.
+
+This is a correctness fix for direct `store.sub` users and any adapter that
+adds or removes subscriptions inside a callback. The React adapter is
+unaffected: `useSyncExternalStore` does its sub/unsub in React's commit phase,
+outside valdres's dispatch. The copy happens only on the path that handed
+`callSubscribers` a live set and only when there are subscribers to fire; the
+deferred (multi-pass commit) and selector paths already accumulate into a fresh
+set and were already snapshotted.

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -141,7 +141,7 @@ const reEvaluateSelector = (
 }
 
 const callSubscribers = (
-    subscriptions: Set<Subscription>,
+    subscriptions: Iterable<Subscription>,
     families?: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
 ) => {
     let firstError: unknown
@@ -420,8 +420,20 @@ export const propagateAtomUpdate = (
                 ) {
                     const subs = data.subscriptions.get(atom)
                     if (subs && subs.size > 0) {
+                        // Snapshot the live subscription set before firing. This
+                        // is the one path that hands callSubscribers the LIVE
+                        // `data.subscriptions` set, so without a copy a listener
+                        // that subscribes/unsubscribes from inside a callback
+                        // would mutate the set mid-iteration — a listener added
+                        // during dispatch would leak into the in-flight change,
+                        // an unsubscribed one would be order-dependently skipped.
+                        // Snapshotting matches the React/Redux contract: the
+                        // listener list is fixed at dispatch start. Copy only
+                        // when actually firing (size > 0, already gated). The
+                        // deferred path collects into a fresh accumulator and is
+                        // already effectively snapshotted — leave it alone.
                         if (notify) addSetToSet(subs, notifyEntryFor(notify, data).subscriptions)
-                        else callSubscribers(subs)
+                        else callSubscribers([...subs])
                     }
                     // No dependents here, so there are no selectors to report; only
                     // the atom would be, and only when reportAtoms is set.

--- a/packages/valdres/test/subscriberSnapshot.test.ts
+++ b/packages/valdres/test/subscriberSnapshot.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "bun:test"
+import { store } from "../src/store"
+import { atom } from "../src/atom"
+import { selector } from "../src/selector"
+
+/**
+ * The immediate (non-batched) single-atom notify path must snapshot the
+ * subscriber list at dispatch start, matching the React/Redux contract:
+ *
+ *  - A listener SUBSCRIBED from inside another listener's callback must NOT
+ *    fire for the in-flight change (it fires on the next dispatch).
+ *  - A listener UNSUBSCRIBED by another listener mid-dispatch was present at
+ *    dispatch start, so it STILL fires for the in-flight change (snapshot
+ *    semantics).
+ *
+ * Before the fix the fast path iterated the LIVE `data.subscriptions` Set, so a
+ * mid-dispatch subscribe leaked into the same dispatch and a mid-dispatch
+ * unsubscribe was order-dependently skipped.
+ */
+describe("subscriber list is snapshotted at dispatch start", () => {
+    test("fast path: a listener subscribed mid-dispatch does NOT fire same dispatch", () => {
+        const store1 = store()
+        const atom1 = atom(0)
+        const calls: string[] = []
+
+        let unsubC: (() => void) | undefined
+        const a = () => {
+            calls.push("A")
+            // Subscribe C from inside A's callback. C must not fire for the
+            // in-flight change.
+            if (!unsubC) {
+                unsubC = store1.sub(atom1, () => calls.push("C"))
+            }
+        }
+        store1.sub(atom1, a)
+        store1.sub(atom1, () => calls.push("B"))
+
+        store1.set(atom1, 1)
+        expect(calls).toEqual(["A", "B"])
+
+        // C is now live — it fires on the next dispatch.
+        calls.length = 0
+        store1.set(atom1, 2)
+        expect(calls.sort()).toEqual(["A", "B", "C"])
+    })
+
+    test("fast path: a listener unsubscribed mid-dispatch STILL fires (was present at start)", () => {
+        const store1 = store()
+        const atom1 = atom(0)
+        const calls: string[] = []
+
+        let unsubB: (() => void) | undefined
+        store1.sub(atom1, () => {
+            calls.push("A")
+            // Unsubscribe B mid-dispatch. B was present at dispatch start, so
+            // under snapshot semantics it still fires for this change.
+            unsubB?.()
+        })
+        unsubB = store1.sub(atom1, () => calls.push("B"))
+
+        store1.set(atom1, 1)
+        expect(calls).toEqual(["A", "B"])
+
+        // B is gone on the next dispatch.
+        calls.length = 0
+        store1.set(atom1, 2)
+        expect(calls).toEqual(["A"])
+    })
+
+    test("selector-subscriber path: a listener subscribed mid-dispatch does NOT fire same dispatch", () => {
+        const store1 = store()
+        const atom1 = atom(0)
+        const sel1 = selector(get => get(atom1) * 2)
+        const calls: string[] = []
+
+        let unsubC: (() => void) | undefined
+        store1.sub(sel1, () => {
+            calls.push("A")
+            if (!unsubC) {
+                unsubC = store1.sub(sel1, () => calls.push("C"))
+            }
+        })
+        store1.sub(sel1, () => calls.push("B"))
+
+        store1.set(atom1, 1)
+        expect(calls).toEqual(["A", "B"])
+
+        calls.length = 0
+        store1.set(atom1, 2)
+        expect(calls.sort()).toEqual(["A", "B", "C"])
+    })
+})


### PR DESCRIPTION
## Problem

The immediate (non-batched) single-atom notify hot path in `propagateAtomUpdate` iterated the **live** `data.subscriptions` set, so subscription churn from inside a subscriber callback leaked into the in-flight dispatch:

- A listener **subscribed** from inside another listener's callback **fired in the same dispatch**.
- A listener **unsubscribed** mid-dispatch was **order-dependently skipped**.

This violates the React/Redux contract: the listener list should be fixed at dispatch start.

## Fix

Snapshot the subscriber set before firing — `callSubscribers([...subs])` — in the single-atom fast path (`packages/valdres/src/lib/propagateUpdatedAtoms.ts`). `callSubscribers` now accepts `Iterable<Subscription>`.

The copy runs **only** on the path that hands `callSubscribers` the live set, and **only** when there are subscribers to fire (`subs.size > 0`, already gated). The deferred (multi-pass commit) and selector paths already accumulate into a fresh set and were already effectively snapshotted — they are unchanged.

### Resulting semantics (pinned by tests)

- A listener added during dispatch does **not** fire for the in-flight change (fires on the next set).
- A listener present at dispatch start **still** fires even if another subscriber removes it mid-dispatch.

These match Redux exactly (iterate `currentListeners` while sub/unsub mutate a cloned `nextListeners`).

## Scope

Correctness fix for direct `store.sub` users and any adapter that adds/removes subscriptions inside a callback. **The React adapter is unaffected** — `useSyncExternalStore` does its sub/unsub in React's commit phase, outside valdres's dispatch.

## Verification

- New regression test `packages/valdres/test/subscriberSnapshot.test.ts` (fast path + selector path; RED before the fix).
- `packages/valdres`: 667 pass / 0 fail. `bunx tsgo --noEmit` clean.
- `packages/valdres-react`: 47 pass / 0 fail.
- Perf head-to-head on `set(atom) with 10 subs` (the bench hitting this exact path): baseline min ~84ns → patched min ~103ns (**+23%**). Bencher gates at **>50%** slower vs same-runner base, so this is within budget. (The `new Set(subs)` alternative was +62% and would have tripped the gate; the array copy is what the fix uses.) `set(atom, value)` with no subscribers is unchanged (~67ns) — the copy only runs when firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)