### PR TITLE
@valdres/redux-devtools: add `exclude` option for high-frequency atoms

### DIFF
--- a/.changeset/wide-nails-happen.md
+++ b/.changeset/wide-nails-happen.md
@@ -2,4 +2,4 @@
 "@valdres/redux-devtools": minor
 ---
 
-Add an `exclude` option to `connectReduxDevtools` for leaving high-frequency atoms (e.g. a cursor-position atom) out of DevTools entirely — neither seeded nor reported as actions. A rule can be an atom/selector reference, an `atomFamily` (excludes all its members), a `name` string, a predicate `(state) => boolean`, or an array mixing any of these.
+Add an `exclude` option to `connectReduxDevtools` for leaving high-frequency atoms (e.g. a cursor-position atom) out of DevTools entirely — neither seeded nor reported as actions. A rule can be an atom/selector reference, an `atomFamily` or `selectorFamily` (excludes all its members), a `name` string, a predicate `(state) => boolean`, or an array mixing any of these.

--- a/.changeset/wide-nails-happen.md
+++ b/.changeset/wide-nails-happen.md
@@ -1,0 +1,5 @@
+---
+"@valdres/redux-devtools": minor
+---
+
+Add an `exclude` option to `connectReduxDevtools` for leaving high-frequency atoms (e.g. a cursor-position atom) out of DevTools entirely — neither seeded nor reported as actions. A rule can be an atom/selector reference, an `atomFamily` (excludes all its members), a `name` string, a predicate `(state) => boolean`, or an array mixing any of these.

--- a/packages/@valdres/redux-devtools/README.md
+++ b/packages/@valdres/redux-devtools/README.md
@@ -45,14 +45,14 @@ const handle = connectReduxDevtools(store())
 
 `connectReduxDevtools(store, options?)` accepts:
 
-| Option      | Type                           | Default     | Notes                                                                                                                                                                                            |
-| ----------- | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`      | `string`                       | `"valdres"` | Instance name in the extension dropdown.                                                                                                                                                         |
-| `serialize` | `(state, value) => unknown`    | identity    | Shape values that aren't structured-cloneable before they're sent.                                                                                                                               |
-| `scopes`    | `boolean`                      | `true`      | Include scope state under `@scopes` and react to scope writes.                                                                                                                                   |
-| `unnamed`   | `"track" \| "ignore"`          | `"track"`   | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them.                                                                                                                              |
-| `exclude`   | `ExcludeRule \| ExcludeRule[]` | —           | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
-| `selectors` | `boolean`                      | `false`     | Also report named selectors under `@computed` (display-only, never restored).                                                                                                                    |
+| Option      | Type                           | Default     | Notes                                                                                                                                                                                                             |
+| ----------- | ------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | `string`                       | `"valdres"` | Instance name in the extension dropdown.                                                                                                                                                                          |
+| `serialize` | `(state, value) => unknown`    | identity    | Shape values that aren't structured-cloneable before they're sent.                                                                                                                                                |
+| `scopes`    | `boolean`                      | `true`      | Include scope state under `@scopes` and react to scope writes.                                                                                                                                                    |
+| `unnamed`   | `"track" \| "ignore"`          | `"track"`   | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them.                                                                                                                                               |
+| `exclude`   | `ExcludeRule \| ExcludeRule[]` | —           | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily`/`selectorFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
+| `selectors` | `boolean`                      | `false`     | Also report named selectors under `@computed` (display-only, never restored).                                                                                                                                     |
 
 ### Excluding high-frequency atoms
 
@@ -63,7 +63,7 @@ your store keeps working normally:
 
 ```ts
 connectReduxDevtools(store, {
-  // any of: a reference, a name, an atomFamily, a predicate, or a mix
+  // any of: a reference, a name, an atomFamily/selectorFamily, a predicate, or a mix
   exclude: [cursorPositionAtom, "pointerAtom", pointerFamily],
 })
 ```

--- a/packages/@valdres/redux-devtools/README.md
+++ b/packages/@valdres/redux-devtools/README.md
@@ -45,25 +45,41 @@ const handle = connectReduxDevtools(store())
 
 `connectReduxDevtools(store, options?)` accepts:
 
-| Option      | Type                        | Default     | Notes                                                                         |
-| ----------- | --------------------------- | ----------- | ----------------------------------------------------------------------------- |
-| `name`      | `string`                    | `"valdres"` | Instance name in the extension dropdown.                                      |
-| `serialize` | `(state, value) => unknown` | identity    | Shape values that aren't structured-cloneable before they're sent.            |
-| `scopes`    | `boolean`                   | `true`      | Include scope state under `@scopes` and react to scope writes.                |
-| `unnamed`   | `"track" \| "ignore"`       | `"track"`   | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them.           |
-| `selectors` | `boolean`                   | `false`     | Also report named selectors under `@computed` (display-only, never restored). |
+| Option      | Type                           | Default     | Notes                                                                                                                                                                                            |
+| ----------- | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`      | `string`                       | `"valdres"` | Instance name in the extension dropdown.                                                                                                                                                         |
+| `serialize` | `(state, value) => unknown`    | identity    | Shape values that aren't structured-cloneable before they're sent.                                                                                                                               |
+| `scopes`    | `boolean`                      | `true`      | Include scope state under `@scopes` and react to scope writes.                                                                                                                                   |
+| `unnamed`   | `"track" \| "ignore"`          | `"track"`   | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them.                                                                                                                              |
+| `exclude`   | `ExcludeRule \| ExcludeRule[]` | —           | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
+| `selectors` | `boolean`                      | `false`     | Also report named selectors under `@computed` (display-only, never restored).                                                                                                                    |
+
+### Excluding high-frequency atoms
+
+A single atom that updates on every frame — a cursor position, pointer
+coordinates, a scroll offset — floods the timeline and buries the actions you
+actually care about. Pass it to `exclude` and it disappears from DevTools while
+your store keeps working normally:
+
+```ts
+connectReduxDevtools(store, {
+  // any of: a reference, a name, an atomFamily, a predicate, or a mix
+  exclude: [cursorPositionAtom, "pointerAtom", pointerFamily],
+})
+```
 
 ## Exports
 
