### PR TITLE
Clean up orphaned selector dependencies

### DIFF
--- a/.changeset/orphan-selector-deps.md
+++ b/.changeset/orphan-selector-deps.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Clean up newly orphaned dependency selectors when the last subscriber to a leaf
+selector unsubscribes. Hidden subtrees now drop their cached selector values and
+reverse dependency edges instead of being re-evaluated on later upstream writes
+despite having no live consumer.

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -364,4 +364,36 @@ describe("subscribe", () => {
         // expect(selector3cb).toHaveBeenCalledTimes(1)
         // expect(subCallback).toHaveBeenCalledTimes(1)
     })
+
+    test("unsubscribe cleans orphaned dependency selectors", () => {
+        const rootStore = store()
+        const source = atom(1, { name: "orphan-source" })
+        const intermediateCallback = mock(get => get(source) * 2)
+        const intermediate = selector(intermediateCallback, {
+            name: "orphan-intermediate",
+        })
+        const leaf = selector(get => get(intermediate) + 1, {
+            name: "orphan-leaf",
+        })
+
+        const unsubscribeLeaf = rootStore.sub(leaf, () => {}, false)
+        expect(rootStore.get(leaf)).toBe(3)
+        expect(rootStore.data.stateDependencies.has(intermediate)).toBe(true)
+        expect(rootStore.data.stateDependents.get(source)).toContain(
+            intermediate,
+        )
+
+        unsubscribeLeaf()
+
+        expect(rootStore.data.stateDependencies.has(leaf)).toBe(false)
+        expect(rootStore.data.stateDependencies.has(intermediate)).toBe(false)
+        expect(rootStore.data.values.has(leaf)).toBe(false)
+        expect(rootStore.data.values.has(intermediate)).toBe(false)
+        expect(rootStore.data.stateDependents.get(source)).not.toContain(
+            intermediate,
+        )
+
+        rootStore.set(source, 2)
+        expect(intermediateCallback).toHaveBeenCalledTimes(1)
+    })
 })

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -85,7 +85,9 @@ const cleanupOrphanedDeps = (
     visited.add(state)
     if (isLive(state, data)) return
 
-    // For selectors: remove from dependencies' stateDependents and clear cache
+    // For selectors: remove from dependencies' stateDependents and clear cache.
+    // Then walk those dependencies too: removing `state` may have been the last
+    // live edge keeping an intermediate selector materialized.
     const deps = data.stateDependencies.get(state)
     if (deps) {
         for (const dep of deps) {
@@ -97,6 +99,9 @@ const cleanupOrphanedDeps = (
         data.stateDependencies.delete(state)
         data.values.delete(state)
         data.abortControllers.delete(state)
+        for (const dep of deps) {
+            cleanupOrphanedDeps(dep, data, visited)
+        }
     }
 
     // Recursively clean up orphaned dependents (selectors that read this state)


### PR DESCRIPTION
## Summary
- clean newly orphaned dependency selectors when the last live leaf subscriber unsubscribes
- prevent hidden/not-live selector subtrees from keeping cached values and reverse dependency edges
- add a regression test that verifies orphan intermediates are not re-evaluated on later upstream writes

## Verification
- bun .context/orphan-not-live-diagnostic.ts
- bun test packages/valdres/src/lib/subscribe.test.ts
- bun test packages/valdres/src/lib/propagateUpdatedAtoms.test.ts packages/valdres/src/lib/propagateDynamicDeps.test.ts packages/valdres/src/lib/liveDependentCountChurn.test.ts packages/valdres/src/lib/liveDependentCountFollowups.test.ts packages/valdres/src/lib/livenessReconciliation.test.ts packages/valdres/src/lib/livenessCyclicFuzz.test.ts packages/valdres/src/lib/mountInClosure.test.ts
- bun run test:ci