### PR TITLE
Fix redundant stranded aggregate evaluations

### DIFF
--- a/.changeset/bound-stranded-fanin-reeval.md
+++ b/.changeset/bound-stranded-fanin-reeval.md
@@ -1,0 +1,15 @@
+---
+"valdres": patch
+---
+
+Bound redundant selector re-evaluation for wide fan-in selectors under dynamic
+dependency churn.
+
+The downstream topological propagation walk now treats removal from its
+`pending` map as the settled marker, preventing dynamically changed dependency
+edges from repeatedly re-queueing an already finalized selector. When a graph
+mutation still requires a settled selector to be revisited, that selector and its
+downstream closure are deferred to the stranded settle phase, which now settles
+work in dependency order before falling back for cyclic regions. This preserves
+correctness for escaped/stranded dynamic-dependency cases while avoiding repeated
+evaluation of subscribed wide aggregators during transient settle waves.

--- a/packages/valdres/src/lib/propagateDynamicDeps.test.ts
+++ b/packages/valdres/src/lib/propagateDynamicDeps.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import { atom } from "../atom"
 import { selector } from "../selector"
 import { store } from "../store"
@@ -87,6 +87,148 @@ describe("dynamic-dependency propagation", () => {
             if (!subs[i]) continue
             expect(s.get(sels[i])).toBe(os.get(o.sels[i]))
         }
+    })
+
+    test("stranded aggregate is settled once after upstream revisits", () => {
+        const defs = [
+            {
+                deps: [1, 2],
+                selDeps: [],
+                altSelDeps: [],
+                ctrl: { atom: 0 },
+                mode: 0,
+            },
+            {
+                deps: [4, 1, 4],
+                selDeps: [0],
+                altSelDeps: [],
+                ctrl: { sel: 0 },
+                mode: 1,
+            },
+            {
+                deps: [2, 0],
+                selDeps: [1, 0],
+                altSelDeps: [1, 1],
+                ctrl: { atom: 4 },
+                mode: 2,
+            },
+            {
+                deps: [1, 2, 1],
+                selDeps: [],
+                altSelDeps: [],
+                ctrl: { atom: 2 },
+                mode: 1,
+            },
+            {
+                deps: [4, 2],
+                selDeps: [2, 2],
+                altSelDeps: [],
+                ctrl: { atom: 4 },
+                mode: 0,
+            },
+            {
+                deps: [1, 3],
+                selDeps: [],
+                altSelDeps: [],
+                ctrl: { sel: 1 },
+                mode: 0,
+            },
+            {
+                deps: [1],
+                selDeps: [],
+                altSelDeps: [0],
+                ctrl: { atom: 2 },
+                mode: 0,
+            },
+            {
+                deps: [2, 0],
+                selDeps: [4],
+                altSelDeps: [],
+                ctrl: { sel: 6 },
+                mode: 0,
+            },
+            {
+                deps: [2],
+                selDeps: [5, 7],
+                altSelDeps: [],
+                ctrl: { sel: 3 },
+                mode: 2,
+            },
+            {
+                deps: [0],
+                selDeps: [0, 0],
+                altSelDeps: [2],
+                ctrl: { atom: 2 },
+                mode: 2,
+            },
+        ] as const
+        const build = () => {
+            const run = ++uid
+            const atoms = Array.from({ length: 5 }, (_, i) =>
+                atom(i, { name: `a${i}.${run}` }),
+            )
+            const sels: any[] = []
+            defs.forEach((def, idx) => {
+                sels.push(
+                    selector(
+                        get => {
+                            const ctrl =
+                                "atom" in def.ctrl
+                                    ? get(atoms[def.ctrl.atom])
+                                    : get(sels[def.ctrl.sel])
+                            let acc = def.mode + (ctrl % 3)
+                            if (ctrl % 2 === 0) {
+                                for (const di of def.deps) acc += get(atoms[di])
+                                for (const si of def.selDeps)
+                                    acc += get(sels[si])
+                            } else {
+                                for (const si of def.altSelDeps)
+                                    acc += get(sels[si]) * 2
+                            }
+                            return acc
+                        },
+                        { name: `s${idx}` },
+                    ),
+                )
+            })
+            const aggregateCallback = mock(get => {
+                let total = 0
+                for (const sel of sels) total += get(sel)
+                return total
+            })
+            const aggregate = selector(aggregateCallback, {
+                name: `strandedAggregate.${run}`,
+            })
+            return { atoms, sels, aggregate, aggregateCallback }
+        }
+
+        const { atoms, sels, aggregate, aggregateCallback } = build()
+        const root = store()
+        const s = root.scope("stranded-aggregate")
+        const subs: (null | (() => void))[] = sels.map(sel =>
+            s.sub(sel, () => {}),
+        )
+        s.sub(aggregate, () => {})
+        s.get(aggregate)
+        subs[7]!()
+        subs[7] = null
+        subs[0]!()
+        subs[0] = null
+        s.set(atoms[0], 18)
+
+        const callsBeforeStrandedUpdate = aggregateCallback.mock.calls.length
+        s.set(atoms[2], 16)
+
+        const o = build()
+        const oRoot = store()
+        const os = oRoot.scope("stranded-aggregate")
+        os.set(o.atoms[0], 18)
+        os.set(o.atoms[2], 16)
+
+        expect(s.get(aggregate)).toBe(os.get(o.aggregate))
+        expect(
+            aggregateCallback.mock.calls.length - callsBeforeStrandedUpdate,
+        ).toBe(1)
     })
 
     // Random dynamic-dependency graphs (branch keyed on a derived selector,