-| Export                        | Kind    | Type                                                                           |
-| ----------------------------- | ------- | ------------------------------------------------------------------------------ |
-| `connectReduxDevtools`        | util fn | `(store: Store, options?: ConnectReduxDevtoolsOptions) => ReduxDevtoolsHandle` |
-| `ConnectReduxDevtoolsOptions` | type    | `{ name?, serialize?, scopes?, unnamed?, selectors? }`                         |
-| `ReduxDevtoolsHandle`         | type    | `{ disconnect(): void }`                                                       |
-| `DevtoolsSnapshot`            | type    | `Record<string, unknown> & { "@scopes"?, "@computed"? }`                       |
-| `ReduxDevtoolsConnection`     | type    | extension connection surface                                                   |
-| `ReduxDevtoolsExtension`      | type    | `window.__REDUX_DEVTOOLS_EXTENSION__` surface                                  |
-| `ReduxDevtoolsMessage`        | type    | message from the extension                                                     |
+| Export                          | Kind    | Type                                                                           |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `connectReduxDevtools`          | util fn | `(store: Store, options?: ConnectReduxDevtoolsOptions) => ReduxDevtoolsHandle` |
+| `ConnectReduxDevtoolsOptions`   | type    | `{ name?, serialize?, scopes?, unnamed?, exclude?, selectors? }`               |
+| `ExcludeOption` / `ExcludeRule` | type    | atom/selector/family reference, `name` string, or `(state) => boolean`         |
+| `ReduxDevtoolsHandle`           | type    | `{ disconnect(): void }`                                                       |
+| `DevtoolsSnapshot`              | type    | `Record<string, unknown> & { "@scopes"?, "@computed"? }`                       |
+| `ReduxDevtoolsConnection`       | type    | extension connection surface                                                   |
+| `ReduxDevtoolsExtension`        | type    | `window.__REDUX_DEVTOOLS_EXTENSION__` surface                                  |
+| `ReduxDevtoolsMessage`          | type    | message from the extension                                                     |
 
 ## Notes
 

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test"
-import { atom, atomFamily, selector, store } from "valdres"
+import { atom, atomFamily, selector, selectorFamily, store } from "valdres"
 import { connectReduxDevtools } from "./connectReduxDevtools"
 import type {
     ReduxDevtoolsConnection,
@@ -403,6 +403,30 @@ describe("connectReduxDevtools", () => {
 
         const labels = fake.sent.map(e => e.action?.type)
         expect(labels).toEqual(["exf_count"])
+        handle.disconnect()
+    })
+
+    test("exclude a selectorFamily excludes all its members from @computed", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const a = atom(0, { name: "exsf_a" })
+        const doubles = selectorFamily(
+            (k: string) => get => `${k}:${get(a) * 2}`,
+            { name: "exsf_doubles" },
+        )
+        s.sub(doubles("x"), () => {}) // live, so it recomputes on change
+        const handle = connectReduxDevtools(s, {
+            selectors: true,
+            exclude: doubles,
+        })
+
+        s.set(a, 5)
+
+        const last = fake.sent.at(-1)!
+        // The atom is reported, but the excluded selector-family member is not.
+        expect(last.state.exsf_a).toBe(5)
+        expect(last.state["@computed"]?.exsf_doubles_x).toBeUndefined()
         handle.disconnect()
     })
 

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
@@ -354,6 +354,114 @@ describe("connectReduxDevtools", () => {
         handle.disconnect()
     })
 
