### PR TITLE
Fix structured family key serialization

### DIFF
--- a/.changeset/structured-family-key-serialization.md
+++ b/.changeset/structured-family-key-serialization.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Fix stable serialization for structured family keys that include Maps. Map
+family arguments no longer throw from an undefined serializer helper, and Map
+and Set arguments are serialized with stable tagged representations to avoid
+ordering instability and collisions with plain objects or arrays.

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -151,6 +151,70 @@ describe("atomFamily", () => {
         expect(docs).toStrictEqual([{ name: "Foo" }, { name: "Bar" }])
     })
 
+    test("atomFamily with structured keys uses stable Map, Set, object, and nested args", () => {
+        const store1 = store()
+        const family = atomFamily<string, [unknown]>("default")
+
+        const mapA = new Map<any, any>([
+            ["b", 2],
+            ["a", 1],
+        ])
+        const mapB = new Map<any, any>([
+            ["a", 1],
+            ["b", 2],
+        ])
+        expect(family(mapA)).toBe(family(mapB))
+        store1.set(family(mapA), "map")
+        expect(store1.get(family(mapB))).toBe("map")
+
+        const setA = new Set([3, 1, 2])
+        const setB = new Set([2, 3, 1])
+        expect(family(setA)).toBe(family(setB))
+        store1.set(family(setA), "set")
+        expect(store1.get(family(setB))).toBe("set")
+
+        expect(family({ b: 2, a: 1 })).toBe(family({ a: 1, b: 2 }))
+
+        const nestedA = {
+            meta: new Map<any, any>([
+                [{ b: 2, a: 1 }, new Set(["z", "a"])],
+                ["tags", new Set([2, 1])],
+            ]),
+        }
+        const nestedB = {
+            meta: new Map<any, any>([
+                ["tags", new Set([1, 2])],
+                [{ a: 1, b: 2 }, new Set(["a", "z"])],
+            ]),
+        }
+        expect(family(nestedA)).toBe(family(nestedB))
+    })
+
+    test("atomFamily structured keys avoid Map and Set collisions", () => {
+        const store1 = store()
+        const family = atomFamily<string, [unknown]>("default")
+        const objectKeyMap = new Map<any, any>([[{ id: 1 }, "value"]])
+        const stringKeyMap = new Map<any, any>([[`{"id":1}`, "value"]])
+        const mapAsObject = new Map<any, any>([["a", 1]])
+        const object = { a: 1 }
+        const set = new Set([1, 2])
+        const array = [1, 2]
+
+        expect(family(objectKeyMap)).not.toBe(family(stringKeyMap))
+        expect(family(mapAsObject)).not.toBe(family(object))
+        expect(family(set)).not.toBe(family(array))
+
+        store1.set(family(objectKeyMap), "object-map")
+        store1.set(family(stringKeyMap), "string-map")
+        store1.set(family(set), "set")
+        store1.set(family(array), "array")
+
+        expect(store1.get(family(objectKeyMap))).toBe("object-map")
+        expect(store1.get(family(stringKeyMap))).toBe("string-map")
+        expect(store1.get(family(set))).toBe("set")
+        expect(store1.get(family(array))).toBe("array")
+    })
+
     test("get an entire atom family", () => {
         const store1 = store()
         const userAtomFamily = atomFamily<{ name: string }, [number]>()

--- a/packages/valdres/src/lib/stableStringify.test.ts
+++ b/packages/valdres/src/lib/stableStringify.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { familyKey } from "./familyKey"
+import { stableStringify } from "./stableStringify"
+import { stringifyFamilyArgs } from "./stringifyFamilyArgs"
+
+describe("stableStringify", () => {
+    test("keeps primitive values on the family-key hot path", () => {
+        expect(stableStringify("user-1")).toBe("user-1")
+        expect(stableStringify(1)).toBe(1)
+        expect(stableStringify(true)).toBe(true)
+        expect(familyKey(["user-1"])).toBe("user-1")
+        expect(stringifyFamilyArgs(["user-1"])).toBe("user-1")
+    })
+
+    test("serializes Maps in stable key order", () => {
+        const a = new Map<any, any>([
+            ["b", 2],
+            ["a", 1],
+            [{ z: 3, y: 2 }, new Set([3, 1, 2])],
+        ])
+        const b = new Map<any, any>([
+            [{ y: 2, z: 3 }, new Set([2, 3, 1])],
+            ["a", 1],
+            ["b", 2],
+        ])
+
+        expect(stableStringify(a)).toBe(stableStringify(b))
+    })
+
+    test("serializes Sets in stable value order", () => {
+        expect(stableStringify(new Set([3, 1, 2]))).toBe(
+            stableStringify(new Set([2, 3, 1])),
+        )
+    })
+
+    test("does not collide Map, Set, Array, object, and string-shaped keys", () => {
+        const objectLikeMap = new Map<any, any>([[{ id: 1 }, "value"]])
+        const stringLikeMap = new Map<any, any>([[`{"id":1}`, "value"]])
+
+        expect(stableStringify(objectLikeMap)).not.toBe(
+            stableStringify(stringLikeMap),
+        )
+        expect(stableStringify(new Map([["a", 1]]))).not.toBe(
+            stableStringify({ a: 1 }),
+        )
+        expect(stableStringify(new Set([1, 2]))).not.toBe(
+            stableStringify([1, 2]),
+        )
+    })
+
+    test("family keys are stable for nested structured arguments", () => {
+        const a = {
+            meta: new Map<any, any>([
+                [{ b: 2, a: 1 }, new Set(["z", "a"])],
+                ["tags", new Set([2, 1])],
+            ]),
+            object: { y: 2, x: 1 },
+        }
+        const b = {
+            object: { x: 1, y: 2 },
+            meta: new Map<any, any>([
+                ["tags", new Set([1, 2])],
+                [{ a: 1, b: 2 }, new Set(["a", "z"])],
+            ]),
+        }
+
+        expect(familyKey([a])).toBe(familyKey([b]))
+        expect(stringifyFamilyArgs([a])).toBe(stringifyFamilyArgs([b]))
+    })
+})

--- a/packages/valdres/src/lib/stableStringify.ts
+++ b/packages/valdres/src/lib/stableStringify.ts
@@ -1,5 +1,7 @@
 import { isPromiseLike } from "../utils/isPromiseLike"
 
+const compareStrings = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+
 const stableStringifyRecurse = (x: any, key?: string): string => {
     // A optimization to avoid the more expensive JSON.stringify() for simple strings
     // This may lose protection for u2028 and u2029, though.
@@ -60,8 +62,8 @@ const stableStringifyRecurse = (x: any, key?: string): string => {
             stableStringifyRecurse(k),
             stableStringifyRecurse(v),
         ]).sort(([ak, av], [bk, bv]) => {
-            const keyOrder = ak.localeCompare(bk)
-            return keyOrder || av.localeCompare(bv)
+            const keyOrder = compareStrings(ak, bk)
+            return keyOrder || compareStrings(av, bv)
         })
         return `__MAP(${stableStringifyRecurse(entries, key)})__`
     }

--- a/packages/valdres/src/lib/stableStringify.ts
+++ b/packages/valdres/src/lib/stableStringify.ts
@@ -53,29 +53,25 @@ const stableStringifyRecurse = (x: any, key?: string): string => {
     }
 
     // For built-in Maps, sort the keys in a stable order instead of the
-    // default insertion order.  Support non-string keys.
+    // default insertion order.  Support non-string keys and keep Maps distinct
+    // from plain objects with the same apparent entries.
     if (x instanceof Map) {
-        const obj = {}
-        for (const [k, v] of x) {
-            // Stringify will escape any nested quotes
-            // @ts-ignore
-            obj[typeof k === "string" ? k : stringify(k, opt)] = v
-        }
-        return stableStringifyRecurse(obj, key)
+        const entries = Array.from(x, ([k, v]) => [
+            stableStringifyRecurse(k),
+            stableStringifyRecurse(v),
+        ]).sort(([ak, av], [bk, bv]) => {
+            const keyOrder = ak.localeCompare(bk)
+            return keyOrder || av.localeCompare(bv)
+        })
+        return `__MAP(${stableStringifyRecurse(entries, key)})__`
     }
 
     // For built-in Sets, sort the keys in a stable order instead of the
-    // default insertion order.
+    // default insertion order.  Keep Sets distinct from Arrays with the same
+    // apparent values.
     if (x instanceof Set) {
-        return stableStringifyRecurse(
-            // $FlowFixMe[missing-local-annot]
-            Array.from(x).sort((a, b) =>
-                stableStringifyRecurse(a).localeCompare(
-                    stableStringifyRecurse(b),
-                ),
-            ),
-            key,
-        )
+        const values = Array.from(x, v => stableStringifyRecurse(v)).sort()
+        return `__SET(${stableStringifyRecurse(values, key)})__`
     }
 
     // Anything else that is iterable serialize as an Array.

--- a/packages/valdres/src/selectorFamily.test.ts
+++ b/packages/valdres/src/selectorFamily.test.ts
@@ -78,6 +78,73 @@ describe("selectorFamily", () => {
         expect(store1.get(testFamily(selector1))).toEqual("Foo")
         expect(testFamily(selector1)).toStrictEqual(testFamily(selector1))
     })
+
+    test("structured keys use stable Map, Set, object, and nested args", () => {
+        const store1 = store()
+        const family = selectorFamily<string, [unknown]>(() => () => "value")
+
+        const mapA = new Map<any, any>([
+            ["b", 2],
+            ["a", 1],
+        ])
+        const mapB = new Map<any, any>([
+            ["a", 1],
+            ["b", 2],
+        ])
+        expect(family(mapA)).toBe(family(mapB))
+
+        const setA = new Set([3, 1, 2])
+        const setB = new Set([2, 3, 1])
+        expect(family(setA)).toBe(family(setB))
+
+        expect(family({ b: 2, a: 1 })).toBe(family({ a: 1, b: 2 }))
+
+        const nestedA = {
+            meta: new Map<any, any>([
+                [{ b: 2, a: 1 }, new Set(["z", "a"])],
+                ["tags", new Set([2, 1])],
+            ]),
+        }
+        const nestedB = {
+            meta: new Map<any, any>([
+                ["tags", new Set([1, 2])],
+                [{ a: 1, b: 2 }, new Set(["a", "z"])],
+            ]),
+        }
+        expect(family(nestedA)).toBe(family(nestedB))
+        expect(store1.get(family(nestedB))).toBe("value")
+    })
+
+    test("structured keys avoid Map and Set collisions", () => {
+        const store1 = store()
+        const objectKeyMap = new Map<any, any>([[{ id: 1 }, "value"]])
+        const stringKeyMap = new Map<any, any>([[`{"id":1}`, "value"]])
+        const mapAsObject = new Map<any, any>([["a", 1]])
+        const object = { a: 1 }
+        const set = new Set([1, 2])
+        const array = [1, 2]
+        const family = selectorFamily<string, [unknown]>(key => () => {
+            if (key === objectKeyMap) return "object-map"
+            if (key === stringKeyMap) return "string-map"
+            if (key === mapAsObject) return "map"
+            if (key === object) return "object"
+            if (key === set) return "set"
+            if (key === array) return "array"
+            return "unknown"
+        })
+
+        expect(family(objectKeyMap)).not.toBe(family(stringKeyMap))
+        expect(family(mapAsObject)).not.toBe(family(object))
+        expect(family(set)).not.toBe(family(array))
+
+        expect(store1.get(family(objectKeyMap))).toBe("object-map")
+        expect(store1.get(family(stringKeyMap))).toBe("string-map")
+        expect(store1.get(family(mapAsObject))).toBe("map")
+        expect(store1.get(family(object))).toBe("object")
+        expect(store1.get(family(set))).toBe("set")
+        expect(store1.get(family(array))).toBe("array")
+    })
+
     test("factory runs once per cache entry, not per read", () => {
         // The wrapper used to be `(get) => callback(...args)(get)`, which
         // re-invoked the user's factory on every selector evaluation and


### PR DESCRIPTION
## Summary
- fix Map serialization in stableStringify by removing the undefined helper call
- serialize Map and Set keys with stable tagged representations to avoid ordering issues and Map/Object or Set/Array collisions
- add focused stableStringify, atomFamily, and selectorFamily coverage for Map, Set, object, and nested structured keys

## Verification
- bun --filter valdres test
- bun --filter valdres build
- bun --filter valdres build:types
- bun --filter valdres typecheck:types
- BENCH_VALDRES_ONLY=1 bun --filter valdres test:bench

Benchmark note: no before/after baseline was available in this workspace. Current run passed; relevant readings included atomFamily cache hit at 4ns and 100x cached structured args at 18.8µs.