### PR TITLE
fix(valdres): scope.set pins a shadow even when value equals the inherited value

### DIFF
--- a/.changeset/scope-set-equal-pins-shadow.md
+++ b/.changeset/scope-set-equal-pins-shadow.md
@@ -1,0 +1,34 @@
+---
+"valdres": patch
+---
+
+Fix `scope.set(atom, value)` silently failing to pin when `value` equals the
+value the scope currently inherits from its parent.
+
+A scope atom that hasn't been written yet is read through to a parent, so
+`setAtom` computed `currentValue` from that inherited value. When the new value
+was equal, it short-circuited (`if (areEqual) return`) *before* establishing the
+scope's own shadow — so the scope kept tracking the parent. A later parent write
+to that atom then leaked into the scope, silently dropping the explicit override
+(and a delegating subscription never re-rooted). The documented contract is the
+opposite: once a scope writes an atom it is isolated, and subsequent parent
+writes must not reach it.
+
+Concretely, this was wrong:
+
+```ts
+const a = atom(2)            // default 2
+const child = root.scope("draft")
+child.set(a, 2)              // equals the inherited default → no shadow created
+root.set(a, 11)
+child.get(a)                 // returned 11; now correctly returns 2
+```
+
+The cross-scope/transaction commit path (`writeAtoms`) already pinned equal
+values; only the individual `set()` path (`setAtom`) was missing it. The fix
+mirrors that branch: on a scope, an equal-valued set of a not-yet-shadowed atom
+now calls `setValueInData` to establish the shadow (registering it in
+`scopeValueIndex` and re-rooting delegating subscriptions) while skipping
+propagation, since the visible value is unchanged. On a root store, or when the
+scope already shadows the atom, the equal-value set remains a true no-op, so the
+write hot path is untouched.

--- a/packages/valdres/src/lib/propagateDynamicDeps.test.ts
+++ b/packages/valdres/src/lib/propagateDynamicDeps.test.ts
@@ -7,6 +7,54 @@ import { store } from "../store"
 // atoms built per run get a unique suffix. Selector names are unaffected.
 let uid = 0
 
+// Shared fuzz helpers (used by both fuzz tests below) — kept at file scope so the
+// two oracles can't drift. `inst` suffixes atom names with a per-build `++uid`, so
+// names stay globally unique no matter how many builds run in this process.
+const mulberry32 = (seed: number) => () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+}
+const buildGraph = (rnd: () => number, nAtoms: number, nSelectors: number) => {
+    const selDefs: any[] = []
+    for (let i = 0; i < nSelectors; i++) {
+        const pick = (n: number, max: number) => {
+            const out: number[] = []
+            for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
+            return out
+        }
+        selDefs.push({
+            deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
+            selDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+            altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+            ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
+            mode: Math.floor(rnd() * 3),
+        })
+    }
+    return { nAtoms, selDefs }
+}
+const inst = (g: any) => {
+    const run = ++uid
+    const atoms = Array.from({ length: g.nAtoms }, (_, i) => atom(i, { name: `a${i}.${run}` }))
+    const sels: any[] = []
+    g.selDefs.forEach((def: any, idx: number) => {
+        sels.push(selector(get => {
+            const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
+            let acc = def.mode + (ctrl % 3)
+            if (ctrl % 2 === 0) {
+                for (const di of def.deps) acc += get(atoms[di])
+                for (const si of def.selDeps) acc += get(sels[si])
+            } else {
+                for (const si of def.altSelDeps) acc += get(sels[si]) * 2
+            }
+            return acc
+        }, { name: `s${idx}` }))
+    })
+    return { atoms, sels }
+}
+
 // Regression tests for a selector-invalidation bug introduced when selector
 // update propagation moved to a static topological closure (1.0.0-beta.4).
 //