+    test("exclude by atom reference drops it from the timeline", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const cursor = atom(0, { name: "ex_cursor" })
+        const count = atom(0, { name: "ex_count" })
+        const handle = connectReduxDevtools(s, { exclude: cursor })
+
+        s.set(cursor, 1)
+        s.set(cursor, 2)
+        s.set(count, 5)
+
+        const labels = fake.sent.map(e => e.action?.type)
+        expect(labels).toEqual(["ex_count"])
+        expect(fake.sent.at(-1)!.state.ex_cursor).toBeUndefined()
+        expect(fake.sent.at(-1)!.state.ex_count).toBe(5)
+        handle.disconnect()
+    })
+
+    test("exclude by name string", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const cursor = atom(0, { name: "exn_cursor" })
+        const count = atom(0, { name: "exn_count" })
+        const handle = connectReduxDevtools(s, { exclude: "exn_cursor" })
+
+        s.set(cursor, 1)
+        s.set(count, 5)
+
+        const labels = fake.sent.map(e => e.action?.type)
+        expect(labels).toEqual(["exn_count"])
+        handle.disconnect()
+    })
+
+    test("exclude an atomFamily excludes all its members", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const cursors = atomFamily(0, { name: "exf_cursors" })
+        const count = atom(0, { name: "exf_count" })
+        const handle = connectReduxDevtools(s, { exclude: cursors })
+
+        s.set(cursors("a"), 1)
+        s.set(cursors("b"), 2)
+        s.set(count, 5)
+
+        const labels = fake.sent.map(e => e.action?.type)
+        expect(labels).toEqual(["exf_count"])
+        handle.disconnect()
+    })
+
+    test("exclude accepts an array mixing references, names and predicates", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const cursor = atom(0, { name: "exa_cursor" })
+        const ping = atom(0, { name: "exa_ping" })
+        const noisy = atom(0, { name: "exa_internal_x" })
+        const count = atom(0, { name: "exa_count" })
+        const handle = connectReduxDevtools(s, {
+            exclude: [
+                cursor,
+                "exa_ping",
+                state => state.name?.startsWith("exa_internal") ?? false,
+            ],
+        })
+
+        s.set(cursor, 1)
+        s.set(ping, 1)
+        s.set(noisy, 1)
+        s.set(count, 5)
+
+        const labels = fake.sent.map(e => e.action?.type)
+        expect(labels).toEqual(["exa_count"])
+        handle.disconnect()
+    })
+
+    test("an excluded atom is not seeded from an enumerable store", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store("exseed_root", { enumerable: true })
+        const cursor = atom(0, { name: "exseed_cursor" })
+        const count = atom(0, { name: "exseed_count" })
+        s.set(cursor, 7)
+        s.set(count, 3)
+
+        const handle = connectReduxDevtools(s, { exclude: cursor })
+
+        const init = fake.inits[0] as any
+        expect(init.exseed_cursor).toBeUndefined()
+        expect(init.exseed_count).toBe(3)
+        handle.disconnect()
+    })
+
+    test("excluding every changed atom emits no action", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        const cursor = atom(0, { name: "exnone_cursor" })
+        const handle = connectReduxDevtools(s, { exclude: cursor })
+
+        s.set(cursor, 1)
+
+        expect(fake.sent).toHaveLength(0)
+        handle.disconnect()
+    })
+
     test("selectors: true reports named derived values under @computed", () => {
         const fake = makeFakeExtension()
         install(fake.ext)

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
@@ -11,6 +11,7 @@ import type {
 } from "./types/ConnectReduxDevtoolsOptions"
 import type { DevtoolsSnapshot } from "./types/DevtoolsSnapshot"
 import { createNameRegistry } from "./lib/nameRegistry"
+import { makeExcludeFilter } from "./lib/makeExcludeFilter"
 import { restoreSnapshot } from "./lib/restoreSnapshot"
 import { atomBucket, cloneSnapshot, computedBucket } from "./lib/snapshot"
 
@@ -93,7 +94,10 @@ export const connectReduxDevtools = (
         scopes: includeScopes = true,
         unnamed = "track",
         selectors: includeSelectors = false,
+        exclude,
     } = options
+
+    const isExcluded = makeExcludeFilter(exclude)
 
     // NB: we intentionally do NOT pass a `features` object to disable the
     // reducer-only controls (skip/reorder/dispatch). In practice the extension
@@ -113,6 +117,7 @@ export const connectReduxDevtools = (
     if (store.data.enumerable) {
         for (const entry of store.snapshot()) {
             if (entry.scope.length > 0 && !includeScopes) continue
+            if (isExcluded(entry.state)) continue
             const scopeKey =
                 entry.scope.length === 0 ? null : entry.scope.join("/")
             if (entry.type === "selector") {
@@ -165,6 +170,7 @@ export const connectReduxDevtools = (
 
         for (const change of changes) {
             if (change.scope.length > 0 && !includeScopes) continue
+            if (isExcluded(change.state)) continue
             const scopeKey =
                 change.scope.length === 0 ? null : change.scope.join("/")
 

--- a/packages/@valdres/redux-devtools/src/index.ts
+++ b/packages/@valdres/redux-devtools/src/index.ts
@@ -2,6 +2,8 @@ export { connectReduxDevtools } from "./connectReduxDevtools"
 
 export type {
     ConnectReduxDevtoolsOptions,
+    ExcludeOption,
+    ExcludeRule,
     ReduxDevtoolsHandle,
 } from "./types/ConnectReduxDevtoolsOptions"
 export type { DevtoolsSnapshot } from "./types/DevtoolsSnapshot"

--- a/packages/@valdres/redux-devtools/src/lib/makeExcludeFilter.ts
+++ b/packages/@valdres/redux-devtools/src/lib/makeExcludeFilter.ts
@@ -1,0 +1,37 @@
+import { isAtomFamily, isSelectorFamily } from "valdres"
+import type { SnapshotEntry } from "valdres"
+import type { ExcludeOption, ExcludeRule } from "../types/ConnectReduxDevtoolsOptions"
+
+type State = SnapshotEntry["state"]
+
+/** Does a single rule match this state? A string matches the state's `name`
+ *  (or, for a family member, the family's `name`, so one string excludes a whole
+ *  family). A family reference matches all its members via `state.family`. A
+ *  plain function is a predicate — checked AFTER the family cases because an
+ *  `atomFamily` / `selectorFamily` is itself callable. Anything else is an atom
+ *  / selector reference matched by identity. */
+const ruleMatches = (rule: ExcludeRule, state: State): boolean => {
+    const family = (state as { family?: unknown }).family
+    if (typeof rule === "string") {
+        return state.name === rule || (family as { name?: string })?.name === rule
+    }
+    if (isAtomFamily(rule) || isSelectorFamily(rule)) return family === rule
+    if (typeof rule === "function") return rule(state)
+    return state === rule
+}
+
+/**
+ * Compile the `exclude` option into a single `(state) => boolean` predicate
+ * (always `false` when nothing is excluded). Atoms whose state matches are
+ * dropped from both the seeded snapshot and the live timeline — useful for
+ * high-frequency atoms (cursor position, pointer coords) that would otherwise
+ * flood the DevTools and crowd out meaningful actions.
+ */
+export const makeExcludeFilter = (
+    exclude: ExcludeOption | undefined,
+): ((state: State) => boolean) => {
+    if (!exclude) return () => false
+    const rules = Array.isArray(exclude) ? exclude : [exclude]
+    if (rules.length === 0) return () => false
+    return (state: State) => rules.some(rule => ruleMatches(rule, state))
+}

--- a/packages/@valdres/redux-devtools/src/redux-devtools.mdx
+++ b/packages/@valdres/redux-devtools/src/redux-devtools.mdx
@@ -128,14 +128,30 @@ const handle = connectReduxDevtools(store())
 | `serialize` | `(state, value) => unknown` | identity | Shape values that aren't structured-cloneable before they're sent. |
 | `scopes` | `boolean` | `true` | Include scope state under `@scopes` and react to scope writes. |
 | `unnamed` | `"track" \| "ignore"` | `"track"` | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them. |
+| `exclude` | `ExcludeRule \| ExcludeRule[]` | — | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
 | `selectors` | `boolean` | `false` | Also report named selectors under `@computed` (display-only, never restored). |
+
+### Excluding high-frequency atoms
+
+A single atom that updates on every frame — a cursor position, pointer
+coordinates, a scroll offset — floods the timeline and buries the actions you
+actually care about. Pass it to `exclude` and it disappears from DevTools while
+your store keeps working normally:
+
+```ts
+connectReduxDevtools(store, {
+  // any of: a reference, a name, an atomFamily, a predicate, or a mix
+  exclude: [cursorPositionAtom, "pointerAtom", pointerFamily],
+})
+```
 
 ## Exports
 
 | Export | Kind | Type |
 |--------|------|------|
 | `connectReduxDevtools` | util fn | `(store: Store, options?: ConnectReduxDevtoolsOptions) => ReduxDevtoolsHandle` |
-| `ConnectReduxDevtoolsOptions` | type | `{ name?, serialize?, scopes?, unnamed?, selectors? }` |
+| `ConnectReduxDevtoolsOptions` | type | `{ name?, serialize?, scopes?, unnamed?, exclude?, selectors? }` |
+| `ExcludeOption` / `ExcludeRule` | type | atom/selector/family reference, `name` string, or `(state) => boolean` |
 | `ReduxDevtoolsHandle` | type | `{ disconnect(): void }` |
 | `DevtoolsSnapshot` | type | `Record<string, unknown> & { "@scopes"?, "@computed"? }` |
 | `ReduxDevtoolsConnection` | type | extension connection surface |

--- a/packages/@valdres/redux-devtools/src/redux-devtools.mdx
+++ b/packages/@valdres/redux-devtools/src/redux-devtools.mdx
@@ -128,7 +128,7 @@ const handle = connectReduxDevtools(store())
 | `serialize` | `(state, value) => unknown` | identity | Shape values that aren't structured-cloneable before they're sent. |
 | `scopes` | `boolean` | `true` | Include scope state under `@scopes` and react to scope writes. |
 | `unnamed` | `"track" \| "ignore"` | `"track"` | `track` labels unnamed atoms `unnamed_atom_N`; `ignore` omits them. |
-| `exclude` | `ExcludeRule \| ExcludeRule[]` | — | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
+| `exclude` | `ExcludeRule \| ExcludeRule[]` | — | Leave atoms/selectors out entirely — neither seeded nor reported. A rule is an atom/selector reference, an `atomFamily`/`selectorFamily` (all its members), a `name` string, or a predicate `(state) => boolean`. |
 | `selectors` | `boolean` | `false` | Also report named selectors under `@computed` (display-only, never restored). |
 
 ### Excluding high-frequency atoms
@@ -140,7 +140,7 @@ your store keeps working normally:
 
 ```ts
 connectReduxDevtools(store, {
-  // any of: a reference, a name, an atomFamily, a predicate, or a mix
+  // any of: a reference, a name, an atomFamily/selectorFamily, a predicate, or a mix
   exclude: [cursorPositionAtom, "pointerAtom", pointerFamily],
 })
 ```

--- a/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
+++ b/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
@@ -1,9 +1,16 @@
-import type { Atom, AtomFamily, Selector, SnapshotEntry } from "valdres"
+import type {
+    Atom,
+    AtomFamily,
+    Selector,
+    SelectorFamily,
+    SnapshotEntry,
+} from "valdres"
 
 /**
  * One way to single out atoms (or selectors) to exclude from DevTools:
  * - an atom / selector reference — matched by identity;
- * - an `atomFamily` reference — matches every one of its members;
+ * - an `atomFamily` / `selectorFamily` reference — matches every one of its
+ *   members;
  * - a `name` string — matches an atom/selector with that `name`, or any member
  *   of a family with that `name`;
  * - a predicate `(state) => boolean` over the changed atom/selector for full
@@ -13,6 +20,7 @@ export type ExcludeRule =
     | Atom<any>
     | AtomFamily<any>
     | Selector<any>
+    | SelectorFamily<any, any>
     | string
     | ((state: SnapshotEntry["state"]) => boolean)
 
@@ -48,10 +56,10 @@ export interface ConnectReduxDevtoolsOptions {
     /**
      * Atoms (or selectors) to leave out of DevTools entirely — neither seeded
      * nor reported as actions. Pass an atom/selector reference, an `atomFamily`
-     * (excludes all its members), a `name` string, a predicate
-     * `(state) => boolean`, or an array mixing any of these. Use this for
-     * high-frequency churn (e.g. a `cursorPositionAtom`) that would otherwise
-     * flood the timeline and make time-travel unusable.
+     * or `selectorFamily` (excludes all its members), a `name` string, a
+     * predicate `(state) => boolean`, or an array mixing any of these. Use this
+     * for high-frequency churn (e.g. a `cursorPositionAtom`) that would
+     * otherwise flood the timeline and make time-travel unusable.
      */
     exclude?: ExcludeOption
     /**

--- a/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
+++ b/packages/@valdres/redux-devtools/src/types/ConnectReduxDevtoolsOptions.ts
@@ -1,4 +1,23 @@
-import type { SnapshotEntry } from "valdres"
+import type { Atom, AtomFamily, Selector, SnapshotEntry } from "valdres"
+
+/**
+ * One way to single out atoms (or selectors) to exclude from DevTools:
+ * - an atom / selector reference — matched by identity;
+ * - an `atomFamily` reference — matches every one of its members;
+ * - a `name` string — matches an atom/selector with that `name`, or any member
+ *   of a family with that `name`;
+ * - a predicate `(state) => boolean` over the changed atom/selector for full
+ *   control.
+ */
+export type ExcludeRule =
+    | Atom<any>
+    | AtomFamily<any>
+    | Selector<any>
+    | string
+    | ((state: SnapshotEntry["state"]) => boolean)
+
+/** One rule, or an array of them. */
+export type ExcludeOption = ExcludeRule | readonly ExcludeRule[]
 
 export interface ConnectReduxDevtoolsOptions {
     /** Instance name shown in the Redux DevTools extension dropdown. */
@@ -26,6 +45,15 @@ export interface ConnectReduxDevtoolsOptions {
      * - `"ignore"`: leave them out of DevTools entirely.
      */
     unnamed?: "track" | "ignore"
+    /**
+     * Atoms (or selectors) to leave out of DevTools entirely — neither seeded
+     * nor reported as actions. Pass an atom/selector reference, an `atomFamily`
+     * (excludes all its members), a `name` string, a predicate
+     * `(state) => boolean`, or an array mixing any of these. Use this for
+     * high-frequency churn (e.g. a `cursorPositionAtom`) that would otherwise
+     * flood the timeline and make time-travel unusable.
+     */
+    exclude?: ExcludeOption
     /**
      * Also report named selector (derived) values under a `@computed` key.
      * Display-only — selectors aren't settable, so they're excluded from


### PR DESCRIPTION
## What

Adds an `exclude` option to `connectReduxDevtools` for leaving atoms (or selectors) out of the Redux DevTools entirely — neither seeded into the initial snapshot nor reported as actions.

### Why

A single atom that updates on every frame — a cursor position, pointer coordinates, a scroll offset — floods the timeline and buries the actions you actually care about, making time-travel unusable.

```ts
connectReduxDevtools(store, { exclude: cursorPositionAtom })
```

### Rule shapes

A rule (or an array mixing any of these) can be:

- an **atom / selector reference** — matched by identity
- an **`atomFamily`** reference — matches all its members
- a **`name` string** — matches an atom/selector with that name, or any member of a family with that name
- a **predicate** `(state) => boolean` for full control

```ts
connectReduxDevtools(store, {
  exclude: [cursorPositionAtom, "pointerAtom", pointerFamily, s => s.name?.endsWith("_tick")],
})
```

## Implementation notes

- New internal helper `lib/makeExcludeFilter.ts` compiles `exclude` into one `(state) => boolean` predicate, applied in both the seeding loop and `handleChanges`.
- Key subtlety: an `atomFamily`/`selectorFamily` is itself callable, so family rules are matched via `isAtomFamily`/`isSelectorFamily` **before** the `typeof === "function"` predicate check — otherwise a family would be misread as a predicate and invoked on every atom.

## Tests / docs

- 6 new tests (reference, name, family, mixed array, seeding, all-excluded → no action); full suite 32 pass.
- Documented in the co-located MDX; README regenerated via `gen-readmes`.
- `minor` changeset added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)