### PR TITLE
fix(valdres): prevent async selectors from resurrecting after unmount

### DIFF
--- a/.changeset/async-selector-unmount-revocation.md
+++ b/.changeset/async-selector-unmount-revocation.md
@@ -4,5 +4,5 @@
 
 Prevent pending async selectors from recreating cache entries and dependency
 edges after their last subscriber unmounts. Queued orphan cleanup now revokes
-the evaluation and aborts its allocated signal, while stale Promise resolution
-and suspension retries are ignored by the store.
+the evaluation while preserving the existing signal contract, and stale Promise
+resolution and suspension retries are ignored by the store.

--- a/.changeset/async-selector-unmount-revocation.md
+++ b/.changeset/async-selector-unmount-revocation.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Prevent pending async selectors from recreating cache entries and dependency
+edges after their last subscriber unmounts. Queued orphan cleanup now revokes
+the evaluation and aborts its allocated signal, while stale Promise resolution
+and suspension retries are ignored by the store.

--- a/packages/valdres/src/lib/abortSignal.test.ts
+++ b/packages/valdres/src/lib/abortSignal.test.ts
@@ -76,7 +76,7 @@ describe("abort signal support for async selectors", () => {
         expect(signals[1]!.aborted).toBe(false)
     })
 
-    test("signal is NOT aborted when unsubscribing", async () => {
+    test("signal is aborted when unsubscribe cleanup drains", async () => {
         const store1 = store()
         const countAtom = atom(1)
         const signals: AbortSignal[] = []
@@ -91,9 +91,12 @@ describe("abort signal support for async selectors", () => {
         expect(signals).toHaveLength(1)
         expect(signals[0]!.aborted).toBe(false)
 
-        // Unsubscribe should NOT abort the signal
+        // Lifecycle unmount remains synchronous, while internal selector graph
+        // and async-evaluation cleanup is batched into the queued microtask.
         unsub()
         expect(signals[0]!.aborted).toBe(false)
+        await Promise.resolve()
+        expect(signals[0]!.aborted).toBe(true)
     })
 
     test("each store gets its own abort signal for the same selector", () => {

--- a/packages/valdres/src/lib/abortSignal.test.ts
+++ b/packages/valdres/src/lib/abortSignal.test.ts
@@ -76,7 +76,7 @@ describe("abort signal support for async selectors", () => {
         expect(signals[1]!.aborted).toBe(false)
     })
 
-    test("signal is aborted when unsubscribe cleanup drains", async () => {
+    test("signal is not aborted when unsubscribe cleanup drains", async () => {
         const store1 = store()
         const countAtom = atom(1)
         const signals: AbortSignal[] = []
@@ -91,12 +91,12 @@ describe("abort signal support for async selectors", () => {
         expect(signals).toHaveLength(1)
         expect(signals[0]!.aborted).toBe(false)
 
-        // Lifecycle unmount remains synchronous, while internal selector graph
-        // and async-evaluation cleanup is batched into the queued microtask.
+        // Internal selector graph and async-evaluation ownership cleanup is
+        // batched, but unmount does not cancel the caller-owned async operation.
         unsub()
         expect(signals[0]!.aborted).toBe(false)
         await Promise.resolve()
-        expect(signals[0]!.aborted).toBe(true)
+        expect(signals[0]!.aborted).toBe(false)
     })
 
     test("each store gets its own abort signal for the same selector", () => {

--- a/packages/valdres/src/lib/asyncUnmountCleanup.test.ts
+++ b/packages/valdres/src/lib/asyncUnmountCleanup.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+describe("async selector unmount cleanup", () => {
+    test("late post-await get cannot resurrect a cleaned selector", async () => {
+        const targetStore = store()
+        const first = atom(1)
+        const late = atom(2)
+        let release!: () => void
+        const gate = new Promise<void>(resolve => {
+            release = resolve
+        })
+        let signal: AbortSignal | undefined
+
+        const derived = selector((get, options) => {
+            signal = options.signal
+            const firstValue = get(first)
+            return gate.then(() => firstValue + get(late))
+        })
+        const callback = mock(() => {})
+        const unsubscribe = targetStore.sub(derived, callback)
+        const pending = targetStore.get(derived) as Promise<number>
+
+        unsubscribe()
+        await Promise.resolve()
+
+        expect(signal!.aborted).toBe(true)
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+        expect(targetStore.data.latestEvalContext.has(derived)).toBe(false)
+
+        release()
+        expect(await pending).toBe(3)
+        await Promise.resolve()
+
+        expect(callback).toHaveBeenCalledTimes(0)
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+        expect(
+            targetStore.data.stateDependents.get(late)?.has(derived) ?? false,
+        ).toBe(false)
+    })
+
+    test("signal first accessed after cleanup is already aborted", async () => {
+        const targetStore = store()
+        const source = atom(1)
+        let release!: () => void
+        const gate = new Promise<void>(resolve => {
+            release = resolve
+        })
+
+        const derived = selector((get, options) => {
+            get(source)
+            return gate.then(() => options.signal.aborted)
+        })
+        const unsubscribe = targetStore.sub(derived, () => {})
+        const pending = targetStore.get(derived) as Promise<boolean>
+
+        unsubscribe()
+        await Promise.resolve()
+        release()
+
+        expect(await pending).toBe(true)
+        await Promise.resolve()
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+    })
+
+    test("deferred get from a settled selector is read-only after cleanup", async () => {
+        const targetStore = store()
+        const source = atom(1)
+        const late = atom(2)
+        let release!: () => void
+        const gate = new Promise<void>(resolve => {
+            release = resolve
+        })
+
+        const derived = selector(get => {
+            get(source)
+            void gate.then(() => get(late))
+            return 1
+        })
+        const unsubscribe = targetStore.sub(derived, () => {})
+
+        unsubscribe()
+        await Promise.resolve()
+        release()
+        await gate
+        await Promise.resolve()
+
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+        expect(
+            targetStore.data.stateDependents.get(late)?.has(derived) ?? false,
+        ).toBe(false)
+    })
+
+    test("a cleaned suspended selector does not retry after its dependency resolves", async () => {
+        const targetStore = store()
+        let resolveDependency!: (value: number) => void
+        const dependencyPromise = new Promise<number>(resolve => {
+            resolveDependency = resolve
+        })
+        const asyncDependency = selector(() => dependencyPromise)
+        let evaluations = 0
+        const derived = selector(get => {
+            evaluations++
+            return get(asyncDependency) * 2
+        })
+        const unsubscribe = targetStore.sub(derived, () => {})
+
+        unsubscribe()
+        await Promise.resolve()
+        resolveDependency(21)
+        expect(await dependencyPromise).toBe(21)
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(evaluations).toBe(1)
+        expect(targetStore.data.values.has(asyncDependency)).toBe(false)
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+    })
+
+    test("old Promise cannot commit through a newer evaluation's graph", async () => {
+        const targetStore = store()
+        const trigger = atom(0)
+        let resolveFirst!: (value: number) => void
+
+        const derived = selector(get => {
+            if (get(trigger) === 0) {
+                return new Promise<number>(resolve => {
+                    resolveFirst = resolve
+                })
+            }
+            throw new Error("newer evaluation failed")
+        })
+        const unsubscribe = targetStore.sub(derived, () => {})
+        const firstPending = targetStore.get(derived) as Promise<number>
+
+        // The newer evaluation installs a new context and retains the existing
+        // dependency graph, but its error leaves no cached value. Value/graph
+        // presence alone therefore cannot identify the old Promise as stale.
+        targetStore.set(trigger, 1)
+        expect(targetStore.data.stateDependencies.has(derived)).toBe(true)
+        expect(targetStore.data.values.has(derived)).toBe(false)
+
+        resolveFirst(42)
+        expect(await firstPending).toBe(42)
+        await Promise.resolve()
+
+        expect(targetStore.data.values.has(derived)).toBe(false)
+        unsubscribe()
+    })
+})

--- a/packages/valdres/src/lib/asyncUnmountCleanup.test.ts
+++ b/packages/valdres/src/lib/asyncUnmountCleanup.test.ts
@@ -26,7 +26,7 @@ describe("async selector unmount cleanup", () => {
         unsubscribe()
         await Promise.resolve()
 
-        expect(signal!.aborted).toBe(true)
+        expect(signal!.aborted).toBe(false)
         expect(targetStore.data.values.has(derived)).toBe(false)
         expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
         expect(targetStore.data.latestEvalContext.has(derived)).toBe(false)
@@ -43,7 +43,7 @@ describe("async selector unmount cleanup", () => {
         ).toBe(false)
     })
 
-    test("signal first accessed after cleanup is already aborted", async () => {
+    test("signal first accessed after cleanup remains active", async () => {
         const targetStore = store()
         const source = atom(1)
         let release!: () => void
@@ -62,10 +62,11 @@ describe("async selector unmount cleanup", () => {
         await Promise.resolve()
         release()
 
-        expect(await pending).toBe(true)
+        expect(await pending).toBe(false)
         await Promise.resolve()
         expect(targetStore.data.values.has(derived)).toBe(false)
         expect(targetStore.data.stateDependencies.has(derived)).toBe(false)
+        expect(targetStore.data.abortControllers.has(derived)).toBe(false)
     })
 
     test("deferred get from a settled selector is read-only after cleanup", async () => {

--- a/packages/valdres/src/lib/cleanupOrphanedDeps.ts
+++ b/packages/valdres/src/lib/cleanupOrphanedDeps.ts
@@ -1,5 +1,6 @@
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
+import type { Selector } from "../types/Selector"
 import { isLive } from "./mountAtom"
 
 /**
@@ -29,12 +30,30 @@ export const cleanupOrphanedDeps = (state: State, data: StoreData) => {
         const dependents = data.stateDependents.get(current)
         const deps = data.stateDependencies.get(current)
         if (deps) {
+            // Revoke the evaluation before removing its graph. Deferred `get`
+            // closures capture this object, so flipping it first makes every
+            // post-cleanup read read-only even after the WeakMap entry is gone.
+            // This also gives pending Promise handlers an evaluation-identity
+            // guard stronger than `stateDependencies.has`, which a stale late
+            // `get` or a newer evaluation can make true again.
+            const selector = current as Selector
+            const evaluationContext = data.latestEvalContext.get(selector)
+            if (evaluationContext) evaluationContext.revoked = true
+            data.latestEvalContext.delete(selector)
+
+            // Abort only a controller allocated by this evaluation (`false` is
+            // the known-sync sentinel). Delete all old state before aborting:
+            // AbortSignal listeners run synchronously and may re-enter the
+            // store, in which case their newly materialized evaluation must not
+            // be deleted when control returns here.
+            const controller = data.abortControllers.get(current)
             for (const dep of deps) {
                 data.stateDependents.get(dep)?.delete(current)
             }
             data.stateDependencies.delete(current)
             data.values.delete(current)
             data.abortControllers.delete(current)
+            if (controller) controller.abort()
 
             if (dependents) {
                 for (const dependent of dependents) stack.push(dependent)

--- a/packages/valdres/src/lib/cleanupOrphanedDeps.ts
+++ b/packages/valdres/src/lib/cleanupOrphanedDeps.ts
@@ -38,22 +38,21 @@ export const cleanupOrphanedDeps = (state: State, data: StoreData) => {
             // `get` or a newer evaluation can make true again.
             const selector = current as Selector
             const evaluationContext = data.latestEvalContext.get(selector)
-            if (evaluationContext) evaluationContext.revoked = true
+            if (evaluationContext) {
+                // Unmount invalidates store ownership but intentionally keeps
+                // the public AbortSignal alive. Re-evaluation still aborts the
+                // superseded signal through evaluateSelector's normal path.
+                evaluationContext.preserveSignalOnRevoke = true
+                evaluationContext.revoked = true
+            }
             data.latestEvalContext.delete(selector)
 
-            // Abort only a controller allocated by this evaluation (`false` is
-            // the known-sync sentinel). Delete all old state before aborting:
-            // AbortSignal listeners run synchronously and may re-enter the
-            // store, in which case their newly materialized evaluation must not
-            // be deleted when control returns here.
-            const controller = data.abortControllers.get(current)
             for (const dep of deps) {
                 data.stateDependents.get(dep)?.delete(current)
             }
             data.stateDependencies.delete(current)
             data.values.delete(current)
             data.abortControllers.delete(current)
-            if (controller) controller.abort()
 
             if (dependents) {
                 for (const dependent of dependents) stack.push(dependent)

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -322,7 +322,16 @@ export const handleSelectorResult = <Value>(
         // abort the signal.
         data.abortControllers.delete(selector)
         const promise = value.promise
+        const evaluationContext = data.latestEvalContext.get(selector)
         promise.then(() => {
+            // Dependency presence alone is not an evaluation identity: a stale
+            // late `get` or a newer evaluation can recreate the selector's graph.
+            // Only the context that installed this handler may retry/commit.
+            if (
+                !evaluationContext ||
+                evaluationContext.revoked ||
+                data.latestEvalContext.get(selector) !== evaluationContext
+            ) return
             // Guard against stale promise — if the selector's value has been
             // replaced with a different value, this resolution is outdated.
             // If the value was deleted (e.g. moved to expired), still proceed.
@@ -346,7 +355,18 @@ export const handleSelectorResult = <Value>(
     } else if (isPromiseLike(value)) {
         // When a promise is returned when initializing a selector we suspend,
         // then we retry when the promise resolves.
+        const evaluationContext = data.latestEvalContext.get(selector)
         value.then(resolved => {
+            // A graph entry can be recreated after this Promise was superseded;
+            // use per-evaluation identity as the primary stale-result guard.
+            if (
+                !evaluationContext ||
+                evaluationContext.revoked ||
+                data.latestEvalContext.get(selector) !== evaluationContext
+            ) {
+                pendingAsyncDeps.delete(value)
+                return
+            }
             // Guard: selector was cleaned up by unsubscribe GC
             if (!data.stateDependencies.has(selector)) {
                 pendingAsyncDeps.delete(value)

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -86,7 +86,7 @@ export const evaluateSelector = <V>(
     const latestEvalContext = data.latestEvalContext
     const prevCtx = latestEvalContext.get(selector)
     if (prevCtx) prevCtx.revoked = true
-    const evalCtx = { revoked: false }
+    const evalCtx = { revoked: false, preserveSignalOnRevoke: false }
     latestEvalContext.set(selector, evalCtx)
 
     if (circularDependencySet.has(selector)) {
@@ -135,7 +135,9 @@ export const evaluateSelector = <V>(
                         if (!controller) {
                             controller = new AbortController()
                             if (myEvalCtx.revoked) {
-                                controller.abort()
+                                if (!myEvalCtx.preserveSignalOnRevoke) {
+                                    controller.abort()
+                                }
                             } else {
                                 data.abortControllers.set(selector, controller)
                             }

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -117,7 +117,10 @@ export type StoreData = {
      *  await) `get` calls from superseded evaluations. Per-store so that
      *  store2 evaluating a shared selector doesn't silently strip dep
      *  registration from store1's in-flight async eval. */
-    latestEvalContext: WeakMap<Selector, { revoked: boolean }>
+    latestEvalContext: WeakMap<
+        Selector,
+        { revoked: boolean; preserveSignalOnRevoke: boolean }
+    >
     /** Per-atom timestamp of the last value write, used for lazy
      *  maxAge revalidation when the atom is unmounted (no active timer
      *  to keep the cache fresh). Only populated for atoms with `maxAge`. */


### PR DESCRIPTION
## Summary

- revoke selector evaluation contexts when queued orphan cleanup drains
- preserve the existing contract that unmount does not abort caller-owned async work
- guard async resolution and suspension retry by evaluation identity
- add regression coverage for late reads, stale commits, delayed signal access, and suspended selectors
- add the required patch changeset for `valdres`

## Semantics

Public lifecycle unmount remains synchronous. Internal graph cleanup and evaluation revocation remain batched in the queued microtask introduced by #217. A stale externally held Promise may still resolve for its caller, and its signal remains active, but it can no longer recreate store edges or commit a store value. Dependency-change reevaluations continue to abort superseded signals.

## Verification

- full monorepo `bun run test:ci` passed
- focused Valdres async/abort/cross-store suite: 26 passed
- Jotai adapter store suite: 59 passed, 1 skipped, 6 todo, 0 failed
- `bun run build`
- `bun run typecheck:types`
- async-unmount reproduction probe passed on Bun and Node
- unsubscribe benchmark passed on Bun and Node