### PR TITLE
Reduce redundant selector propagation

### DIFF
--- a/.changeset/selector-overlap-propagation.md
+++ b/.changeset/selector-overlap-propagation.md
@@ -1,0 +1,11 @@
+---
+"valdres": patch
+---
+
+Avoid redundant selector evaluations when an initial dirty selector is also
+downstream of another initial dirty selector in the same propagation pass.
+The initial dirty set is now ordered topologically when that subgraph is
+acyclic, and selectors scheduled later in that initial pass are not queued
+again for downstream propagation before they run. Cyclic initial regions keep
+the existing insertion-order behavior so dynamic dependency churn continues to
+use the established liveness reconciliation path.

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
@@ -42,6 +42,38 @@ test("deleting atom family member from root propagates into scope with cloned fa
     expect(scopedStore.get(countSelector)).toBe(2)
 })
 
+test("overlapping initial and downstream dirty selectors evaluate once", () => {
+    const rootStore = store()
+    const source = atom(1, { name: "overlap-source" })
+
+    const parentSelectorCallback = mock(get => get(source) * 2)
+    const parentSelector = selector(parentSelectorCallback, {
+        name: "overlap-parent",
+    })
+    const childSelectorCallback = mock(
+        // Read `source` before `parentSelector` so the child is inserted before
+        // the parent in source's dependent set. The old linear-first pass then
+        // evaluated child once before parent settled, and once again downstream.
+        get => get(source) + get(parentSelector),
+    )
+    const childSelector = selector(childSelectorCallback, {
+        name: "overlap-child",
+    })
+
+    const callback = mock(() => {})
+    rootStore.sub(childSelector, callback)
+    expect(rootStore.get(childSelector)).toBe(3)
+    expect(parentSelectorCallback).toHaveBeenCalledTimes(1)
+    expect(childSelectorCallback).toHaveBeenCalledTimes(1)
+
+    rootStore.set(source, 2)
+
+    expect(rootStore.get(childSelector)).toBe(6)
+    expect(parentSelectorCallback).toHaveBeenCalledTimes(2)
+    expect(childSelectorCallback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenCalledTimes(1)
+})
+
 test("propagateUpdatedAtoms", () => {
     const rootStore = store()
     const userFamily = atomFamily<

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -782,7 +782,6 @@ const propagateDownstreamTopo = (
         pending.set(s, count)
         if (count === 0) ready.push(s)
     }
-
     // A closure member only needs re-evaluation if at least one of its
     // upstream parents actually changed value. Seeds reach here because
     // a first-pass parent changed, so they start as needing eval. Pure
@@ -980,25 +979,148 @@ const propagateDownstreamTopo = (
     }
 }
 
-// Re-evaluate the initial dirty selectors, then topologically evaluate
-// anything downstream of selectors whose values actually shifted. The topo
-// path guarantees each transitive selector evaluates at most once per
-// propagation even when reachable through paths of differing lengths — the
-// wide-DAG case where a pure BFS would recompute shared nodes once per
-// depth.
-//
-// The first sweep stays a plain linear loop (matching the legacy BFS first
-// iteration) so flat fan-out and init-only chain initialization — where
-// values often don't change at all — pay zero topo overhead. We only
-// allocate closure/pending state when at least one parent's value shift
-// produced live downstream work.
-//
-// Caveat: a selector that's both in the initial set AND a downstream of
-// another initial selector can be evaluated twice in this scheme (once in
-// the linear sweep with potentially stale upstream, once in the topo
-// settle). This matches the legacy BFS behavior and is a niche case in
-// practice; the wide-DAG payoff comes from intermediate (non-initial)
-// selectors which the topo path handles exactly once.
+const orderInitialSelectors = (
+    selectors: Set<Selector>,
+    data: StoreData,
+): Selector[] => {
+    if (selectors.size < 2) return [...selectors]
+
+    const pending = new Map<Selector, number>()
+    const downstream = new Map<Selector, Selector[]>()
+    const ready: Selector[] = []
+
+    for (const selector of selectors) {
+        let count = 0
+        const deps = data.stateDependencies.get(selector)
+        if (deps) {
+            for (const dep of deps) {
+                if (!selectors.has(dep as Selector)) continue
+                count++
+                let list = downstream.get(dep as Selector)
+                if (!list) {
+                    list = []
+                    downstream.set(dep as Selector, list)
+                }
+                list.push(selector)
+            }
+        }
+        pending.set(selector, count)
+        if (count === 0) ready.push(selector)
+    }
+
+    const ordered: Selector[] = []
+    let head = 0
+    while (head < ready.length) {
+        const selector = ready[head++]
+        ordered.push(selector)
+        const children = downstream.get(selector)
+        if (!children) continue
+        for (const child of children) {
+            const count = (pending.get(child) ?? 0) - 1
+            pending.set(child, count)
+            if (count === 0) ready.push(child)
+        }
+    }
+
+    // Cyclic initial regions rely on the old insertion-order behavior plus the
+    // liveness reconcile. Only reorder when the initial subgraph is acyclic.
+    return ordered.length === selectors.size ? ordered : [...selectors]
+}
+
+const propagateSelectorUpdatesLinearFirst = (
+    selectors: Set<Selector>,
+    data: StoreData,
+    collectedSubscribers: Set<any>,
+    updatedInitializedAtoms: Set<Atom>,
+    isInitOnly: boolean,
+    changedSelectors?: Set<Selector>,
+) => {
+    let downstreamSeeds: Set<Selector> | undefined
+    const orderedSelectors = orderInitialSelectors(selectors, data)
+    const processedInitialSelectors = new Set<Selector>()
+    // Reused across every re-evaluated selector — see propagateDownstreamTopo.
+    const depsChange: DepsChange = {}
+    for (const selector of orderedSelectors) {
+        const currentValue = data.values.get(selector)
+        if (isPromiseLike(currentValue) && isInitOnly) {
+            processedInitialSelectors.add(selector)
+            continue
+        }
+        const dependents = data.stateDependents.get(selector)
+        const subscribers = data.subscriptions.get(selector)
+        if (
+            !isPromiseLike(currentValue) &&
+            (!dependents || dependents.size === 0) &&
+            (!subscribers || subscribers.size === 0)
+        ) {
+            // No live consumer — invalidate for lazy re-eval on next read.
+            data.values.delete(selector)
+            processedInitialSelectors.add(selector)
+            continue
+        }
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluateSelector(
+            selector,
+            data,
+            updatedInitializedAtoms,
+            depsChange,
+            currentValue,
+        )
+        // Casts work around a tsgo control-flow narrowing quirk where
+        // property accesses lose their narrowing after a function call.
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if ((added || removed) && isLive(selector, data)) {
+            if (added) {
+                for (const dep of added) {
+                    onLiveDependencyAdded(dep, data)
+                    mountTransitiveDeps(dep, data)
+                }
+            }
+            if (removed) {
+                for (const dep of removed) {
+                    onLiveDependencyRemoved(dep, data)
+                    unmountOrphanedDeps(dep, data)
+                }
+            }
+        }
+        processedInitialSelectors.add(selector)
+        if (!wasValueUpdated) continue
+        if (changedSelectors) changedSelectors.add(selector)
+        if (subscribers) addSetToSet(subscribers, collectedSubscribers)
+        // Re-fetch dependents — eval may have changed them.
+        const downstream = data.stateDependents.get(selector)
+        if (downstream && downstream.size > 0) {
+            if (!downstreamSeeds) downstreamSeeds = new Set()
+            for (const d of downstream) {
+                if (selectors.has(d) && !processedInitialSelectors.has(d)) {
+                    continue
+                }
+                downstreamSeeds.add(d)
+            }
+        }
+    }
+
+    if (downstreamSeeds && downstreamSeeds.size > 0) {
+        propagateDownstreamTopo(
+            downstreamSeeds,
+            data,
+            collectedSubscribers,
+            updatedInitializedAtoms,
+            isInitOnly,
+            changedSelectors,
+        )
+    }
+}
+
+// Re-evaluate the initial dirty selectors, then topologically evaluate anything
+// downstream of selectors whose values actually shifted. The initial sweep is
+// ordered topologically when that initial subgraph is acyclic, and a downstream
+// selector already scheduled later in the same initial sweep is not queued for a
+// second topo pass. Cyclic regions keep the old insertion-order behavior because
+// the liveness churn tests rely on those transitional cycles being evaluated
+// and reconciled by the existing backstop.
 const propagateSelectorUpdates = (
     selectors: Set<Selector>,
     data: StoreData,
@@ -1009,7 +1131,6 @@ const propagateSelectorUpdates = (
 ) => {
     if (selectors.size === 0) return
 
-    let downstreamSeeds: Set<Selector> | undefined
     // Own the per-pass liveness-reconcile collector. `evaluateSelector` populates
     // `data.livenessSeeds` (selectors whose dep SET changed + removed deps) and
     // arms one of two flags: `livenessRemovalArmed` (a dep was removed — gated on
@@ -1027,70 +1148,14 @@ const propagateSelectorUpdates = (
     const ownsLivenessSeeds = beginLivenessPass(data)
     let seedsToReconcile: Set<State> | null = null
     try {
-        // Reused across every re-evaluated selector — see propagateDownstreamTopo.
-        const depsChange: DepsChange = {}
-        for (const selector of selectors) {
-            const currentValue = data.values.get(selector)
-            if (isPromiseLike(currentValue) && isInitOnly) continue
-            const dependents = data.stateDependents.get(selector)
-            const subscribers = data.subscriptions.get(selector)
-            if (
-                !isPromiseLike(currentValue) &&
-                (!dependents || dependents.size === 0) &&
-                (!subscribers || subscribers.size === 0)
-            ) {
-                // No live consumer — invalidate for lazy re-eval on next read.
-                data.values.delete(selector)
-                continue
-            }
-            depsChange.added = undefined
-            depsChange.removed = undefined
-            const wasValueUpdated = reEvaluateSelector(
-                selector,
-                data,
-                updatedInitializedAtoms,
-                depsChange,
-                currentValue,
-            )
-            // Casts work around a tsgo control-flow narrowing quirk where
-            // property accesses lose their narrowing after a function call.
-            const added = depsChange.added as Set<State> | undefined
-            const removed = depsChange.removed as Set<State> | undefined
-            if ((added || removed) && isLive(selector, data)) {
-                if (added) {
-                    for (const dep of added) {
-                        onLiveDependencyAdded(dep, data)
-                        mountTransitiveDeps(dep, data)
-                    }
-                }
-                if (removed) {
-                    for (const dep of removed) {
-                        onLiveDependencyRemoved(dep, data)
-                        unmountOrphanedDeps(dep, data)
-                    }
-                }
-            }
-            if (!wasValueUpdated) continue
-            if (changedSelectors) changedSelectors.add(selector)
-            if (subscribers) addSetToSet(subscribers, collectedSubscribers)
-            // Re-fetch dependents — eval may have changed them.
-            const downstream = data.stateDependents.get(selector)
-            if (downstream && downstream.size > 0) {
-                if (!downstreamSeeds) downstreamSeeds = new Set()
-                for (const d of downstream) downstreamSeeds.add(d)
-            }
-        }
-
-        if (downstreamSeeds && downstreamSeeds.size > 0) {
-            propagateDownstreamTopo(
-                downstreamSeeds,
-                data,
-                collectedSubscribers,
-                updatedInitializedAtoms,
-                isInitOnly,
-                changedSelectors,
-            )
-        }
+        propagateSelectorUpdatesLinearFirst(
+            selectors,
+            data,
+            collectedSubscribers,
+            updatedInitializedAtoms,
+            isInitOnly,
+            changedSelectors,
+        )
     } finally {
         // Always release the collector — even if a user onMount/cleanup above threw
         // (see the note at the top). Returns the region to reconcile, or null.


### PR DESCRIPTION
## Summary
- topologically order acyclic initial dirty selector sets during propagation
- skip queueing initial selectors for a second downstream topo pass before they have run
- preserve insertion-order behavior for cyclic initial regions so liveness churn reconciliation stays intact
- add a regression test for direct+downstream dirty selector overlap

## Verification
- bun test packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
- bun test packages/valdres/src/lib/liveDependentCountChurn.test.ts
- bun test packages/valdres/src/lib/propagateDynamicDeps.test.ts
- bun test packages/valdres/src/lib/mountInClosure.test.ts packages/valdres/src/lib/livenessReconciliation.test.ts packages/valdres/src/lib/liveDependentCountFollowups.test.ts packages/valdres/src/lib/livenessCyclicFuzz.test.ts packages/valdres/src/lib/livenessReconcileMountCleanup.test.ts packages/valdres/src/lib/livenessSeedsReleaseOnThrow.test.ts
- bun test packages/valdres/src/lib/subscribe.test.ts packages/valdres/src/selector.test.ts packages/valdres/test/unsubscribedSelectorRefStability.test.ts packages/valdres/test/asyncSelector.test.ts packages/valdres/src/lib/scope.test.ts
- cd packages/valdres && bun test --reporter=dots (589 pass, 1 todo; fails only on missing optional local test deps jotai/zod)

## Measurement
Synthetic layout-like steady-state repro in .context measured current and v0.2.0-alpha.28 at the same stable selector eval count: 360 evals/interaction on a 240-node graph.