@@ -94,51 +142,6 @@ describe("dynamic-dependency propagation", () => {
     // both a root store and a scope. Each step is checked against a fresh store
     // replaying the identical op sequence — any divergence is a stale selector.
     test("fuzz: incremental store matches fresh-replay oracle", () => {
-        const mulberry32 = (seed: number) => () => {
-            seed |= 0
-            seed = (seed + 0x6d2b79f5) | 0
-            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
-            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
-            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-        }
-        const buildGraph = (rnd: () => number, nAtoms: number, nSelectors: number) => {
-            const selDefs: any[] = []
-            for (let i = 0; i < nSelectors; i++) {
-                const pick = (n: number, max: number) => {
-                    const out: number[] = []
-                    for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
-                    return out
-                }
-                selDefs.push({
-                    deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
-                    selDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
-                    altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
-                    ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
-                    mode: Math.floor(rnd() * 3),
-                })
-            }
-            return { nAtoms, selDefs }
-        }
-        const inst = (g: any) => {
-            const run = ++uid
-            const atoms = Array.from({ length: g.nAtoms }, (_, i) => atom(i, { name: `a${i}.${run}` }))
-            const sels: any[] = []
-            g.selDefs.forEach((def: any, idx: number) => {
-                sels.push(selector(get => {
-                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
-                    let acc = def.mode + (ctrl % 3)
-                    if (ctrl % 2 === 0) {
-                        for (const di of def.deps) acc += get(atoms[di])
-                        for (const si of def.selDeps) acc += get(sels[si])
-                    } else {
-                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
-                    }
-                    return acc
-                }, { name: `s${idx}` }))
-            })
-            return { atoms, sels }
-        }
-
         for (let seed = 1; seed <= 200; seed++) {
             const rnd = mulberry32(seed)
             const nAtoms = 3 + Math.floor(rnd() * 4)
@@ -206,51 +209,6 @@ describe("dynamic-dependency propagation", () => {
     // and applies the root values before the scope shadows, so the scope's
     // explicit set is always the last write and the shadow is guaranteed to pin.
     test("fuzz: scope shadows pin regardless of set order (order-independent oracle)", () => {
-        const mulberry32 = (seed: number) => () => {
-            seed |= 0
-            seed = (seed + 0x6d2b79f5) | 0
-            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
-            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
-            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-        }
-        const buildGraph = (rnd: () => number, nAtoms: number, nSelectors: number) => {
-            const selDefs: any[] = []
-            for (let i = 0; i < nSelectors; i++) {
-                const pick = (n: number, max: number) => {
-                    const out: number[] = []
-                    for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
-                    return out
-                }
-                selDefs.push({
-                    deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
-                    selDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
-                    altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
-                    ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
-                    mode: Math.floor(rnd() * 3),
-                })
-            }
-            return { nAtoms, selDefs }
-        }
-        const inst = (g: any) => {
-            const run = ++uid
-            const atoms = Array.from({ length: g.nAtoms }, (_, i) => atom(i, { name: `oa${i}.${run}` }))
-            const sels: any[] = []
-            g.selDefs.forEach((def: any, idx: number) => {
-                sels.push(selector(get => {
-                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
-                    let acc = def.mode + (ctrl % 3)
-                    if (ctrl % 2 === 0) {
-                        for (const di of def.deps) acc += get(atoms[di])
-                        for (const si of def.selDeps) acc += get(sels[si])
-                    } else {
-                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
-                    }
-                    return acc
-                }, { name: `s${idx}` }))
-            })
-            return { atoms, sels }
-        }
-
         for (let seed = 1; seed <= 300; seed++) {
             const rnd = mulberry32(seed)
             const nAtoms = 3 + Math.floor(rnd() * 4)

--- a/packages/valdres/src/lib/propagateDynamicDeps.test.ts
+++ b/packages/valdres/src/lib/propagateDynamicDeps.test.ts
@@ -190,4 +190,124 @@ describe("dynamic-dependency propagation", () => {
             subbed.forEach(u => u && u())
         }
     })
+
+    // Regression for the scope-shadow-on-equal bug: `scope.set(atom, v)` must
+    // establish the scope's shadow even when `v` equals the value currently
+    // INHERITED from the parent — otherwise the scope keeps tracking the parent
+    // and a later parent write to that atom leaks in, silently dropping the
+    // explicit override. (setAtom short-circuited on `areEqual` before writing
+    // the shadow; the txn path in writeAtoms already pinned equal values.)
+    //
+    // The fuzz above never caught this: its oracle REPLAYS the same ops in the
+    // same order, so when a scope set was order-dependently dropped, the oracle
+    // dropped it identically and the two agreed. This oracle is ORDER-INDEPENDENT
+    // — it derives each atom's expected scope value from a model (the scope's own
+    // last set if it ever set the atom, else read-through to the root's last set)
+    // and applies the root values before the scope shadows, so the scope's
+    // explicit set is always the last write and the shadow is guaranteed to pin.
+    test("fuzz: scope shadows pin regardless of set order (order-independent oracle)", () => {
+        const mulberry32 = (seed: number) => () => {
+            seed |= 0
+            seed = (seed + 0x6d2b79f5) | 0
+            let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+        }
+        const buildGraph = (rnd: () => number, nAtoms: number, nSelectors: number) => {
+            const selDefs: any[] = []
+            for (let i = 0; i < nSelectors; i++) {
+                const pick = (n: number, max: number) => {
+                    const out: number[] = []
+                    for (let j = 0; j < n; j++) out.push(Math.floor(rnd() * max))
+                    return out
+                }
+                selDefs.push({
+                    deps: pick(1 + Math.floor(rnd() * 3), nAtoms),
+                    selDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                    altSelDeps: i > 0 ? pick(Math.floor(rnd() * 3), i) : [],
+                    ctrl: i > 0 && rnd() < 0.6 ? { sel: Math.floor(rnd() * i) } : { atom: Math.floor(rnd() * nAtoms) },
+                    mode: Math.floor(rnd() * 3),
+                })
+            }
+            return { nAtoms, selDefs }
+        }
+        const inst = (g: any) => {
+            const run = ++uid
+            const atoms = Array.from({ length: g.nAtoms }, (_, i) => atom(i, { name: `oa${i}.${run}` }))
+            const sels: any[] = []
+            g.selDefs.forEach((def: any, idx: number) => {
+                sels.push(selector(get => {
+                    const ctrl = "atom" in def.ctrl ? get(atoms[def.ctrl.atom]) : get(sels[def.ctrl.sel])
+                    let acc = def.mode + (ctrl % 3)
+                    if (ctrl % 2 === 0) {
+                        for (const di of def.deps) acc += get(atoms[di])
+                        for (const si of def.selDeps) acc += get(sels[si])
+                    } else {
+                        for (const si of def.altSelDeps) acc += get(sels[si]) * 2
+                    }
+                    return acc
+                }, { name: `s${idx}` }))
+            })
+            return { atoms, sels }
+        }
+
+        for (let seed = 1; seed <= 300; seed++) {
+            const rnd = mulberry32(seed)
+            const nAtoms = 3 + Math.floor(rnd() * 4)
+            const nSelectors = 10 + Math.floor(rnd() * 12)
+            const g = buildGraph(rnd, nAtoms, nSelectors)
+            const I = inst(g)
+            const root = store()
+            const child: any = root.scope("child")
+
+            // Order-independent model: per atom, the root's last set (default = i)
+            // and the scope's own last set (if it ever set it).
+            const rootVal = Array.from({ length: nAtoms }, (_, i) => i)
+            const scopeSet = new Array(nAtoms).fill(false)
+            const scopeVal = new Array(nAtoms).fill(0)
+
+            const subbed: (null | (() => void))[] = new Array(nSelectors).fill(null)
+            const toggle = (si: number) => {
+                if (subbed[si]) { subbed[si]!(); subbed[si] = null }
+                else subbed[si] = child.sub(I.sels[si], () => {})
+            }
+            for (let si = 0; si < nSelectors; si++) if (rnd() < 0.6) toggle(si)
+
+            for (let step = 0; step < 40; step++) {
+                const churn = Math.floor(rnd() * 3)
+                for (let c = 0; c < churn; c++) toggle(Math.floor(rnd() * nSelectors))
+                // Interleave individual root and scope sets in random order — the
+                // very mix that order-dependent shadow creation got wrong.
+                const m = 1 + Math.floor(rnd() * 3)
+                for (let j = 0; j < m; j++) {
+                    const ai = Math.floor(rnd() * nAtoms)
+                    const v = Math.floor(rnd() * 20)
+                    if (rnd() < 0.5) {
+                        root.set(I.atoms[ai], v)
+                        rootVal[ai] = v
+                    } else {
+                        child.set(I.atoms[ai], v)
+                        scopeSet[ai] = true
+                        scopeVal[ai] = v
+                    }
+                }
+
+                // Fresh oracle from the model: apply ALL root values first, then the
+                // scope shadows, so each scope set is the last write for its atom and
+                // the shadow is guaranteed to pin — independent of the live store's
+                // interleaving.
+                const oI = inst(g)
+                const oRoot = store()
+                const oChild: any = oRoot.scope("child")
+                for (let ai = 0; ai < nAtoms; ai++) oRoot.set(oI.atoms[ai], rootVal[ai])
+                for (let ai = 0; ai < nAtoms; ai++) if (scopeSet[ai]) oChild.set(oI.atoms[ai], scopeVal[ai])
+
+                for (let si = 0; si < nSelectors; si++) {
+                    if (!subbed[si]) continue
+                    expect(child.get(I.sels[si])).toBe(oChild.get(oI.sels[si]))
+                }
+            }
+            subbed.forEach(u => u && u())
+        }
+    })
 })

--- a/packages/valdres/src/lib/scope.test.ts
+++ b/packages/valdres/src/lib/scope.test.ts
@@ -423,6 +423,143 @@ describe("subscribe / unsubscribe / resubscribe across scopes", () => {
     })
 })
 
+describe("scope set pins even when value equals the inherited value", () => {
+    // Regression: setAtom short-circuited on `areEqual` BEFORE establishing the
+    // scope shadow, so `scope.set(atom, v)` where v equalled the currently
+    // INHERITED value created no shadow — the scope kept tracking the parent and
+    // a later parent write leaked in, silently dropping the explicit override.
+    // The txn commit path (writeAtoms) already pinned equal values; the
+    // individual-set path (setAtom) did not. Both must agree.
+
+    test("set to the inherited value still shadows; a later parent write does not leak", () => {
+        const a = atom(2, { name: "pin-eq-a" }) // default 2
+        const A = store()
+        const B = A.scope("B")
+
+        // B pins a=2 — the SAME value it currently inherits from A's default.
+        B.set(a, 2)
+        expect(B.data.values.has(a)).toBe(true) // shadow established
+
+        A.set(a, 11)
+        expect(A.get(a)).toBe(11)
+        expect(B.get(a)).toBe(2) // explicit override holds — parent write doesn't leak
+    })
+
+    test("the equal-value set itself notifies no one (visible value unchanged) but re-roots", () => {
+        const a = atom(2, { name: "pin-eq-b" })
+        const A = store()
+        const B = A.scope("B")
+
+        const cb = mock(() => {})
+        B.sub(a, cb)
+        // Until B writes, B's subscription is delegated up at A.
+        expect(A.data.subscriptions.get(a)?.size).toBe(1)
+
+        B.set(a, 2) // equal to inherited — visible value unchanged
+        expect(cb).toHaveBeenCalledTimes(0) // no notification for an unchanged value
+
+        // But the subscription has re-rooted into B, so a later parent write must
+        // NOT notify B (B now shadows the atom).
+        A.set(a, 11)
+        expect(cb).toHaveBeenCalledTimes(0)
+        expect(B.get(a)).toBe(2)
+    })
+
+    test("a scope selector reading the equal-pinned atom stays fresh after a parent write", () => {
+        const a = atom(2, { name: "pin-eq-c" })
+        const sel = selector(get => get(a) * 10, { name: "pin-eq-sel" })
+        const A = store()
+        const B = A.scope("B")
+
+        const cb = mock(() => {})
+        B.sub(sel, cb)
+        expect(B.get(sel)).toBe(20)
+
+        B.set(a, 2) // equal-value pin: B selector value unchanged
+        expect(cb).toHaveBeenCalledTimes(0)
+
+        A.set(a, 11) // must not leak into B
+        expect(A.get(sel)).toBe(110)
+        expect(B.get(sel)).toBe(20)
+        expect(cb).toHaveBeenCalledTimes(0)
+    })
+
+    test("individual set and txn set agree on pinning an equal value", () => {
+        const a1 = atom(2, { name: "pin-eq-d1" })
+        const a2 = atom(2, { name: "pin-eq-d2" })
+        const A = store()
+        const B = A.scope("B")
+
+        B.set(a1, 2) // individual set path (setAtom)
+        B.txn(t => t.set(a2, 2)) // txn commit path (writeAtoms)
+
+        A.set(a1, 99)
+        A.set(a2, 99)
+
+        expect(B.get(a1)).toBe(2)
+        expect(B.get(a2)).toBe(2)
+    })
+
+    test("family member: equal-value set in a scope holds against a later root write", () => {
+        const fam = atomFamily<number, [string]>(0, { name: "pin-eq-fam" })
+        const m = fam("k")
+        const A = store()
+        A.set(m, 5)
+        const B = A.scope("B")
+        B.set(m, 5) // equal to inherited 5
+        A.set(m, 99)
+        expect(A.get(m)).toBe(99)
+        expect(B.get(m)).toBe(5)
+    })
+
+    test("deep nesting: a grandchild equal-pin follows neither a later parent nor grandparent write", () => {
+        const a = atom(7, { name: "pin-eq-deep" })
+        const A = store()
+        A.set(a, 7)
+        const B = A.scope("B")
+        const C = B.scope("C")
+        C.set(a, 7) // equal to the value inherited (through B) from A
+        A.set(a, 50)
+        expect(A.get(a)).toBe(50)
+        expect(B.get(a)).toBe(50) // B never shadowed → follows root
+        expect(C.get(a)).toBe(7) // C pinned
+    })
+
+    test("function updater returning the inherited value still pins", () => {
+        const a = atom(3, { name: "pin-eq-fn" })
+        const A = store()
+        const B = A.scope("B")
+        B.set(a, current => current) // resolves to the inherited 3
+        A.set(a, 42)
+        expect(B.get(a)).toBe(3)
+    })
+
+    test("set-equal then unset re-inherits (the shadow really was created, then removed)", () => {
+        const a = atom(4, { name: "pin-eq-unset" })
+        const A = store()
+        const B = A.scope("B")
+        B.set(a, 4) // equal-value pin → shadow established
+        expect(B.data.values.has(a)).toBe(true)
+        B.unset(a) // remove the shadow → re-inherit
+        expect(B.data.values.has(a)).toBe(false)
+        A.set(a, 88)
+        expect(B.get(a)).toBe(88) // follows root again
+    })
+
+    test("equal-value set on a root store is a true no-op (no spurious write)", () => {
+        // The fix is scoped to scopes: a root store has no parent to leak from,
+        // so an equal-value set must remain a no-op on the write hot path.
+        const a = atom(1, { name: "pin-eq-root" })
+        const A = store()
+        A.set(a, 5)
+        const cb = mock(() => {})
+        A.sub(a, cb)
+        A.set(a, 5) // same value
+        expect(cb).toHaveBeenCalledTimes(0)
+        expect(A.get(a)).toBe(5)
+    })
+})
+
 describe("maxAge interaction with scopes", () => {
     test("scope reading a maxAge atom inherits root's cached value, no separate timer", async () => {
         const A = store("A")

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -89,7 +89,23 @@ export const setAtom = <Value = any>(
     const areEqual = isPromiseLike(currentValue)
         ? currentValue === syncValue
         : atom.equal(currentValue, syncValue)
-    if (areEqual) return syncValue
+    if (areEqual) {
+        // On a scope, an atom that hasn't been shadowed yet is read through to a
+        // parent, so `currentValue` is the INHERITED value. Setting it to a value
+        // equal to the inherited one must STILL establish the shadow — otherwise
+        // the scope keeps tracking the parent and a later parent write leaks in,
+        // silently dropping this explicit override (and a delegating subscription
+        // never re-roots). setValueInData pins the value, registers the shadow in
+        // scopeValueIndex, and re-roots any delegating subscriptions. The visible
+        // value is unchanged, so there is nothing to propagate or notify. This
+        // mirrors writeAtoms' equal branch, which already does this for the txn
+        // commit path. On a root (no parent) or an already-shadowed scope atom
+        // this is a true no-op, so the write hot path is untouched.
+        if (data.parent && !data.values.has(atom)) {
+            return setValueInData(atom, syncValue, data)
+        }
+        return syncValue
+    }
     syncValue = setValueInData(atom, syncValue, data)
     if (atom.onSet && !skipOnSet) atom.onSet(syncValue, data)
     resolvePendingDefault(atom, data, syncValue)


### PR DESCRIPTION
## Summary

A subscribed selector returning a stale value after a scope write turned out to trace to a much simpler root cause than the original "txn + scope dynamic-dep staleness" framing suggested. After reproducing, delta-debugging to a **single static selector**, and tracing, the bug is:

`setAtom` short-circuits `if (areEqual) return` **before establishing a scope's own shadow**. On a scope, an atom not yet shadowed is read *through* to a parent, so `currentValue` is the **inherited** value. That means `child.set(atom, v)` where `v` equals the inherited value created **no shadow** — the scope kept tracking the parent, and a later `root.set(atom, …)` then leaked in, silently dropping the explicit override (and a delegating subscription never re-rooted).

Purest repro (no selectors, no txn, no dynamic deps):

```ts
const a = atom(2)                 // default 2
const child = root.scope("draft")
child.set(a, 2)                   // equals inherited default 2 → no shadow (bug)
root.set(a, 11)
child.get(a)                      // returned 11; must be 2 (explicit pin)
```

This violates the documented contract (`docs/.../scoped-stores.mdx`: *"once a scope shadows an atom, parent updates no longer affect the scope"*).

## Why this was mis-framed as "txn + dynamic-dep"

- The **txn/cross-scope commit path was already correct** — `writeAtoms`' equal branch explicitly calls `setValueInData` ("…still override it in that scope"). Only the individual `set()` path (`setAtom`) lacked the equivalent.
- A fuzzer that drives the system one way (txn → pins) and the oracle another (individual `set()` → leaks) diverges, which *looked* like a txn-path bug. The incremental (txn) value was actually correct; the **oracle** was the buggy one.
- The graph minimized to **one static selector** — no dynamic deps, no wide fan-in, no multi-pass commit involved.

## Fix

In `setAtom`, when `areEqual && data.parent && !data.values.has(atom)`, call `setValueInData` to establish the shadow (registering it in `scopeValueIndex` and re-rooting delegating subscriptions) while **skipping propagation**, since the visible value is unchanged. Mirrors `writeAtoms`. On a root store, or when the scope already shadows the atom, the equal-value set stays a true no-op — the write hot path is untouched.

## Tests

- **`scope.test.ts`** — deterministic block "scope set pins even when value equals the inherited value": isolation holds against later parent writes, the equal set itself notifies no one but re-roots, a scope selector stays fresh, individual `set()` and `txn` set agree, family members, deep nesting, function updaters, set-equal→unset round-trip, and a root-store no-op guard.
- **`propagateDynamicDeps.test.ts`** — an **order-independent** fuzz. The existing fuzz never caught this because its oracle replays the same ops in the same order (so it reproduced the bug identically and agreed); the new oracle derives each atom's expected scope value from a semantic model (scope's own last set if any, else root's last set).

4/5 deterministic cases + the fuzz fail against the unfixed code (git-stash verified). Full monorepo suite — core + all 5 framework adapters — passes.

## Risk

Behavior change to `scope.set`: an equal-valued scope set now materializes a shadow (one map entry). That is the intended pin semantics, and it aligns `set` with the already-shipped txn behavior. No public API change; no docs change needed (the fix makes the implementation match the existing docs).

Changeset: `valdres` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)