### PR TITLE
feat: @valdres/browser-mouse — reactive mouse position, buttons, inside-page state

### DIFF
--- a/.changeset/browser-mouse-package.md
+++ b/.changeset/browser-mouse-package.md
@@ -1,0 +1,11 @@
+---
+"@valdres/browser-mouse": minor
+---
+
+New package: `@valdres/browser-mouse` — reactive mouse cursor position and
+button state as global atoms. Exposes `mousePositionAtom` (`clientX/Y`,
+`pageX/Y`, `screenX/Y`), `mouseButtonsAtom` (raw `buttons` bitmask plus
+`left`/`right`/`middle` booleans), and `mouseInsideAtom` (cursor within the
+document). Each atom attaches its own `MouseEvent` listeners on the first
+subscriber and detaches on the last, following the `@valdres/browser-*` pattern.
+For touch, pen, or multiple simultaneous contacts, use `@valdres/browser-pointer`.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The package tables below are auto-generated — do not hand-edit.
 | [`@valdres/browser-focus`](https://valdres.dev/react/plugins/browser-focus) | Reactive document focus state from the window focus/blur events |
 | [`@valdres/browser-geolocation`](https://valdres.dev/react/plugins/browser-geolocation) | Reactive geolocation — position, accuracy, permission, and status |
 | [`@valdres/browser-keyboard`](https://valdres.dev/react/plugins/browser-keyboard) | Reactive pressed-key state from keydown / keyup |
+| [`@valdres/browser-mouse`](https://valdres.dev/react/plugins/browser-mouse) | Reactive mouse cursor position and button state, tracked through mouse events |
 | [`@valdres/browser-online`](https://valdres.dev/react/plugins/browser-online) | Reactive online/offline status from navigator.onLine |
 | [`@valdres/browser-presence`](https://valdres.dev/react/plugins/browser-presence) | Whether the user is present — tab visible and window focused |
 | [`@valdres/browser-reduced-data`](https://valdres.dev/react/plugins/browser-reduced-data) | Reactive prefers-reduced-data media query |

--- a/bun.lock
+++ b/bun.lock
@@ -274,6 +274,19 @@
         "valdres": "^1.0.0-beta.7",
       },
     },
+    "packages/@valdres/browser-mouse": {
+      "name": "@valdres/browser-mouse",
+      "version": "1.0.0-beta.0",
+      "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "workspace:^",
+      },
+      "peerDependencies": {
+        "valdres": "^1.0.0-beta.7",
+      },
+    },
     "packages/@valdres/browser-online": {
       "name": "@valdres/browser-online",
       "version": "1.0.0-beta.4",
@@ -1111,6 +1124,8 @@
     "@valdres/browser-geolocation": ["@valdres/browser-geolocation@workspace:packages/@valdres/browser-geolocation"],
 
     "@valdres/browser-keyboard": ["@valdres/browser-keyboard@workspace:packages/@valdres/browser-keyboard"],
+
+    "@valdres/browser-mouse": ["@valdres/browser-mouse@workspace:packages/@valdres/browser-mouse"],
 
     "@valdres/browser-online": ["@valdres/browser-online@workspace:packages/@valdres/browser-online"],
 
@@ -2317,6 +2332,10 @@
     "@valdres/browser-geolocation/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 
     "@valdres/browser-geolocation/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
+
+    "@valdres/browser-mouse/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
+
+    "@valdres/browser-mouse/happy-dom": ["happy-dom@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "@types/whatwg-mimetype": "^3.0.2", "whatwg-mimetype": "^3.0.0" } }, "sha512-AiqA0rfS7WR1kihXt9W9aA5LFLaOKzwiL+QoI7BkOQ0r21C7VHTOf4k8QNlnWYaHLhpI2tZzJPLV1lY1obDTmw=="],
 
     "@valdres/browser-online/@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.5", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.5" } }, "sha512-RWQ85on4fiYKw5D1xk0nU2YGCYsJEJ5iXmZHTRyeYft4OCN4IRMFZ3uX91/Tncf/9K4tPOnU1HiEOtLs2Zxukw=="],
 

--- a/docs/src/islands/plugins/registry.ts
+++ b/docs/src/islands/plugins/registry.ts
@@ -49,6 +49,11 @@ import {
     requestOrientationPermission,
 } from "@valdres/browser-device-orientation"
 import { focusAtom } from "@valdres/browser-focus"
+import {
+    mousePositionAtom,
+    mouseButtonsAtom,
+    mouseInsideAtom,
+} from "@valdres/browser-mouse"
 import { presenceSelector } from "@valdres/browser-presence"
 import {
     reducedDataAtom,
@@ -214,6 +219,31 @@ export const pluginDemos: Record<string, (el: HTMLElement) => void> = {
     "browser-focus": inspector({
         hint: "Click outside the page or switch tabs/windows and back",
         rows: [{ label: "focusAtom", state: focusAtom }],
+    }),
+
+    "browser-mouse": inspector({
+        hint: "Move the mouse and press buttons over this page",
+        rows: [
+            {
+                label: "mousePositionAtom",
+                state: mousePositionAtom,
+                format: (p: { clientX: number; clientY: number }) =>
+                    `${p.clientX} × ${p.clientY}`,
+            },
+            {
+                label: "mouseButtonsAtom",
+                state: mouseButtonsAtom,
+                format: (b: {
+                    left: boolean
+                    right: boolean
+                    middle: boolean
+                }) =>
+                    [b.left && "left", b.right && "right", b.middle && "middle"]
+                        .filter(Boolean)
+                        .join(", ") || "none",
+            },
+            { label: "mouseInsideAtom", state: mouseInsideAtom },
+        ],
     }),
 
     "browser-presence": inspector({

--- a/packages/@valdres/browser-mouse/README.md
+++ b/packages/@valdres/browser-mouse/README.md
@@ -1,0 +1,51 @@
+<!-- DOCS:START -->
+
+# browser-mouse
+
+Wraps the [`MouseEvent`](https://developer.mozilla.org/docs/Web/API/MouseEvent) stream as global atoms: cursor `position`, pressed `buttons`, and whether the cursor is `inside` the page.
+
+For touch and pen, or for tracking multiple simultaneous contacts, reach for `@valdres/browser-pointer` instead — a mouse is a single cursor, so this package keeps it to simple singleton atoms.
+
+## Install
+
+```bash
+bun add @valdres/browser-mouse
+```
+
+## Live example
+
+▶ Live example: [https://valdres.dev/react/plugins/browser-mouse](https://valdres.dev/react/plugins/browser-mouse)
+
+## Usage
+
+```tsx
+import { useValue } from "valdres-react"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+function Cursor() {
+    const { clientX, clientY } = useValue(mousePositionAtom)
+    return <span>{clientX}, {clientY}</span>
+}
+```
+
+## Exports
+
+| Export              | Kind             | Type            |
+| ------------------- | ---------------- | --------------- |
+| `mousePositionAtom` | atom (read-only) | `MousePosition` |
+| `mouseButtonsAtom`  | atom (read-only) | `MouseButtons`  |
+| `mouseInsideAtom`   | atom (read-only) | `boolean`       |
+
+`MousePosition` carries `clientX/Y`, `pageX/Y`, and `screenX/Y`. `MouseButtons` carries the raw `buttons` bitmask plus `left` / `right` / `middle` booleans.
+
+## Cross-framework
+
+Global atoms — they work in every framework; only the read primitive's name changes (`useValue`, `createValue`, `injectValue`, `watch`, or `store.get` in plain JS). Each atom attaches its own listeners on the first subscriber and detaches them when the last leaves, so subscribing only to `mouseButtonsAtom` won't wire up `mousemove`.
+
+Three things to know. There is no API to read the cursor position without an event, so `mousePositionAtom` stays zeroed until the first `mousemove`. `mouseButtonsAtom` resyncs from the live `buttons` bitmask on each mouse event — so a right-click shows as pressed while the context menu is open (which swallows the `mouseup`) and clears on the first move after the menu is dismissed; a focus loss (alt-tab, devtools, releasing outside the page) clears it immediately. And `mouseInsideAtom` tracks _geometric_ containment via `mouseenter` / `mouseleave` — it stays `true` when you alt-tab away with the cursor still over the page, because the cursor really is still there. Compose with [`@valdres/browser-focus`](https://valdres.dev/react/plugins/browser-focus) if you want a focus-gated "user is actively here" signal.
+
+---
+
+Full documentation: https://valdres.dev/react/plugins/browser-mouse
+
+<!-- DOCS:END -->

--- a/packages/@valdres/browser-mouse/bunfig.toml
+++ b/packages/@valdres/browser-mouse/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = "./test/setup/happyDom.ts"

--- a/packages/@valdres/browser-mouse/dev/index.html
+++ b/packages/@valdres/browser-mouse/dev/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>@valdres/browser-mouse demo</title>
+        <style>
+            :root {
+                color-scheme: light dark;
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    sans-serif;
+            }
+            body {
+                max-width: 720px;
+                margin: 2rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                margin-bottom: 0;
+            }
+            .muted {
+                color: #888;
+                font-size: 0.9rem;
+            }
+            .card {
+                margin-top: 1.5rem;
+                border: 1px solid #8884;
+                border-radius: 8px;
+                padding: 1rem 1.25rem;
+            }
+            dl {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 0.4rem 1.25rem;
+                margin: 0;
+                font-size: 0.95rem;
+            }
+            dt {
+                color: #888;
+            }
+            dd {
+                margin: 0;
+                font-family:
+                    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>@valdres/browser-mouse</h1>
+        <p class="muted">
+            Reactive wrapper for mouse <code>position</code>,
+            <code>buttons</code>, and whether the cursor is inside the page. Move
+            the mouse and press buttons to see updates.
+        </p>
+
+        <div class="card">
+            <dl id="state"></dl>
+        </div>
+
+        <script>
+            // valdres reads process.env.VALDRES_VERSION at import time
+            window.process = window.process || { env: {} }
+        </script>
+        <script type="module" src="./index.ts"></script>
+    </body>
+</html>

--- a/packages/@valdres/browser-mouse/dev/index.ts
+++ b/packages/@valdres/browser-mouse/dev/index.ts
@@ -1,0 +1,34 @@
+import { store } from "valdres"
+import {
+    mouseButtonsAtom,
+    mouseInsideAtom,
+    mousePositionAtom,
+} from "../src"
+
+const s = store()
+const el = document.getElementById("state")!
+
+const field = (label: string, value: string | number) =>
+    `<dt>${label}</dt><dd>${value}</dd>`
+
+const render = () => {
+    const pos = s.get(mousePositionAtom)
+    const btn = s.get(mouseButtonsAtom)
+    const inside = s.get(mouseInsideAtom)
+    const pressed =
+        [btn.left && "left", btn.right && "right", btn.middle && "middle"]
+            .filter(Boolean)
+            .join(", ") || "none"
+    el.innerHTML = [
+        field("client", `${pos.clientX} × ${pos.clientY}`),
+        field("page", `${pos.pageX} × ${pos.pageY}`),
+        field("screen", `${pos.screenX} × ${pos.screenY}`),
+        field("buttons", pressed),
+        field("inside page", String(inside)),
+    ].join("")
+}
+
+s.sub(mousePositionAtom, render)
+s.sub(mouseButtonsAtom, render)
+s.sub(mouseInsideAtom, render)
+render()

--- a/packages/@valdres/browser-mouse/dev/server.ts
+++ b/packages/@valdres/browser-mouse/dev/server.ts
@@ -1,0 +1,11 @@
+import index from "./index.html"
+
+const server = Bun.serve({
+    port: Number(process.env.PORT ?? 3028),
+    development: true,
+    routes: {
+        "/": index,
+    },
+})
+
+console.log(`@valdres/browser-mouse demo: ${server.url}`)

--- a/packages/@valdres/browser-mouse/package.json
+++ b/packages/@valdres/browser-mouse/package.json
@@ -1,0 +1,41 @@
+{
+    "name": "@valdres/browser-mouse",
+    "description": "Reactive mouse cursor position and button state, tracked through mouse events",
+    "version": "1.0.0-beta.0",
+    "license": "MIT",
+    "author": {
+        "name": "Eigil Sagafos"
+    },
+    "homepage": "https://valdres.dev",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/eigilsagafos/valdres.git"
+    },
+    "type": "module",
+    "exports": {
+        ".": "./src/index.ts"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "NODE_ENV=production bun build src/index.ts --outdir ./dist --packages external",
+        "build:types": "rm -rf dist/types && bunx tsgo",
+        "dev": "bun run dev/server.ts",
+        "test": "bun test",
+        "test:ci": "bun test"
+    },
+    "devDependencies": {
+        "@happy-dom/global-registrator": "20.0.5",
+        "happy-dom": "20.0.5",
+        "typescript": "5.9.2",
+        "valdres": "workspace:^"
+    },
+    "peerDependencies": {
+        "valdres": "^1.0.0-beta.7"
+    },
+    "publishConfig": {
+        "access": "public",
+        "registry": "https://registry.npmjs.org/"
+    }
+}

--- a/packages/@valdres/browser-mouse/src/atoms/mouseButtonsAtom.test.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mouseButtonsAtom.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { mouseButtonsAtom } from "./mouseButtonsAtom"
+
+describe("mouseButtonsAtom", () => {
+    beforeEach(() => {
+        mouseButtonsAtom.resetSelf()
+    })
+
+    test("initial value has nothing pressed", () => {
+        const s = store()
+        expect(s.get(mouseButtonsAtom)).toEqual({
+            buttons: 0,
+            left: false,
+            right: false,
+            middle: false,
+        })
+    })
+
+    test("tracks press and release", () => {
+        const s = store()
+        const unsub = s.sub(mouseButtonsAtom, () => {})
+
+        window.dispatchEvent(new MouseEvent("mousedown", { buttons: 1 }))
+        expect(s.get(mouseButtonsAtom).left).toBe(true)
+
+        window.dispatchEvent(new MouseEvent("mouseup", { buttons: 0 }))
+        expect(s.get(mouseButtonsAtom).left).toBe(false)
+        unsub()
+    })
+
+    test("shows the right button while held, then clears on the next move", () => {
+        const s = store()
+        const unsub = s.sub(mouseButtonsAtom, () => {})
+
+        // Right-click shows the press; the native context menu then swallows the
+        // mouseup, so the next mousemove (buttons === 0) is what resyncs it.
+        window.dispatchEvent(new MouseEvent("mousedown", { buttons: 2 }))
+        expect(s.get(mouseButtonsAtom).right).toBe(true)
+
+        window.dispatchEvent(new MouseEvent("mousemove", { buttons: 0 }))
+        expect(s.get(mouseButtonsAtom).right).toBe(false)
+        unsub()
+    })
+
+    test("mousemove with an unchanged bitmask does not write a new state", () => {
+        const s = store()
+        const unsub = s.sub(mouseButtonsAtom, () => {})
+
+        const before = s.get(mouseButtonsAtom)
+        window.dispatchEvent(new MouseEvent("mousemove", { buttons: 0 }))
+        // Same reference => the guard skipped setSelf, so no churn per pixel.
+        expect(s.get(mouseButtonsAtom)).toBe(before)
+        unsub()
+    })
+
+    test("clears stuck buttons when the window loses focus", () => {
+        const s = store()
+        const unsub = s.sub(mouseButtonsAtom, () => {})
+
+        window.dispatchEvent(new MouseEvent("mousedown", { buttons: 1 }))
+        expect(s.get(mouseButtonsAtom).left).toBe(true)
+
+        window.dispatchEvent(new Event("blur"))
+        expect(s.get(mouseButtonsAtom).left).toBe(false)
+        unsub()
+    })
+
+    test("stops tracking after the last subscriber leaves", () => {
+        const s = store()
+        const unsub = s.sub(mouseButtonsAtom, () => {})
+        unsub()
+
+        window.dispatchEvent(new MouseEvent("mousedown", { buttons: 1 }))
+        expect(s.get(mouseButtonsAtom).left).toBe(false)
+    })
+})

--- a/packages/@valdres/browser-mouse/src/atoms/mouseButtonsAtom.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mouseButtonsAtom.ts
@@ -1,0 +1,16 @@
+import { atom } from "valdres"
+import type { MouseButtons } from "../types/MouseButtons"
+import { subscribeButtons } from "../lib/subscribeButtons"
+
+const INITIAL: MouseButtons = Object.freeze({
+    buttons: 0,
+    left: false,
+    right: false,
+    middle: false,
+})
+
+export const mouseButtonsAtom = atom<MouseButtons>(INITIAL, {
+    global: true,
+    name: "@valdres/browser-mouse/buttons",
+    onMount: () => subscribeButtons(),
+})

--- a/packages/@valdres/browser-mouse/src/atoms/mouseInsideAtom.test.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mouseInsideAtom.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { mouseInsideAtom } from "./mouseInsideAtom"
+
+describe("mouseInsideAtom", () => {
+    beforeEach(() => {
+        mouseInsideAtom.resetSelf()
+    })
+
+    test("starts false", () => {
+        const s = store()
+        expect(s.get(mouseInsideAtom)).toBe(false)
+    })
+
+    test("flips on enter and leave", () => {
+        const s = store()
+        const unsub = s.sub(mouseInsideAtom, () => {})
+
+        document.dispatchEvent(new MouseEvent("mouseenter"))
+        expect(s.get(mouseInsideAtom)).toBe(true)
+
+        document.dispatchEvent(new MouseEvent("mouseleave"))
+        expect(s.get(mouseInsideAtom)).toBe(false)
+        unsub()
+    })
+
+    test("stops tracking after the last subscriber leaves", () => {
+        const s = store()
+        const unsub = s.sub(mouseInsideAtom, () => {})
+        unsub()
+
+        document.dispatchEvent(new MouseEvent("mouseenter"))
+        expect(s.get(mouseInsideAtom)).toBe(false)
+    })
+})

--- a/packages/@valdres/browser-mouse/src/atoms/mouseInsideAtom.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mouseInsideAtom.ts
@@ -1,0 +1,16 @@
+import { atom } from "valdres"
+import { subscribeInside } from "../lib/subscribeInside"
+
+// Whether the cursor is geometrically within the document, tracked purely via
+// mouseenter/mouseleave. This is independent of focus on purpose: alt-tabbing
+// away with the cursor still over the page keeps this `true`, because the cursor
+// really is still there. Compose with `@valdres/browser-focus` if you want a
+// focus-gated "user is actively here" signal instead.
+//
+// There is no way to know the state before the first enter/leave event, so it
+// starts `false` (also the SSR value).
+export const mouseInsideAtom = atom<boolean>(false, {
+    global: true,
+    name: "@valdres/browser-mouse/inside",
+    onMount: () => subscribeInside(),
+})

--- a/packages/@valdres/browser-mouse/src/atoms/mousePositionAtom.test.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mousePositionAtom.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, test } from "bun:test"
+import { store } from "valdres"
+import { mousePositionAtom } from "./mousePositionAtom"
+
+describe("mousePositionAtom", () => {
+    beforeEach(() => {
+        // The atom is global; reset so state from another test file doesn't bleed in.
+        mousePositionAtom.resetSelf()
+    })
+
+    test("initial value is zeroed", () => {
+        const s = store()
+        expect(s.get(mousePositionAtom)).toEqual({
+            clientX: 0,
+            clientY: 0,
+            pageX: 0,
+            pageY: 0,
+            screenX: 0,
+            screenY: 0,
+        })
+    })
+
+    test("updates when mousemove fires", () => {
+        const s = store()
+        const unsub = s.sub(mousePositionAtom, () => {})
+
+        window.dispatchEvent(
+            new MouseEvent("mousemove", {
+                clientX: 12,
+                clientY: 34,
+                screenX: 112,
+                screenY: 134,
+            }),
+        )
+
+        const pos = s.get(mousePositionAtom)
+        expect(pos.clientX).toBe(12)
+        expect(pos.clientY).toBe(34)
+        expect(pos.screenX).toBe(112)
+        expect(pos.screenY).toBe(134)
+        // pageX/pageY are intentionally not asserted: happy-dom's MouseEvent
+        // implements neither, so they always read 0 here regardless of the
+        // event init. They are exercised by the real browser, not this suite —
+        // don't add an assertion that would only ever verify 0 === 0.
+        unsub()
+    })
+
+    test("stops updating after the last subscriber leaves", () => {
+        const s = store()
+        const unsub = s.sub(mousePositionAtom, () => {})
+        window.dispatchEvent(new MouseEvent("mousemove", { clientX: 5 }))
+        expect(s.get(mousePositionAtom).clientX).toBe(5)
+
+        unsub()
+        window.dispatchEvent(new MouseEvent("mousemove", { clientX: 99 }))
+        expect(s.get(mousePositionAtom).clientX).toBe(5)
+    })
+})

--- a/packages/@valdres/browser-mouse/src/atoms/mousePositionAtom.ts
+++ b/packages/@valdres/browser-mouse/src/atoms/mousePositionAtom.ts
@@ -1,0 +1,20 @@
+import { atom } from "valdres"
+import type { MousePosition } from "../types/MousePosition"
+import { subscribePosition } from "../lib/subscribePosition"
+
+// MouseEvent exposes no way to read the cursor position up front, so the atom
+// starts zeroed and fills in on the first `mousemove`.
+const INITIAL: MousePosition = Object.freeze({
+    clientX: 0,
+    clientY: 0,
+    pageX: 0,
+    pageY: 0,
+    screenX: 0,
+    screenY: 0,
+})
+
+export const mousePositionAtom = atom<MousePosition>(INITIAL, {
+    global: true,
+    name: "@valdres/browser-mouse/position",
+    onMount: () => subscribePosition(),
+})

--- a/packages/@valdres/browser-mouse/src/browser-mouse.mdx
+++ b/packages/@valdres/browser-mouse/src/browser-mouse.mdx
@@ -1,0 +1,114 @@
+---
+title: browser-mouse
+description: Reactive mouse cursor position and button state from mouse events
+---
+
+# browser-mouse
+
+Wraps the [`MouseEvent`](https://developer.mozilla.org/docs/Web/API/MouseEvent) stream as global atoms: cursor `position`, pressed `buttons`, and whether the cursor is `inside` the page.
+
+For touch and pen, or for tracking multiple simultaneous contacts, reach for `@valdres/browser-pointer` instead — a mouse is a single cursor, so this package keeps it to simple singleton atoms.
+
+## Install
+
+```bash
+bun add @valdres/browser-mouse
+```
+
+## Live example
+
+<PluginDemo plugin="browser-mouse" />
+
+## Usage
+
+<FrameworkBlock fw="react">
+
+```tsx
+import { useValue } from "valdres-react"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+function Cursor() {
+    const { clientX, clientY } = useValue(mousePositionAtom)
+    return <span>{clientX}, {clientY}</span>
+}
+```
+
+</FrameworkBlock>
+
+<FrameworkBlock fw="vue">
+
+```vue
+<script setup>
+import { useValue } from "valdres-vue"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+const pos = useValue(mousePositionAtom) // Ref<MousePosition>
+</script>
+
+<template>{{ pos.clientX }}, {{ pos.clientY }}</template>
+```
+
+</FrameworkBlock>
+
+<FrameworkBlock fw="svelte">
+
+```svelte
+<script>
+import { watch } from "valdres-svelte"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+const pos = watch(mousePositionAtom)
+</script>
+
+{pos.value.clientX}, {pos.value.clientY}
+```
+
+</FrameworkBlock>
+
+<FrameworkBlock fw="solid">
+
+```tsx
+import { createValue } from "valdres-solid"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+function Cursor() {
+    const pos = createValue(mousePositionAtom) // () => MousePosition
+    return <span>{pos().clientX}, {pos().clientY}</span>
+}
+```
+
+</FrameworkBlock>
+
+<FrameworkBlock fw="angular">
+
+```ts
+import { Component } from "@angular/core"
+import { injectValue } from "valdres-angular"
+import { mousePositionAtom } from "@valdres/browser-mouse"
+
+@Component({
+    selector: "cursor-readout",
+    template: `{{ pos.value().clientX }}, {{ pos.value().clientY }}`,
+})
+export class CursorReadout {
+    pos = injectValue(mousePositionAtom) // ValueState<MousePosition>
+}
+```
+
+</FrameworkBlock>
+
+## Exports
+
+| Export | Kind | Type |
+|--------|------|------|
+| `mousePositionAtom` | atom (read-only) | `MousePosition` |
+| `mouseButtonsAtom` | atom (read-only) | `MouseButtons` |
+| `mouseInsideAtom` | atom (read-only) | `boolean` |
+
+`MousePosition` carries `clientX/Y`, `pageX/Y`, and `screenX/Y`. `MouseButtons` carries the raw `buttons` bitmask plus `left` / `right` / `middle` booleans.
+
+## Cross-framework
+
+Global atoms — they work in every framework; only the read primitive's name changes (`useValue`, `createValue`, `injectValue`, `watch`, or `store.get` in plain JS). Each atom attaches its own listeners on the first subscriber and detaches them when the last leaves, so subscribing only to `mouseButtonsAtom` won't wire up `mousemove`.
+
+Three things to know. There is no API to read the cursor position without an event, so `mousePositionAtom` stays zeroed until the first `mousemove`. `mouseButtonsAtom` resyncs from the live `buttons` bitmask on each mouse event — so a right-click shows as pressed while the context menu is open (which swallows the `mouseup`) and clears on the first move after the menu is dismissed; a focus loss (alt-tab, devtools, releasing outside the page) clears it immediately. And `mouseInsideAtom` tracks *geometric* containment via `mouseenter` / `mouseleave` — it stays `true` when you alt-tab away with the cursor still over the page, because the cursor really is still there. Compose with [`@valdres/browser-focus`](/react/plugins/browser-focus) if you want a focus-gated "user is actively here" signal.

--- a/packages/@valdres/browser-mouse/src/index.ts
+++ b/packages/@valdres/browser-mouse/src/index.ts
@@ -1,0 +1,6 @@
+export { mousePositionAtom } from "./atoms/mousePositionAtom"
+export { mouseButtonsAtom } from "./atoms/mouseButtonsAtom"
+export { mouseInsideAtom } from "./atoms/mouseInsideAtom"
+
+export type { MousePosition } from "./types/MousePosition"
+export type { MouseButtons } from "./types/MouseButtons"

--- a/packages/@valdres/browser-mouse/src/lib/readButtons.test.ts
+++ b/packages/@valdres/browser-mouse/src/lib/readButtons.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { readButtons } from "./readButtons"
+
+describe("readButtons", () => {
+    test("no buttons pressed", () => {
+        expect(readButtons(0)).toEqual({
+            buttons: 0,
+            left: false,
+            right: false,
+            middle: false,
+        })
+    })
+
+    test("left button (bit 1)", () => {
+        const b = readButtons(1)
+        expect(b.left).toBe(true)
+        expect(b.right).toBe(false)
+        expect(b.middle).toBe(false)
+    })
+
+    test("right button (bit 2)", () => {
+        const b = readButtons(2)
+        expect(b.left).toBe(false)
+        expect(b.right).toBe(true)
+    })
+
+    test("middle button (bit 4)", () => {
+        expect(readButtons(4).middle).toBe(true)
+    })
+
+    test("left + right pressed together", () => {
+        const b = readButtons(1 | 2)
+        expect(b.left).toBe(true)
+        expect(b.right).toBe(true)
+        expect(b.middle).toBe(false)
+    })
+})

--- a/packages/@valdres/browser-mouse/src/lib/readButtons.ts
+++ b/packages/@valdres/browser-mouse/src/lib/readButtons.ts
@@ -1,0 +1,11 @@
+import type { MouseButtons } from "../types/MouseButtons"
+
+// MouseEvent.buttons is a bitmask: 1 = primary (left), 2 = secondary (right),
+// 4 = auxiliary (middle). See
+// https://developer.mozilla.org/docs/Web/API/MouseEvent/buttons
+export const readButtons = (buttons: number): MouseButtons => ({
+    buttons,
+    left: (buttons & 1) !== 0,
+    right: (buttons & 2) !== 0,
+    middle: (buttons & 4) !== 0,
+})

--- a/packages/@valdres/browser-mouse/src/lib/subscribeButtons.ts
+++ b/packages/@valdres/browser-mouse/src/lib/subscribeButtons.ts
@@ -1,0 +1,37 @@
+import { mouseButtonsAtom } from "../atoms/mouseButtonsAtom"
+import { readButtons } from "./readButtons"
+
+// The bitmask guard is a perf optimization, not a correctness requirement: the
+// core already deep-equals writes and no-ops unchanged ones, so notifications
+// never churn. What the guard avoids is the wasted work of allocating a fresh
+// object (via `readButtons`) and running that deep compare on every `mousemove`
+// pixel — a plain number comparison short-circuits all of it.
+const sync = (event: MouseEvent) => {
+    if (event.buttons !== mouseButtonsAtom.getSelf().buttons)
+        mouseButtonsAtom.setSelf(readButtons(event.buttons))
+}
+
+// Clears everything when the window loses focus (alt-tab, devtools, releasing
+// the mouse outside the page) — situations where no further mouse event will
+// arrive to resync the state. Left unguarded on purpose: blur is rare, and the
+// core deep-equals the write, so resetting when already idle is a silent no-op.
+const reset = () => mouseButtonsAtom.setSelf(readButtons(0))
+
+// `mousedown` / `mouseup` give immediate press/release transitions. `mousemove`
+// resyncs after an event we never saw — most importantly the right-click
+// `mouseup` swallowed by the native context menu, which would otherwise leave
+// the button stuck. The press still shows while the menu is open; it clears on
+// the first move once the menu is dismissed.
+export const subscribeButtons = () => {
+    if (typeof window === "undefined") return
+    window.addEventListener("mousedown", sync)
+    window.addEventListener("mouseup", sync)
+    window.addEventListener("mousemove", sync)
+    window.addEventListener("blur", reset)
+    return () => {
+        window.removeEventListener("mousedown", sync)
+        window.removeEventListener("mouseup", sync)
+        window.removeEventListener("mousemove", sync)
+        window.removeEventListener("blur", reset)
+    }
+}

--- a/packages/@valdres/browser-mouse/src/lib/subscribeInside.ts
+++ b/packages/@valdres/browser-mouse/src/lib/subscribeInside.ts
@@ -1,0 +1,16 @@
+import { mouseInsideAtom } from "../atoms/mouseInsideAtom"
+
+const onEnter = () => mouseInsideAtom.setSelf(true)
+const onLeave = () => mouseInsideAtom.setSelf(false)
+
+// `mouseenter` / `mouseleave` on the document fire once as the cursor crosses
+// the page boundary (they don't bubble per descendant the way over/out do).
+export const subscribeInside = () => {
+    if (typeof document === "undefined") return
+    document.addEventListener("mouseenter", onEnter)
+    document.addEventListener("mouseleave", onLeave)
+    return () => {
+        document.removeEventListener("mouseenter", onEnter)
+        document.removeEventListener("mouseleave", onLeave)
+    }
+}

--- a/packages/@valdres/browser-mouse/src/lib/subscribePosition.ts
+++ b/packages/@valdres/browser-mouse/src/lib/subscribePosition.ts
@@ -1,0 +1,21 @@
+import { mousePositionAtom } from "../atoms/mousePositionAtom"
+
+const update = (event: MouseEvent) =>
+    mousePositionAtom.setSelf({
+        clientX: event.clientX,
+        clientY: event.clientY,
+        pageX: event.pageX,
+        pageY: event.pageY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+    })
+
+// There is no API to read the cursor position without an event, so the atom
+// keeps its zeroed initial value until the first `mousemove`.
+export const subscribePosition = () => {
+    if (typeof window === "undefined") return
+    window.addEventListener("mousemove", update)
+    return () => {
+        window.removeEventListener("mousemove", update)
+    }
+}

--- a/packages/@valdres/browser-mouse/src/types/MouseButtons.ts
+++ b/packages/@valdres/browser-mouse/src/types/MouseButtons.ts
@@ -1,0 +1,7 @@
+export type MouseButtons = {
+    /** Raw `MouseEvent.buttons` bitmask of currently pressed buttons. */
+    buttons: number
+    left: boolean
+    right: boolean
+    middle: boolean
+}

--- a/packages/@valdres/browser-mouse/src/types/MousePosition.ts
+++ b/packages/@valdres/browser-mouse/src/types/MousePosition.ts
@@ -1,0 +1,8 @@
+export type MousePosition = {
+    clientX: number
+    clientY: number
+    pageX: number
+    pageY: number
+    screenX: number
+    screenY: number
+}

--- a/packages/@valdres/browser-mouse/test/setup/happyDom.ts
+++ b/packages/@valdres/browser-mouse/test/setup/happyDom.ts
@@ -1,0 +1,3 @@
+import { GlobalRegistrator } from "@happy-dom/global-registrator"
+
+GlobalRegistrator.register()

--- a/packages/@valdres/browser-mouse/tsconfig.json
+++ b/packages/@valdres/browser-mouse/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../../tsconfig.json",
+    "include": ["src/index.ts"],
+    "exclude": ["test", "dev", "dist", "src/**/*.test.ts"],
+    "compilerOptions": {
+        "rootDir": "src",
+        "declaration": true,
+        "noEmit": false,
+        "emitDeclarationOnly": true,
+        "outDir": "dist/types"
+    }
+}


### PR DESCRIPTION
## What

New `@valdres/browser-mouse` package that wraps the `MouseEvent` stream as reactive global atoms — the first of the pointer-input family (a `browser-pointer` family package for touch/pen/multi-contact is planned as a follow-up).

Three independent singleton atoms, each attaching its own listeners on the first subscriber and tearing them down on the last, per the `@valdres/browser-*` pattern:

| Export | Type | Notes |
|--------|------|-------|
| `mousePositionAtom` | `MousePosition` | `clientX/Y`, `pageX/Y`, `screenX/Y` |
| `mouseButtonsAtom` | `MouseButtons` | raw `buttons` bitmask + `left`/`right`/`middle` |
| `mouseInsideAtom` | `boolean` | cursor geometrically within the document |

## Design notes

- **A mouse is a singleton**, so these are plain global atoms (the family case — multiple simultaneous touch/pen pointers — is deferred to `browser-pointer`).
- **Button state resyncs from the live `buttons` bitmask on every mouse event**, guarded by a cheap number compare so listening to `mousemove` costs nothing per pixel (the core already deep-equal-dedupes writes; the guard just avoids the allocation). This makes the right-click-then-context-menu case self-heal: the menu swallows the `mouseup`, so the press stays visible while the menu is open and clears on the first move after it's dismissed. `blur` clears immediately on focus loss.
- **`mouseInsideAtom` is geometric, not focus-gated** — it stays `true` when you alt-tab away with the cursor over the page (documented; compose with `@valdres/browser-focus` for focus-gated presence).

## Docs

- Co-located `browser-mouse.mdx` (install → live demo → per-framework usage → exports → cross-framework notes), auto-discovered into `/<fw>/plugins/browser-mouse` for all five frameworks.
- Live inspector demo registered in `docs/src/islands/plugins/registry.ts`.

## Checks (`/before-pr`)

- `bun test` — 17/17 pass
- `bun run docs:build` — clean (197 pages)
- `gen-readmes --check` — in sync
- `changeset status` — `@valdres/browser-mouse` (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)