@@ -188,6 +330,93 @@ describe("dynamic-dependency propagation", () => {
                 }
             }
             subbed.forEach(u => u && u())
+        }
+    })
+
+    // Regression for the 1.0.0-beta wide-fan-in re-evaluation blow-up: a
+    // subscribed aggregator with dynamic deps that reads many upstream selectors
+    // was re-evaluated roughly once per dependency on a single commit. This
+    // seed produced ~169 evaluations of one selector before the fix.
+    test("wide fan-in aggregator is not re-evaluated once per dependency", () => {
+        const mulberry32 = (seed: number) => () => {
+            seed |= 0
+            seed = (seed + 0x6d2b79f5) | 0
+            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        }
+        const seed = 1147
+        const rnd = mulberry32(seed)
+        const nAtoms = 4 + Math.floor(rnd() * 6)
+        const nSelectors = 12 + Math.floor(rnd() * 24)
+        const evals = new Map<number, number>()
+        const defs: any[] = []
+        for (let i = 0; i < nSelectors; i++) {
+            const pick = (n: number, max: number) => {
+                const out: number[] = []
+                for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
+                return out
+            }
+            const wide = i >= nSelectors - 3 && i > 4
+            defs.push({
+                ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
+                deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
+                selDeps: wide ? Array.from({ length: i }, (_, k) => k) : i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                mode: Math.floor(rnd() * 3),
+            })
+        }
+        const inst = (countEvals: boolean) => {
+            const run = ++uid
+            const atoms = Array.from({ length: nAtoms }, (_, i) => atom(i, { name: `wfi-a${i}.${run}` }))
+            const sels: any[] = []
+            defs.forEach((def, idx) => {
+                sels.push(selector(get => {
+                    if (countEvals) evals.set(idx, (evals.get(idx) ?? 0) + 1)
+                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
+                    let acc = def.mode + (ctrl % 3)
+                    if (ctrl % 2 === 0) {
+                        for (const di of def.deps) acc += get(atoms[di])
+                        for (const si of def.selDeps) acc += get(sels[si])
+                    } else {
+                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
+                    }
+                    return acc
+                }, { name: `wfi-s${idx}.${run}` }))
+            })
+            return { atoms, sels }
+        }
+
+        const I = inst(true)
+        const root = store()
+        const child = root.scope("draft")
+        const unsubs: (() => void)[] = []
+        for (let i = 0; i < nSelectors; i++)
+            if (rnd() < 0.5) unsubs.push(child.sub(I.sels[i], () => {}))
+        for (let i = Math.max(0, nSelectors - 3); i < nSelectors; i++)
+            unsubs.push(child.sub(I.sels[i], () => {}))
+        for (let i = 0; i < nSelectors; i++) child.get(I.sels[i])
+
+        evals.clear()
+        const nChanged = 1 + Math.floor(rnd() * 4)
+        const changed: { ai: number; v: number }[] = []
+        for (let k = 0; k < nChanged; k++)
+            changed.push({ ai: Math.floor(rnd() * nAtoms), v: 100 + Math.floor(rnd() * 50) })
+        child.txn(({ set }) => {
+            for (const c of changed) set(I.atoms[c.ai], c.v)
+        })
+
+        let maxEvals = 0
+        for (const n of evals.values()) if (n > maxEvals) maxEvals = n
+        unsubs.forEach(u => u())
+        expect(maxEvals).toBeLessThan(40)
+
+        const O = inst(false)
+        const oRoot = store()
+        const oChild = oRoot.scope("draft")
+        for (const c of changed) oChild.set(O.atoms[c.ai], c.v)
+        for (let i = 0; i < nSelectors; i++) {
+            expect(child.get(I.sels[i])).toBe(oChild.get(O.sels[i]))
         }
     })
 })

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -733,13 +733,17 @@ export const propagateDirtySelectors = (
 }
 
 
