### PR TITLE
Make orphan cleanup iterative

### DIFF
--- a/.changeset/iterative-orphan-cleanup.md
+++ b/.changeset/iterative-orphan-cleanup.md
@@ -1,0 +1,6 @@
+---
+"valdres": patch
+---
+
+Make orphan selector dependency cleanup iterative so unsubscribing deep selector
+chains does not depend on JavaScript call-stack depth.

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -396,4 +396,32 @@ describe("subscribe", () => {
         rootStore.set(source, 2)
         expect(intermediateCallback).toHaveBeenCalledTimes(1)
     })
+
+    test("unsubscribe cleans deep orphaned selector chains iteratively", () => {
+        const rootStore = store()
+        const source = atom(1)
+        const depth = 100_000
+        let current = selector(get => get(source) + 1)
+        const first = current
+        rootStore.get(current)
+
+        for (let i = 1; i < depth; i++) {
+            const previous = current
+            current = selector(get => get(previous) + 1)
+            // Materialize each link as it is built so this test isolates
+            // unsubscribe cleanup depth rather than selector eval recursion.
+            rootStore.get(current)
+        }
+
+        const unsubscribeTail = rootStore.sub(current, () => {}, false)
+
+        expect(() => unsubscribeTail()).not.toThrow()
+        expect(rootStore.data.stateDependencies.has(current)).toBe(false)
+        expect(rootStore.data.stateDependencies.has(first)).toBe(false)
+        expect(rootStore.data.values.has(current)).toBe(false)
+        expect(rootStore.data.values.has(first)).toBe(false)
+        expect(rootStore.data.stateDependents.get(source)).not.toContain(
+            first,
+        )
+    })
 })

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -79,36 +79,48 @@ export const unsubscribe = <V>(
 const cleanupOrphanedDeps = (
     state: State,
     data: StoreData,
-    visited: Set<State> = new Set(),
 ) => {
-    if (visited.has(state)) return
-    visited.add(state)
-    if (isLive(state, data)) return
+    const visited = new Set<State>()
+    const stack = [state]
+    while (stack.length > 0) {
+        const current = stack.pop()!
+        if (visited.has(current)) continue
+        visited.add(current)
+        if (isLive(current, data)) continue
 
-    // For selectors: remove from dependencies' stateDependents and clear cache.
-    // Then walk those dependencies too: removing `state` may have been the last
-    // live edge keeping an intermediate selector materialized.
-    const deps = data.stateDependencies.get(state)
-    if (deps) {
-        for (const dep of deps) {
-            const depDependents = data.stateDependents.get(dep)
-            if (depDependents) {
-                depDependents.delete(state)
+        const dependents = data.stateDependents.get(current)
+
+        // For selectors: remove from dependencies' stateDependents and clear
+        // cache. Then walk those dependencies too: removing `current` may have
+        // been the last live edge keeping an intermediate selector materialized.
+        const deps = data.stateDependencies.get(current)
+        if (deps) {
+            for (const dep of deps) {
+                const depDependents = data.stateDependents.get(dep)
+                if (depDependents) {
+                    depDependents.delete(current)
+                }
             }
-        }
-        data.stateDependencies.delete(state)
-        data.values.delete(state)
-        data.abortControllers.delete(state)
-        for (const dep of deps) {
-            cleanupOrphanedDeps(dep, data, visited)
-        }
-    }
+            data.stateDependencies.delete(current)
+            data.values.delete(current)
+            data.abortControllers.delete(current)
 
-    // Recursively clean up orphaned dependents (selectors that read this state)
-    const dependents = data.stateDependents.get(state)
-    if (dependents) {
-        for (const dep of [...dependents]) {
-            cleanupOrphanedDeps(dep, data, visited)
+            if (dependents) {
+                for (const dep of dependents) {
+                    stack.push(dep)
+                }
+            }
+            for (const dep of deps) {
+                stack.push(dep)
+            }
+            continue
+        }
+
+        // Clean up orphaned dependents (selectors that read this state).
+        if (dependents) {
+            for (const dep of dependents) {
+                stack.push(dep)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- convert orphan dependency cleanup from recursive traversal to an explicit stack
- preserve the newly merged upstream/downstream orphan cleanup behavior while avoiding call-stack depth risk on deep selector chains

## Verification
- bunx changeset status --since=origin/main
- bun .context/orphan-not-live-diagnostic.ts
- bun test packages/valdres/src/lib/subscribe.test.ts packages/valdres/src/lib/propagateUpdatedAtoms.test.ts packages/valdres/src/lib/propagateDynamicDeps.test.ts packages/valdres/src/lib/liveDependentCountChurn.test.ts packages/valdres/src/lib/liveDependentCountFollowups.test.ts packages/valdres/src/lib/livenessReconciliation.test.ts packages/valdres/src/lib/livenessCyclicFuzz.test.ts packages/valdres/src/lib/mountInClosure.test.ts packages/valdres/src/lib/abortSignal.test.ts