-// Topological evaluation of a downstream subgraph. Each selector in
-// `seeds` (and everything transitively reachable from them) is re-evaluated
-// at most once, in dependency order. The seeds are direct dependents of
-// initial selectors whose values just changed in the first sweep — i.e.
-// "level-2" selectors. We only enter the topo path when there's actual
-// downstream work, since the bookkeeping (closure + pending count) is
-// material relative to a simple BFS pass.
+// Topological evaluation of a downstream subgraph. The main ready queue visits
+// each selector in `seeds` (and everything transitively reachable from them) at
+// most once, in dependency order. A finalized node is deleted from `pending`,
+// which caps duplicate pushes caused by dynamic dependency churn without a
+// separate queued/evaluated Set. If churn later proves that a settled selector
+// must run again, that selector and its downstream closure are deferred to the
+// settle phase below so wide aggregates run after upstream revisits rather than
+// once per transient wave. The seeds are direct dependents of initial selectors
+// whose values just changed in the first sweep — i.e. "level-2" selectors. We
+// only enter the topo path when there's actual downstream work, since the
+// bookkeeping (closure + pending count) is material relative to a simple BFS pass.
 const propagateDownstreamTopo = (
     seeds: Set<Selector>,
     data: StoreData,
@@ -790,9 +794,24 @@ const propagateDownstreamTopo = (
 
     // Set when the dependency graph changes during the walk (a selector's deps
     // were added/removed, or an out-of-closure dependent was pulled in). Only
-    // then can a node be left stranded with an undrained `pending`, so the
-    // settle scan below is skipped entirely on the steady-state path.
+    // then can a node need the settle scan below, so the steady-state fast path
+    // skips it entirely.
     let graphMutated = false
+    let resweep: Set<Selector> | undefined
+    const markForResweep = (selector: Selector) => {
+        graphMutated = true
+        if (!resweep) resweep = new Set()
+        const stack = [selector]
+        for (let i = 0; i < stack.length; i++) {
+            const s = stack[i]
+            if (resweep.has(s)) continue
+            resweep.add(s)
+            const downstream = data.stateDependents.get(s)
+            if (downstream) {
+                for (const d of downstream) stack.push(d)
+            }
+        }
+    }
 
     const advance = (selector: Selector, propagateChange: boolean) => {
         const downstream = data.stateDependents.get(selector)
@@ -818,7 +837,12 @@ const propagateDownstreamTopo = (
                 }
                 continue
             }
-            const c = (pending.get(d) ?? 0) - 1
+            const cur = pending.get(d)
+            if (cur === undefined) {
+                if (propagateChange) markForResweep(d)
+                continue
+            }
+            const c = cur - 1
             pending.set(d, c)
             if (propagateChange) needsEval.add(d)
             if (c <= 0) ready.push(d)
@@ -834,15 +858,19 @@ const propagateDownstreamTopo = (
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
+        if (resweep?.has(selector)) continue
+        if (!pending.has(selector)) continue
 
         const currentValue = data.values.get(selector)
 
         if (isPromiseLike(currentValue) && isInitOnly) {
+            pending.delete(selector)
             advance(selector, false)
             continue
         }
 
         if (!needsEval.has(selector)) {
+            pending.delete(selector)
             advance(selector, false)
             continue
         }
@@ -857,6 +885,7 @@ const propagateDownstreamTopo = (
         ) {
             // No live consumer — invalidate for lazy re-eval on next read.
             data.values.delete(selector)
+            pending.delete(selector)
             advance(selector, false)
             continue
         }
@@ -893,6 +922,7 @@ const propagateDownstreamTopo = (
             }
         }
 
+        pending.delete(selector)
         advance(selector, wasValueUpdated)
         if (wasValueUpdated) {
             if (changedSelectors) changedSelectors.add(selector)
@@ -900,24 +930,26 @@ const propagateDownstreamTopo = (
         }
     }
 
-    // Settle stranded nodes. The `pending` counts are a snapshot taken before
-    // the walk; they assume the dependency graph is fixed for its duration. But
-    // a selector can be re-evaluated out-of-band DURING the walk — most commonly
-    // lazily re-initialized via getState when another selector reads it (after
-    // its value was dropped by an earlier orphan-invalidation/unsubscribe). If
-    // that re-eval drops a dependency it was snapshotted with, the dropped
-    // parent's reverse edge is gone, so it never decrements this node's
-    // `pending`, which then stalls above 0 and the node is never processed —
-    // even though one of its surviving dependencies changed. Such a node is left
-    // stale, and so is anything that read it. Re-settle the stranded set (and
-    // whatever depends on it) with a fixpoint that re-fetches dependents each
-    // pass, which is inherently robust to a graph that changed under us. Guarded
-    // by `graphMutated`, so the steady-state fast path skips it entirely.
+    // Settle stranded/resweep nodes. The `pending` counts are a snapshot taken
+    // before the walk; they assume the dependency graph is fixed for its
+    // duration. But a selector can be re-evaluated out-of-band DURING the walk —
+    // most commonly lazily re-initialized via getState when another selector
+    // reads it (after its value was dropped by an earlier
+    // orphan-invalidation/unsubscribe). If that re-eval drops a dependency it
+    // was snapshotted with, the dropped parent's reverse edge is gone, so it
+    // never decrements this node's `pending`, which then stalls above 0 and the
+    // node is never processed. Also, a node already settled by the main ready
+    // queue can receive another real changed-parent signal after graph churn; it
+    // has no `pending` entry, so it is recorded in `resweep`. Re-settle those
+    // nodes and their downstream closure with a dynamic topo fixpoint. That lets
+    // upstream revisits settle before wide downstream aggregates run, while
+    // still falling back to wave settling for cyclic regions. Guarded by
+    // `graphMutated`, so the steady-state fast path skips it entirely.
     if (!graphMutated) return
 
-    let stranded: Set<Selector> | undefined
+    let stranded: Set<Selector> | undefined = resweep
     for (const s of closure) {
-        if (needsEval.has(s) && (pending.get(s) ?? 0) > 0) {
+        if (needsEval.has(s) && pending.has(s)) {
             if (!stranded) stranded = new Set()
             stranded.add(s)
         }
@@ -925,57 +957,87 @@ const propagateDownstreamTopo = (
     if (!stranded) return
 
     let work = stranded
-    while (work.size > 0) {
-        const next = new Set<Selector>()
-        for (const selector of work) {
-            const currentValue = data.values.get(selector)
-            if (isPromiseLike(currentValue) && isInitOnly) continue
-            const dependents = data.stateDependents.get(selector)
-            const subscribers = data.subscriptions.get(selector)
-            if (
-                !isPromiseLike(currentValue) &&
-                (!dependents || dependents.size === 0) &&
-                (!subscribers || subscribers.size === 0)
-            ) {
-                data.values.delete(selector)
-                continue
-            }
-            depsChange.added = undefined
-            depsChange.removed = undefined
-            const wasValueUpdated = reEvaluateSelector(
-                selector,
-                data,
-                updatedInitializedAtoms,
-                depsChange,
-                currentValue,
-            )
-            const added = depsChange.added as Set<State> | undefined
-            const removed = depsChange.removed as Set<State> | undefined
-            if ((added || removed) && isLive(selector, data)) {
-                if (added) {
-                    for (const dep of added) {
-                        onLiveDependencyAdded(dep, data)
-                        mountTransitiveDeps(dep, data)
-                    }
+    const hasUnsettledDependency = (selector: Selector) => {
+        const deps = data.stateDependencies.get(selector)
+        if (!deps) return false
+        for (const dep of deps) {
+            if (dep !== selector && work.has(dep as Selector)) return true
+        }
+        return false
+    }
+    const enqueueDownstream = (selector: Selector) => {
+        const downstream = data.stateDependents.get(selector)
+        if (!downstream) return
+        for (const d of downstream) {
+            work.add(d)
+        }
+    }
+    const evaluateStrandedSelector = (selector: Selector) => {
+        const currentValue = data.values.get(selector)
+        if (isPromiseLike(currentValue) && isInitOnly) return false
+        const dependents = data.stateDependents.get(selector)
+        const subscribers = data.subscriptions.get(selector)
+        if (
+            !isPromiseLike(currentValue) &&
+            (!dependents || dependents.size === 0) &&
+            (!subscribers || subscribers.size === 0)
+        ) {
+            data.values.delete(selector)
+            return false
+        }
+        depsChange.added = undefined
+        depsChange.removed = undefined
+        const wasValueUpdated = reEvaluateSelector(
+            selector,
+            data,
+            updatedInitializedAtoms,
+            depsChange,
+            currentValue,
+        )
+        const added = depsChange.added as Set<State> | undefined
+        const removed = depsChange.removed as Set<State> | undefined
+        if ((added || removed) && isLive(selector, data)) {
+            if (added) {
+                for (const dep of added) {
+                    onLiveDependencyAdded(dep, data)
+                    mountTransitiveDeps(dep, data)
                 }
-                if (removed) {
-                    for (const dep of removed) {
-                        onLiveDependencyRemoved(dep, data)
-                        unmountOrphanedDeps(dep, data)
-                    }
-                }
             }
-            if (wasValueUpdated) {
-                if (changedSelectors) changedSelectors.add(selector)
-                if (subscribers) addSetToSet(subscribers, collectedSubscribers)
-                // Re-fetch dependents — eval may have changed them.
-                const downstream = data.stateDependents.get(selector)
-                if (downstream) {
-                    for (const d of downstream) next.add(d)
+            if (removed) {
+                for (const dep of removed) {
+                    onLiveDependencyRemoved(dep, data)
+                    unmountOrphanedDeps(dep, data)
                 }
             }
         }
-        work = next
+        if (wasValueUpdated) {
+            if (changedSelectors) changedSelectors.add(selector)
+            if (subscribers) addSetToSet(subscribers, collectedSubscribers)
+            // Re-fetch dependents — eval may have changed them.
+            enqueueDownstream(selector)
+        }
+        return wasValueUpdated
+    }
+    while (work.size > 0) {
+        let progressed = false
+        const batch = [...work]
+        for (const selector of batch) {
+            if (!work.has(selector)) continue
+            if (hasUnsettledDependency(selector)) continue
+            work.delete(selector)
+            progressed = true
+            evaluateStrandedSelector(selector)
+        }
+        if (progressed) continue
+
+        // Cyclic stranded regions have no dependency-free node. Fall back to the
+        // previous wave behavior for that region so cyclic dynamic graphs still
+        // get a chance to settle instead of stalling behind the topo gate.
+        const cyclicBatch = [...work]
+        work = new Set()
+        for (const selector of cyclicBatch) {
+            evaluateStrandedSelector(selector)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- use `pending.delete(selector)` as the settled marker, inspired by PR #210, so dynamic-dep churn cannot repeatedly re-queue finalized selectors
- defer genuine settled-node revisits into a resweep set, including their downstream closure, so wide aggregates wait for upstream revisits
- settle stranded/resweep work with a dynamic topo worklist, preserving cyclic fallback behavior
- add scoped regression coverage for the stranded aggregate evaluating once and matching a fresh replay oracle
- add PR #210's seeded wide-fan-in regression test to guard the original per-dependency blow-up
- add a patch changeset

## Verification
- bun test packages/valdres/src/lib/propagateDynamicDeps.test.ts packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
- bun --filter valdres build

## Additional probes
- stranded aggregate probe: 1 aggregate eval, correct
- PR #210 seeded wide-fan-in probe: max 3 selector evals, correct

## Notes
- Full `bun test packages/valdres/src` is currently blocked by missing `zod` in schema/hydration tests.
- `bun --filter valdres build:types` is currently blocked by `bunx tsgo` resolving `tsgo` from npm and getting a 404.