### PR TITLE
fix(valdres): finish commits after onSet errors

### DIFF
--- a/.changeset/onset-error-commit.md
+++ b/.changeset/onset-error-commit.md
@@ -1,0 +1,7 @@
+---
+"valdres": patch
+---
+
+Finish atom writes, `onSet` hooks, selector propagation, and subscriber
+notification across direct sets, transactions, scopes, and global stores before
+rethrowing the first hook error.

--- a/packages/valdres/src/lib/commitErrors.ts
+++ b/packages/valdres/src/lib/commitErrors.ts
@@ -1,0 +1,20 @@
+export type CommitErrors = {
+    hasError: boolean
+    firstError: unknown
+}
+
+export const createCommitErrors = (): CommitErrors => ({
+    hasError: false,
+    firstError: undefined,
+})
+
+export const recordCommitError = (errors: CommitErrors, error: unknown) => {
+    if (!errors.hasError) {
+        errors.hasError = true
+        errors.firstError = error
+    }
+}
+
+export const throwCommitError = (errors: CommitErrors) => {
+    if (errors.hasError) throw errors.firstError
+}

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -12,6 +12,13 @@ import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { installMaxAgeTimer } from "./subscribe"
 import { globalStore } from "../globalStore"
 
+// Every global atom carries an onSet function, even when the user did not
+// provide one. This lets the write hot path use the existing `atom.onSet`
+// property as its single fast/slow discriminator: ordinary atoms without hooks
+// stay on the original inline propagation path, while global atoms enter the
+// phased fan-out path. Shared across atoms so the marker itself allocates once.
+const globalOnSetMarker: AtomOnSet<any> = () => {}
+
 export const globalAtom = <Value = unknown>(
     defaultValue: AtomDefaultValue<Value>,
     options: AtomOptions<Value>,
@@ -27,10 +34,10 @@ export const globalAtom = <Value = unknown>(
     }
 
     // Cross-store synchronization is part of the write phase (see
-    // globalAtomFanOut), rather than this hook. Keeping only the user's hook
-    // here lets every peer value land before any hook runs, and every hook
-    // finish before selector propagation/subscriber notification starts.
-    const onSet: AtomOnSet<Value> | undefined = userOnSet
+    // globalAtomFanOut), rather than this hook. The no-op fallback marks a
+    // global atom as commit-sensitive without adding another property check to
+    // every ordinary set.
+    const onSet: AtomOnSet<Value> = userOnSet ?? globalOnSetMarker
 
     // For global atoms, options.onMount fires when the FIRST subscriber across
     // any store attaches, and its cleanup fires when the LAST subscriber across

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -9,7 +9,6 @@ import type { GlobalAtom } from "./../types/GlobalAtom"
 import type { StoreData } from "./../types/StoreData"
 import { isLive, mountAtom, unmountAtom } from "./mountAtom"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
-import { setAtom } from "./setAtom"
 import { installMaxAgeTimer } from "./subscribe"
 import { globalStore } from "../globalStore"
 
@@ -27,18 +26,11 @@ export const globalAtom = <Value = unknown>(
         stores.add(data)
     }
 
-    // Cross-store sync propagates to peers with skipOnSet=true, so the user
-    // hook fires exactly once per set — in the originating store.
-    const onSet: AtomOnSet<Value> = (newValue, currentStore) => {
-        if (stores.size > 1) {
-            for (const store of stores) {
-                if (store.id !== currentStore.id) {
-                    setAtom(atom, newValue, store, true)
-                }
-            }
-        }
-        userOnSet?.(newValue, currentStore)
-    }
+    // Cross-store synchronization is part of the write phase (see
+    // globalAtomFanOut), rather than this hook. Keeping only the user's hook
+    // here lets every peer value land before any hook runs, and every hook
+    // finish before selector propagation/subscriber notification starts.
+    const onSet: AtomOnSet<Value> | undefined = userOnSet
 
     // For global atoms, options.onMount fires when the FIRST subscriber across
     // any store attaches, and its cleanup fires when the LAST subscriber across

--- a/packages/valdres/src/lib/globalAtomFanOut.ts
+++ b/packages/valdres/src/lib/globalAtomFanOut.ts
@@ -1,0 +1,115 @@
+import type { Atom } from "../types/Atom"
+import type { GlobalAtom } from "../types/GlobalAtom"
+import type { StoreData } from "../types/StoreData"
+import { isPromiseLike } from "../utils/isPromiseLike"
+import type { CommitErrors } from "./commitErrors"
+import { recordCommitError } from "./commitErrors"
+import { getState } from "./getState"
+import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { resolvePendingDefault } from "./resolvePendingDefault"
+import { setValueInData } from "./setValueInData"
+import { validateSchema } from "./validateSchema"
+
+/** A changed global atom whose value still needs to be applied to its peers. */
+export type DeferredGlobalSet = [GlobalAtom<any>, any]
+
+export type StoreAtomUpdates = Map<StoreData, Atom<any>[]>
+
+/** Hold every affected store tree's commit-end boundary across the shared
+ * propagation/notification phase of a global write. */
+export const beginGlobalCommit = (
+    origin: StoreData,
+    updates: StoreAtomUpdates,
+): StoreData[] => {
+    if (commitEndRegistry.count === 0) return []
+    const roots = [beginCommit(origin)]
+    for (const data of updates.keys()) roots.push(beginCommit(data))
+    return roots
+}
+
+export const endGlobalCommit = (roots: StoreData[], errors: CommitErrors) => {
+    for (const root of roots) {
+        try {
+            // Once an earlier phase failed, commit-end errors must not mask it.
+            endCommit(root, errors.hasError)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+}
+
+const addUpdates = (
+    updates: StoreAtomUpdates,
+    data: StoreData,
+    atoms: Atom<any>[],
+) => {
+    if (atoms.length === 0) return
+    const existing = updates.get(data)
+    if (existing) existing.push(...atoms)
+    else updates.set(data, atoms)
+}
+
+/**
+ * Apply one already-resolved global value to a peer without running hooks or
+ * propagation. The enclosing commit owns those later phases.
+ */
+const applyPeerValue = (
+    atom: GlobalAtom<any>,
+    value: any,
+    data: StoreData,
+): Atom<any>[] => {
+    const initializedAtoms = new Set<Atom<any>>()
+    const currentValue = getState(atom, data, initializedAtoms)
+    value = validateSchema(atom, value, data)
+    const currentIsPromise = isPromiseLike(currentValue)
+    const areEqual =
+        currentIsPromise || isPromiseLike(value)
+            ? currentValue === value
+            : atom.equal(currentValue, value)
+
+    if (areEqual) {
+        // Preserve the transaction/direct-set rule that an equal write in a
+        // scope still establishes an own shadow.
+        if (data.parent && !data.values.has(atom)) {
+            setValueInData(atom, value, data)
+        }
+        return []
+    }
+
+    value = setValueInData(atom, value, data)
+    if (currentIsPromise && !isPromiseLike(value)) {
+        resolvePendingDefault(atom, data, value)
+    }
+
+    const updatedAtoms: Atom<any>[] = [atom]
+    for (const initialized of initializedAtoms) updatedAtoms.push(initialized)
+    return updatedAtoms
+}
+
+/**
+ * Complete the write phase for global atoms. Every registered peer is attempted
+ * before hooks or propagation begin; a failure in one peer cannot starve later
+ * peers. Returned updates are grouped by store for the propagation phase.
+ */
+export const applyGlobalSets = (
+    globalSets: DeferredGlobalSet[],
+    errors: CommitErrors,
+): StoreAtomUpdates => {
+    const updates: StoreAtomUpdates = new Map()
+    for (const [atom, value] of globalSets) {
+        // Snapshot: initializing or user code in a later phase may mutate the
+        // registration set, but it must not change this commit's fan-out list.
+        for (const peer of [...atom.stores]) {
+            try {
+                // Include the originating store. This is normally an equal
+                // no-op, but when one commit stages the same global atom from
+                // multiple stores it makes the last queued value win EVERYWHERE
+                // instead of leaving each origin on a different prior value.
+                addUpdates(updates, peer, applyPeerValue(atom, value, peer))
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+    }
+    return updates
+}

--- a/packages/valdres/src/lib/globalAtomFanOut.ts
+++ b/packages/valdres/src/lib/globalAtomFanOut.ts
@@ -1,6 +1,7 @@
 import type { Atom } from "../types/Atom"
 import type { GlobalAtom } from "../types/GlobalAtom"
 import type { StoreData } from "../types/StoreData"
+import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import type { CommitErrors } from "./commitErrors"
 import { recordCommitError } from "./commitErrors"
@@ -9,6 +10,7 @@ import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 import { validateSchema } from "./validateSchema"
+import type { DeferredOnSet } from "./writeAtoms"
 
 /** A changed global atom whose value still needs to be applied to its peers. */
 export type DeferredGlobalSet = [GlobalAtom<any>, any]
@@ -91,25 +93,54 @@ const applyPeerValue = (
  * before hooks or propagation begin; a failure in one peer cannot starve later
  * peers. Returned updates are grouped by store for the propagation phase.
  */
+const applyGlobalSet = (
+    atom: GlobalAtom<any>,
+    value: any,
+    updates: StoreAtomUpdates,
+    errors: CommitErrors,
+): void => {
+    // Snapshot: initializing or user code in a later phase may mutate the
+    // registration set, but it must not change this commit's fan-out list.
+    for (const peer of [...atom.stores]) {
+        try {
+            // Include the originating store. This is normally an equal no-op,
+            // but when one commit stages the same global atom from multiple
+            // stores it makes the last queued value win EVERYWHERE instead of
+            // leaving each origin on a different prior value.
+            addUpdates(updates, peer, applyPeerValue(atom, value, peer))
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+}
+
 export const applyGlobalSets = (
     globalSets: DeferredGlobalSet[],
     errors: CommitErrors,
 ): StoreAtomUpdates => {
     const updates: StoreAtomUpdates = new Map()
     for (const [atom, value] of globalSets) {
-        // Snapshot: initializing or user code in a later phase may mutate the
-        // registration set, but it must not change this commit's fan-out list.
-        for (const peer of [...atom.stores]) {
-            try {
-                // Include the originating store. This is normally an equal
-                // no-op, but when one commit stages the same global atom from
-                // multiple stores it makes the last queued value win EVERYWHERE
-                // instead of leaving each origin on a different prior value.
-                addUpdates(updates, peer, applyPeerValue(atom, value, peer))
-            } catch (error) {
-                recordCommitError(errors, error)
-            }
-        }
+        applyGlobalSet(atom, value, updates, errors)
+    }
+    return updates
+}
+
+/**
+ * Apply only the global writes from a deferred-hook queue. Global atoms carry
+ * an onSet marker even without a user hook, so the queue is also the complete
+ * set of commit-sensitive writes. The updates map is created lazily: a
+ * transaction containing ordinary user hooks but no globals allocates no
+ * global fan-out state.
+ */
+export const applyGlobalOnSets = (
+    onSets: DeferredOnSet[],
+    errors: CommitErrors,
+    updates?: StoreAtomUpdates,
+): StoreAtomUpdates | undefined => {
+    for (const [atom, value] of onSets) {
+        if (!isGlobalAtom(atom)) continue
+        updates ??= new Map()
+        applyGlobalSet(atom, value, updates, errors)
     }
     return updates
 }

--- a/packages/valdres/src/lib/globalAtomFanOut.ts
+++ b/packages/valdres/src/lib/globalAtomFanOut.ts
@@ -6,7 +6,12 @@ import { isPromiseLike } from "../utils/isPromiseLike"
 import type { CommitErrors } from "./commitErrors"
 import { recordCommitError } from "./commitErrors"
 import { getState } from "./getState"
-import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import {
+    beginCommit,
+    commitEndRegistry,
+    commitRootOf,
+    endCommit,
+} from "./onCommitEnd"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 import { validateSchema } from "./validateSchema"
@@ -22,14 +27,18 @@ export type StoreAtomUpdates = Map<StoreData, Atom<any>[]>
 export const beginGlobalCommit = (
     origin: StoreData,
     updates: StoreAtomUpdates,
-): StoreData[] => {
+): Iterable<StoreData> => {
     if (commitEndRegistry.count === 0) return []
-    const roots = [beginCommit(origin)]
-    for (const data of updates.keys()) roots.push(beginCommit(data))
+    const roots = new Set<StoreData>([commitRootOf(origin)])
+    for (const data of updates.keys()) roots.add(commitRootOf(data))
+    for (const root of roots) beginCommit(root)
     return roots
 }
 
-export const endGlobalCommit = (roots: StoreData[], errors: CommitErrors) => {
+export const endGlobalCommit = (
+    roots: Iterable<StoreData>,
+    errors: CommitErrors,
+) => {
     for (const root of roots) {
         try {
             // Once an earlier phase failed, commit-end errors must not mask it.

--- a/packages/valdres/src/lib/onCommitEnd.test.ts
+++ b/packages/valdres/src/lib/onCommitEnd.test.ts
@@ -194,6 +194,26 @@ describe("store.onCommitEnd", () => {
             scoped.detach()
         })
 
+        test("a scoped global write opens one boundary for the store tree", () => {
+            const root = store()
+            const scoped = root.scope("ce-global")
+            const value = atom(0, { global: true })
+            const subscriberDepths: number[] = []
+            root.get(value)
+            const unsubValue = scoped.sub(value, () => {
+                subscriberDepths.push(root.data.commitDepth ?? 0)
+            })
+            const unsubCommit = root.onCommitEnd(() => {})
+
+            scoped.set(value, 1)
+
+            expect(subscriberDepths).toEqual([1])
+            expect(root.data.commitDepth).toBe(0)
+            unsubValue()
+            unsubCommit()
+            scoped.detach()
+        })
+
         test("an unrelated root store's commit does not fire this tree's listeners", () => {
             const store1 = store()
             const store2 = store()

--- a/packages/valdres/src/lib/onCommitEnd.ts
+++ b/packages/valdres/src/lib/onCommitEnd.ts
@@ -7,7 +7,9 @@ import type { StoreData } from "../types/StoreData"
  *  no allocation. */
 export const commitEndRegistry = { count: 0 }
 
-const rootOf = (data: StoreData): StoreData => {
+/** Resolve the root that owns commit state for a store tree. Exported for
+ * multi-store commits so they can de-duplicate scopes before opening roots. */
+export const commitRootOf = (data: StoreData): StoreData => {
     let root = data
     while (root.parent) root = root.parent
     return root
@@ -19,7 +21,7 @@ const rootOf = (data: StoreData): StoreData => {
  *  on every path (including throws) using the returned root, so a listener
  *  unsubscribing mid-commit can't strand the depth counter. */
 export const beginCommit = (data: StoreData): StoreData => {
-    const root = rootOf(data)
+    const root = commitRootOf(data)
     root.commitDepth = (root.commitDepth ?? 0) + 1
     return root
 }
@@ -67,7 +69,7 @@ export const onCommitEnd = (
     callback: () => void,
     data: StoreData,
 ): (() => void) => {
-    const root = rootOf(data)
+    const root = commitRootOf(data)
     let listeners = root.commitEndListeners
     if (!listeners) {
         listeners = new Set()

--- a/packages/valdres/src/lib/onSetErrors.test.ts
+++ b/packages/valdres/src/lib/onSetErrors.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+describe("throwing onSet hooks", () => {
+    test("a direct set still propagates and notifies before rethrowing", () => {
+        const hookError = new Error("onSet failed")
+        const count = atom(0, {
+            onSet: () => {
+                throw hookError
+            },
+        })
+        const doubled = selector(get => get(count) * 2)
+        const s = store()
+        const seen: number[] = []
+        s.sub(doubled, () => seen.push(s.get(doubled)))
+
+        let thrown: unknown
+        try {
+            s.set(count, 1)
+        } catch (error) {
+            thrown = error
+        }
+
+        expect(thrown).toBe(hookError)
+        expect(s.get(count)).toBe(1)
+        expect(s.get(doubled)).toBe(2)
+        expect(seen).toEqual([2])
+    })
+
+    test("a transaction applies every write, runs every hook, and notifies before rethrowing the first error", () => {
+        const firstError = new Error("first onSet failed")
+        const secondError = new Error("second onSet failed")
+        const hookOrder: string[] = []
+        const a = atom(0, {
+            onSet: () => {
+                hookOrder.push("a")
+                throw firstError
+            },
+        })
+        const b = atom(0, {
+            onSet: () => {
+                hookOrder.push("b")
+                throw secondError
+            },
+        })
+        const sum = selector(get => get(a) + get(b))
+        const s = store()
+        const seen: number[] = []
+        s.sub(sum, () => seen.push(s.get(sum)))
+
+        let thrown: unknown
+        try {
+            s.txn(txn => {
+                txn.set(a, 1)
+                txn.set(b, 2)
+            })
+        } catch (error) {
+            thrown = error
+        }
+
+        expect(thrown).toBe(firstError)
+        expect(hookOrder).toEqual(["a", "b"])
+        expect(s.get(a)).toBe(1)
+        expect(s.get(b)).toBe(2)
+        expect(s.get(sum)).toBe(3)
+        expect(seen).toEqual([3])
+    })
+
+    test("a cross-scope transaction finishes hooks and propagation in every store", () => {
+        const rootError = new Error("root onSet failed")
+        const scopeError = new Error("scope onSet failed")
+        const hookOrder: string[] = []
+        const root = store()
+        const child = root.scope("child")
+        const rootValue = atom(0, {
+            onSet: () => {
+                hookOrder.push("root")
+                throw rootError
+            },
+        })
+        const childValue = atom(0, {
+            onSet: () => {
+                hookOrder.push("child")
+                throw scopeError
+            },
+        })
+        child.set(childValue, 0)
+        const sum = selector(get => get(rootValue) + get(childValue))
+        const seen: number[] = []
+        child.sub(sum, () => seen.push(child.get(sum)))
+
+        let thrown: unknown
+        try {
+            root.txn(txn => {
+                txn.set(rootValue, 1)
+                txn.scope("child", scoped => scoped.set(childValue, 2))
+            })
+        } catch (error) {
+            thrown = error
+        }
+
+        expect(thrown).toBe(rootError)
+        expect(hookOrder).toEqual(["root", "child"])
+        expect(root.get(rootValue)).toBe(1)
+        expect(child.get(childValue)).toBe(2)
+        expect(child.get(sum)).toBe(3)
+        expect(seen).toEqual([3])
+    })
+
+    test("global fan-out applies and notifies every store before rethrowing the first hook error", () => {
+        const hookError = new Error("global onSet failed")
+        const subscriberError = new Error("peer subscriber failed")
+        const onSet = mock(() => {
+            throw hookError
+        })
+        const value = atom(0, { global: true, onSet })
+        const doubled = selector(get => get(value) * 2)
+        const source = store()
+        const throwingPeer = store()
+        const trailingPeer = store()
+        const sourceSeen: number[] = []
+        const throwingPeerSeen: number[] = []
+        const trailingPeerSeen: number[] = []
+        const snapshots: Array<[number, number, number]> = []
+        const snapshot = () =>
+            snapshots.push([
+                source.get(doubled),
+                throwingPeer.get(doubled),
+                trailingPeer.get(doubled),
+            ])
+
+        source.sub(doubled, () => {
+            sourceSeen.push(source.get(doubled))
+            snapshot()
+        })
+        throwingPeer.sub(doubled, () => {
+            throwingPeerSeen.push(throwingPeer.get(doubled))
+            snapshot()
+            throw subscriberError
+        })
+        trailingPeer.sub(doubled, () => {
+            trailingPeerSeen.push(trailingPeer.get(doubled))
+            snapshot()
+        })
+
+        let thrown: unknown
+        try {
+            source.set(value, 1)
+        } catch (error) {
+            thrown = error
+        }
+
+        // Hooks run before propagation, so their first error wins even though a
+        // later subscriber also throws. Neither error may interrupt fan-out.
+        expect(thrown).toBe(hookError)
+        expect(onSet).toHaveBeenCalledTimes(1)
+        for (const s of [source, throwingPeer, trailingPeer]) {
+            expect(s.get(value)).toBe(1)
+            expect(s.get(doubled)).toBe(2)
+        }
+        expect(sourceSeen).toEqual([2])
+        expect(throwingPeerSeen).toEqual([2])
+        expect(trailingPeerSeen).toEqual([2])
+        expect(snapshots).toEqual([
+            [2, 2, 2],
+            [2, 2, 2],
+            [2, 2, 2],
+        ])
+    })
+
+    test("the last cross-scope global write converges every store despite a hook error", () => {
+        const hookError = new Error("first global hook failed")
+        let hookCalls = 0
+        const value = atom(0, {
+            global: true,
+            onSet: () => {
+                hookCalls++
+                if (hookCalls === 1) throw hookError
+            },
+        })
+        const doubled = selector(get => get(value) * 2)
+        const root = store()
+        const child = root.scope("global-child")
+        const rootSeen: number[] = []
+        const childSeen: number[] = []
+        root.sub(doubled, () => rootSeen.push(root.get(doubled)))
+        child.sub(doubled, () => childSeen.push(child.get(doubled)))
+
+        let thrown: unknown
+        try {
+            root.txn(txn => {
+                txn.set(value, 1)
+                txn.scope("global-child", scoped => scoped.set(value, 2))
+            })
+        } catch (error) {
+            thrown = error
+        }
+
+        expect(thrown).toBe(hookError)
+        expect(hookCalls).toBe(2)
+        expect(root.get(value)).toBe(2)
+        expect(child.get(value)).toBe(2)
+        expect(root.get(doubled)).toBe(4)
+        expect(child.get(doubled)).toBe(4)
+        expect(rootSeen).toEqual([4])
+        expect(childSeen).toEqual([4])
+    })
+})

--- a/packages/valdres/src/lib/setAtom.test.ts
+++ b/packages/valdres/src/lib/setAtom.test.ts
@@ -306,18 +306,24 @@ describe("setAtom", () => {
             })
             const store1 = store()
             const stringAtom = atom<string>("initial", { onSet: onSetMock })
+            const isUpdated = selector(get => get(stringAtom) === "updated")
+            const subscriber = mock(() => {})
             store1.get(stringAtom)
+            store1.sub(isUpdated, subscriber)
 
             const result = setAtom(
                 stringAtom,
                 () => Promise.resolve("updated"),
                 store1.data,
             )
+            const callsWhilePending = subscriber.mock.calls.length
             await result
             // Allow unhandled rejection tracking to flush
             await new Promise(r => setTimeout(r, 10))
 
             expect(rejections).toHaveLength(0)
+            expect(store1.get(isUpdated)).toBe(true)
+            expect(subscriber.mock.calls.length).toBe(callsWhilePending + 1)
         } finally {
             process.off("unhandledRejection", handler)
         }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -1,14 +1,115 @@
 import type { Atom } from "../types/Atom"
 import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
+import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
+import {
+    createCommitErrors,
+    recordCommitError,
+    throwCommitError,
+} from "./commitErrors"
 import { getState } from "./getState"
-import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
+import {
+    applyGlobalSets,
+    beginGlobalCommit,
+    endGlobalCommit,
+} from "./globalAtomFanOut"
+import { createChangeSink, flushChangeSink } from "./notifyChangeListeners"
+import {
+    notifyDeferred,
+    propagateAtomUpdate,
+    type NotifyTarget,
+} from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 import { validateResolvedValue } from "./validateResolvedValue"
 import { validateSchema } from "./validateSchema"
+
+/**
+ * Finish a settled atom write after its value has landed. Global peer writes
+ * are applied first, then the user hook runs, then every store propagates and
+ * notifies. Errors never interrupt a later phase; the first is rethrown last.
+ */
+const finishAtomSet = <Value>(
+    atom: Atom<Value>,
+    value: Value,
+    data: StoreData,
+    updatedAtoms: Atom<any>[],
+    skipOnSet: boolean,
+    source: "set" | "async-set",
+) => {
+    // The overwhelmingly common path stays allocation-free.
+    if (skipOnSet || !isGlobalAtom(atom)) {
+        let hasHookError = false
+        let hookError: unknown
+        if (atom.onSet && !skipOnSet) {
+            try {
+                atom.onSet(value, data)
+            } catch (error) {
+                hasHookError = true
+                hookError = error
+            }
+        }
+        try {
+            propagateAtomUpdate(updatedAtoms, data, false, undefined, source)
+        } catch (error) {
+            if (hasHookError) throw hookError
+            throw error
+        }
+        if (hasHookError) throw hookError
+        return
+    }
+
+    const errors = createCommitErrors()
+    const globalUpdates = applyGlobalSets([[atom, value]], errors)
+
+    if (atom.onSet) {
+        try {
+            atom.onSet(value, data)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+
+    if (globalUpdates.size === 0) {
+        try {
+            propagateAtomUpdate(updatedAtoms, data, false, undefined, source)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    } else {
+        const notify: NotifyTarget = new Map()
+        const changeSink = createChangeSink(undefined, source)
+        const commitRoots = beginGlobalCommit(data, globalUpdates)
+        // Preserve global onChange ordering: peers report before the origin.
+        for (const [peer, peerAtoms] of globalUpdates) {
+            try {
+                propagateAtomUpdate(peerAtoms, peer, false, notify, changeSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        try {
+            propagateAtomUpdate(updatedAtoms, data, false, notify, changeSink)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        try {
+            notifyDeferred(notify)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        try {
+            flushChangeSink(changeSink)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        endGlobalCommit(commitRoots, errors)
+    }
+
+    throwCommitError(errors)
+}
 
 const handlePromise = <Value>(
     atom: Atom<Value>,
@@ -33,9 +134,15 @@ const handlePromise = <Value>(
                 return
             }
             setValueInData(atom, resolvedValue, data)
-            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
             resolvePendingDefault(atom, data, resolvedValue)
-            propagateAtomUpdate([atom], data, false, undefined, "async-set")
+            finishAtomSet(
+                atom,
+                resolvedValue,
+                data,
+                [atom],
+                skipOnSet,
+                "async-set",
+            )
         })
         // Chained .catch so errors thrown inside the fulfilled handler
         // (e.g. from atom.onSet) don't surface as unhandled rejections.
@@ -107,13 +214,19 @@ export const setAtom = <Value = any>(
         return syncValue
     }
     syncValue = setValueInData(atom, syncValue, data)
-    if (atom.onSet && !skipOnSet) atom.onSet(syncValue, data)
     resolvePendingDefault(atom, data, syncValue)
     if (initializedAtomsSet && initializedAtomsSet.size > 0) {
         initializedAtomsSet.add(atom)
-        propagateAtomUpdate([...initializedAtomsSet], data, false, undefined, "set")
+        finishAtomSet(
+            atom,
+            syncValue,
+            data,
+            [...initializedAtomsSet],
+            skipOnSet,
+            "set",
+        )
     } else {
-        propagateAtomUpdate([atom], data, false, undefined, "set")
+        finishAtomSet(atom, syncValue, data, [atom], skipOnSet, "set")
     }
     return syncValue
 }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -27,29 +27,26 @@ import { validateResolvedValue } from "./validateResolvedValue"
 import { validateSchema } from "./validateSchema"
 
 /**
- * Finish a settled atom write after its value has landed. Global peer writes
- * are applied first, then the user hook runs, then every store propagates and
- * notifies. Errors never interrupt a later phase; the first is rethrown last.
+ * Slow path for a settled write carrying an onSet hook (global atoms always
+ * carry a no-op marker hook). Global peer writes are applied first, then the
+ * hook runs, then every store propagates and notifies. Errors never interrupt a
+ * later phase; the first is rethrown last.
  */
 const finishAtomSet = <Value>(
     atom: Atom<Value>,
     value: Value,
     data: StoreData,
     updatedAtoms: Atom<any>[],
-    skipOnSet: boolean,
     source: "set" | "async-set",
 ) => {
-    // The overwhelmingly common path stays allocation-free.
-    if (skipOnSet || !isGlobalAtom(atom)) {
+    if (!isGlobalAtom(atom)) {
         let hasHookError = false
         let hookError: unknown
-        if (atom.onSet && !skipOnSet) {
-            try {
-                atom.onSet(value, data)
-            } catch (error) {
-                hasHookError = true
-                hookError = error
-            }
+        try {
+            atom.onSet!(value, data)
+        } catch (error) {
+            hasHookError = true
+            hookError = error
         }
         try {
             propagateAtomUpdate(updatedAtoms, data, false, undefined, source)
@@ -64,12 +61,10 @@ const finishAtomSet = <Value>(
     const errors = createCommitErrors()
     const globalUpdates = applyGlobalSets([[atom, value]], errors)
 
-    if (atom.onSet) {
-        try {
-            atom.onSet(value, data)
-        } catch (error) {
-            recordCommitError(errors, error)
-        }
+    try {
+        atom.onSet!(value, data)
+    } catch (error) {
+        recordCommitError(errors, error)
     }
 
     if (globalUpdates.size === 0) {
@@ -135,14 +130,20 @@ const handlePromise = <Value>(
             }
             setValueInData(atom, resolvedValue, data)
             resolvePendingDefault(atom, data, resolvedValue)
-            finishAtomSet(
-                atom,
-                resolvedValue,
-                data,
-                [atom],
-                skipOnSet,
-                "async-set",
-            )
+            if (atom.onSet && !skipOnSet) {
+                finishAtomSet(atom, resolvedValue, data, [atom], "async-set")
+            } else {
+                // Ordinary atoms retain the original inline, allocation-free
+                // propagation path. Only hook/global writes pay for phased
+                // error handling.
+                propagateAtomUpdate(
+                    [atom],
+                    data,
+                    false,
+                    undefined,
+                    "async-set",
+                )
+            }
         })
         // Chained .catch so errors thrown inside the fulfilled handler
         // (e.g. from atom.onSet) don't surface as unhandled rejections.
@@ -215,18 +216,17 @@ export const setAtom = <Value = any>(
     }
     syncValue = setValueInData(atom, syncValue, data)
     resolvePendingDefault(atom, data, syncValue)
+    let updatedAtoms: Atom<any>[]
     if (initializedAtomsSet && initializedAtomsSet.size > 0) {
         initializedAtomsSet.add(atom)
-        finishAtomSet(
-            atom,
-            syncValue,
-            data,
-            [...initializedAtomsSet],
-            skipOnSet,
-            "set",
-        )
+        updatedAtoms = [...initializedAtomsSet]
     } else {
-        finishAtomSet(atom, syncValue, data, [atom], skipOnSet, "set")
+        updatedAtoms = [atom]
+    }
+    if (atom.onSet && !skipOnSet) {
+        finishAtomSet(atom, syncValue, data, updatedAtoms, "set")
+    } else {
+        propagateAtomUpdate(updatedAtoms, data, false, undefined, "set")
     }
     return syncValue
 }

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -7,10 +7,9 @@ import {
     throwCommitError,
 } from "./commitErrors"
 import {
-    applyGlobalSets,
+    applyGlobalOnSets,
     beginGlobalCommit,
     endGlobalCommit,
-    type DeferredGlobalSet,
 } from "./globalAtomFanOut"
 import { createChangeSink, flushChangeSink } from "./notifyChangeListeners"
 import {
@@ -20,31 +19,49 @@ import {
 } from "./propagateUpdatedAtoms"
 import { runOnSets, writeAtoms, type DeferredOnSet } from "./writeAtoms"
 
+// Safe only with writeAtoms(skipOnSet=true), which cannot mutate this queue.
+// Reusing it keeps transactions without hooks/globals on the pre-fix
+// allocation profile.
+const noOnSets: DeferredOnSet[] = []
+
 export const setAtoms = (
     pairs: Map<Atom<any>, any>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     skipOnSet = false,
     report?: ChangeReport,
+    hasCommitEffects = true,
 ) => {
+    if (skipOnSet || !hasCommitEffects) {
+        const updatedAtoms = writeAtoms(
+            pairs,
+            data,
+            initializedAtomsSet,
+            true,
+            noOnSets,
+        )
+        if (updatedAtoms.length > 0) {
+            propagateAtomUpdate(updatedAtoms, data, false, undefined, report)
+        }
+        return
+    }
+
     const onSets: DeferredOnSet[] = []
-    const globalSets: DeferredGlobalSet[] = []
     const updatedAtoms = writeAtoms(
         pairs,
         data,
         initializedAtomsSet,
-        skipOnSet,
+        false,
         onSets,
-        globalSets,
     )
     const errors = createCommitErrors()
 
     // Complete global fan-out while still in the write phase. Only after every
     // peer has been attempted do user hooks run.
-    const globalUpdates = applyGlobalSets(globalSets, errors)
+    const globalUpdates = applyGlobalOnSets(onSets, errors)
     runOnSets(onSets, errors)
 
-    if (globalUpdates.size === 0) {
+    if (!globalUpdates || globalUpdates.size === 0) {
         if (updatedAtoms.length > 0) {
             try {
                 propagateAtomUpdate(

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -1,8 +1,24 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import type { ChangeReport } from "./notifyChangeListeners"
-import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
-import { writeAtoms } from "./writeAtoms"
+import {
+    createCommitErrors,
+    recordCommitError,
+    throwCommitError,
+} from "./commitErrors"
+import {
+    applyGlobalSets,
+    beginGlobalCommit,
+    endGlobalCommit,
+    type DeferredGlobalSet,
+} from "./globalAtomFanOut"
+import { createChangeSink, flushChangeSink } from "./notifyChangeListeners"
+import {
+    notifyDeferred,
+    propagateAtomUpdate,
+    type NotifyTarget,
+} from "./propagateUpdatedAtoms"
+import { runOnSets, writeAtoms, type DeferredOnSet } from "./writeAtoms"
 
 export const setAtoms = (
     pairs: Map<Atom<any>, any>,
@@ -11,8 +27,71 @@ export const setAtoms = (
     skipOnSet = false,
     report?: ChangeReport,
 ) => {
-    const updatedAtoms = writeAtoms(pairs, data, initializedAtomsSet, skipOnSet)
-    if (updatedAtoms.length > 0) {
-        propagateAtomUpdate(updatedAtoms, data, false, undefined, report)
+    const onSets: DeferredOnSet[] = []
+    const globalSets: DeferredGlobalSet[] = []
+    const updatedAtoms = writeAtoms(
+        pairs,
+        data,
+        initializedAtomsSet,
+        skipOnSet,
+        onSets,
+        globalSets,
+    )
+    const errors = createCommitErrors()
+
+    // Complete global fan-out while still in the write phase. Only after every
+    // peer has been attempted do user hooks run.
+    const globalUpdates = applyGlobalSets(globalSets, errors)
+    runOnSets(onSets, errors)
+
+    if (globalUpdates.size === 0) {
+        if (updatedAtoms.length > 0) {
+            try {
+                propagateAtomUpdate(
+                    updatedAtoms,
+                    data,
+                    false,
+                    undefined,
+                    report,
+                )
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+    } else {
+        // Fan-out is one logical commit: settle every store's selectors before
+        // firing any subscriber, and let no store's error starve a later store.
+        const notify: NotifyTarget = new Map()
+        const globalSink = createChangeSink(undefined, "set")
+        const commitRoots = beginGlobalCommit(data, globalUpdates)
+        // Global peer changes retain their historical direct-set metadata and
+        // are reported before the transaction origin.
+        for (const [peer, atoms] of globalUpdates) {
+            try {
+                propagateAtomUpdate(atoms, peer, false, notify, globalSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        if (updatedAtoms.length > 0) {
+            try {
+                propagateAtomUpdate(updatedAtoms, data, false, notify, report)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        try {
+            notifyDeferred(notify)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        try {
+            flushChangeSink(globalSink)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        endGlobalCommit(commitRoots, errors)
     }
+
+    throwCommitError(errors)
 }

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -330,7 +330,7 @@ describe("cross-scope transactions are atomically observable", () => {
             // The distinguishing test for deferral: writes run leaf-first, so the
             // scope atom is written BEFORE the root atom. If onSet fired inline
             // during the write loop it would observe the not-yet-written root
-            // value (0). Deferring every onSet to the notify phase — after all
+            // value (0). Deferring every onSet to the hook phase — after all
             // writes — guarantees it sees the fully-applied root value.
             const root = store()
             const S = root.scope("S")
@@ -350,18 +350,16 @@ describe("cross-scope transactions are atomically observable", () => {
             expect(seen).toEqual([7]) // never the inline-observed 0
         })
 
-        test("onSet still fires inline (mid-write-loop) for a non-scoped txn", () => {
-            // The single-store fast path is unchanged: onSet fires during the
-            // write loop, before subscribers, exactly as before.
+        test("onSet runs after all writes and before subscribers for a non-scoped txn", () => {
             const root = store()
             const order: string[] = []
-            const a = atom(0, {
-                name: "inline-a",
-                onSet: () => order.push("onSet:a"),
-            })
             const b = atom(0, {
-                name: "inline-b",
+                name: "deferred-b",
                 onSet: () => order.push("onSet:b"),
+            })
+            const a = atom(0, {
+                name: "deferred-a",
+                onSet: () => order.push(`onSet:a:b=${root.get(b)}`),
             })
             root.sub(a, () => order.push("sub:a"))
             root.sub(b, () => order.push("sub:b"))
@@ -371,8 +369,13 @@ describe("cross-scope transactions are atomically observable", () => {
                 t.set(b, 1)
             })
 
-            // Both onSets fire during the write loop, then subscribers.
-            expect(order).toEqual(["onSet:a", "onSet:b", "sub:a", "sub:b"])
+            // `a`'s hook sees `b`'s write even though `a` was staged first.
+            expect(order).toEqual([
+                "onSet:a:b=1",
+                "onSet:b",
+                "sub:a",
+                "sub:b",
+            ])
         })
     })
 

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -29,6 +29,17 @@ import {
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import { IS_PROD } from "./IS_PROD"
 import {
+    createCommitErrors,
+    recordCommitError,
+    throwCommitError,
+} from "./commitErrors"
+import {
+    applyGlobalSets,
+    beginGlobalCommit,
+    endGlobalCommit,
+    type DeferredGlobalSet,
+} from "./globalAtomFanOut"
+import {
     cloneAtomFamilyIndex,
     createAtomFamilyIndex,
     renderAtomFamilyIndex,
@@ -40,7 +51,7 @@ import {
     type NotifyTarget,
 } from "./propagateUpdatedAtoms"
 import { setAtoms } from "./setAtoms"
-import { writeAtoms, type DeferredOnSet } from "./writeAtoms"
+import { runOnSets, writeAtoms, type DeferredOnSet } from "./writeAtoms"
 
 /** One store's slot in a cross-scope commit. Collected root-first; written
  *  leaf-first (see commit) but notified root-first. */
@@ -51,6 +62,7 @@ type CommitWrite = {
     deleted: AtomFamilyAtom<any, any>[] | undefined
     unsetAtoms: Atom[] | undefined
     onSets: DeferredOnSet[]
+    globalSets: DeferredGlobalSet[]
 }
 
 // const findDependencies = (
@@ -402,28 +414,80 @@ export class Transaction {
     }
 
     private commitWork = (sink: ChangeSink | undefined) => {
-        // Single-store fast path: no scoped transactions to coordinate, so
-        // write-and-notify in one pass. onSet fires inline during the write loop.
+        // Single-store fast path: no scoped transactions to coordinate.
         if (!this._scopedTransactions) {
             const initializedAtomsSet = new Set<Atom>()
-            if (this._unsetSet?.size) {
-                // An unset empties this scope value, so it can't share the
-                // single-pass setAtoms path (which reports out of data.values).
-                // Write any set atoms, then detach + propagate the unsets into the
-                // same deferred notify so subscribers fire once with final state.
-                const notify: NotifyTarget = new Map()
-                const updatedAtoms = writeAtoms(
+            if (!this._unsetSet?.size && !this._deleteSet?.size) {
+                setAtoms(
                     this._atomMap,
                     this.data,
                     initializedAtomsSet,
+                    false,
+                    sink,
                 )
-                if (updatedAtoms.length > 0) {
-                    propagateAtomUpdate(updatedAtoms, this.data, false, notify, sink)
+                return
+            }
+
+            // Deletes/unsets require multiple propagation passes. Complete ALL
+            // mutations first, then hooks, then every propagation/notification.
+            const onSets: DeferredOnSet[] = []
+            const globalSets: DeferredGlobalSet[] = []
+            const updatedAtoms = writeAtoms(
+                this._atomMap,
+                this.data,
+                initializedAtomsSet,
+                false,
+                onSets,
+                globalSets,
+            )
+            const deleted = this._deleteSet?.size
+                ? [...this._deleteSet]
+                : undefined
+            if (this._deleteSet?.size) {
+                deleteAtomFamilyAtoms(this._deleteSet, this.data)
+            }
+            const unsetAtoms = this._unsetSet?.size
+                ? this.applyUnsets(this._unsetSet, this.data)
+                : []
+
+            const errors = createCommitErrors()
+            const globalUpdates = applyGlobalSets(globalSets, errors)
+            runOnSets(onSets, errors)
+
+            const notify: NotifyTarget = new Map()
+            const globalSink =
+                globalUpdates.size > 0
+                    ? createChangeSink(undefined, "set")
+                    : undefined
+            const commitRoots = globalSink
+                ? beginGlobalCommit(this.data, globalUpdates)
+                : []
+            // Global peers historically surface as direct `set` changes and
+            // report before the transaction origin.
+            for (const [peer, atoms] of globalUpdates) {
+                try {
+                    propagateAtomUpdate(atoms, peer, false, notify, globalSink)
+                } catch (error) {
+                    recordCommitError(errors, error)
                 }
-                if (this._deleteSet?.size) {
-                    deleteAtomFamilyAtoms(this._deleteSet, this.data)
+            }
+            if (updatedAtoms.length > 0) {
+                try {
+                    propagateAtomUpdate(
+                        updatedAtoms,
+                        this.data,
+                        false,
+                        notify,
+                        sink,
+                    )
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
+            }
+            if (deleted) {
+                try {
                     propagateDeletedAtoms(
-                        [...this._deleteSet],
+                        deleted,
                         this.data,
                         undefined,
                         undefined,
@@ -431,66 +495,59 @@ export class Transaction {
                         notify,
                         sink,
                     )
+                } catch (error) {
+                    recordCommitError(errors, error)
                 }
-                const unsetAtoms = this.applyUnsets(this._unsetSet, this.data)
-                if (unsetAtoms.length > 0) {
-                    // Atoms first (emitted as "unset"), then propagate with
-                    // reportAtoms=false so dependent-selector recomputes are
-                    // reported too (the atom value is gone from data.values, so it
-                    // must not also surface as a "set").
-                    if (sink) {
-                        for (const atom of unsetAtoms) {
-                            reportUnsetAtom(
-                                atom,
-                                this.data,
-                                effectiveValueAfterUnset(atom, this.data),
-                                sink,
-                            )
-                        }
-                    }
-                    propagateAtomUpdate(unsetAtoms, this.data, false, notify, sink, false, false)
-                }
-                notifyDeferred(notify)
-                // Re-delegate AFTER firing: the deferred notify fires the
-                // scope-local callback (which idempotently drops the delegate),
-                // so re-establishing the parent delegate must come last.
-                for (const atom of unsetAtoms) {
-                    reDelegateScopeSubscriptions(atom, this.data)
-                }
-            } else if (this._deleteSet?.size) {
-                // Updates and a delete in one single-store txn: a selector that
-                // depends on both an updated atom and the deleted family is
-                // reachable by the update pass (propagateAtomUpdate) and the
-                // delete pass (propagateDeletedAtoms). Defer subscriber
-                // notification across both passes so an observer never sees the
-                // update pass's value of a selector the delete pass recomputes
-                // (and vice versa). No cross-pass dedup guard: each pass
-                // re-derives its selectors against the fully-written state, so
-                // the later pass corrects any value the earlier one computed
-                // from a not-yet-final selector input. (See NotifyTarget.)
-                const notify: NotifyTarget = new Map()
-                const updatedAtoms = writeAtoms(
-                    this._atomMap,
-                    this.data,
-                    initializedAtomsSet,
-                )
-                if (updatedAtoms.length > 0) {
-                    propagateAtomUpdate(updatedAtoms, this.data, false, notify, sink)
-                }
-                deleteAtomFamilyAtoms(this._deleteSet, this.data)
-                propagateDeletedAtoms(
-                    [...this._deleteSet],
-                    this.data,
-                    undefined,
-                    undefined,
-                    undefined,
-                    notify,
-                    sink,
-                )
-                notifyDeferred(notify)
-            } else {
-                setAtoms(this._atomMap, this.data, initializedAtomsSet, false, sink)
             }
+            if (unsetAtoms.length > 0) {
+                if (sink) {
+                    for (const atom of unsetAtoms) {
+                        reportUnsetAtom(
+                            atom,
+                            this.data,
+                            effectiveValueAfterUnset(atom, this.data),
+                            sink,
+                        )
+                    }
+                }
+                try {
+                    propagateAtomUpdate(
+                        unsetAtoms,
+                        this.data,
+                        false,
+                        notify,
+                        sink,
+                        false,
+                        false,
+                    )
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
+            }
+            try {
+                notifyDeferred(notify)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+            if (globalSink) {
+                try {
+                    flushChangeSink(globalSink)
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
+                endGlobalCommit(commitRoots, errors)
+            }
+            // Re-delegate AFTER firing: the deferred scope-local callback
+            // idempotently drops its delegate, so the fresh parent delegate is
+            // established last even when a callback threw.
+            for (const atom of unsetAtoms) {
+                try {
+                    reDelegateScopeSubscriptions(atom, this.data)
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
+            }
+            throwCommitError(errors)
             return
         }
 
@@ -521,6 +578,7 @@ export class Transaction {
                 new Set<Atom>(),
                 false,
                 entry.onSets,
+                entry.globalSets,
             )
             if (txn._deleteSet?.size) {
                 deleteAtomFamilyAtoms(txn._deleteSet, entry.data)
@@ -533,18 +591,19 @@ export class Transaction {
             }
         }
 
-        // Every value across the tree is now applied. onSet hooks fire here, in
-        // the notify phase, so a hook reading any atom — root or scope — sees
-        // the fully-applied transaction. Fired root-first (matching the old
-        // model's order) and before any subscriber, preserving the
-        // long-standing onSet-before-subscribers ordering. (Deliberate
-        // placement: in the old model onSet fired mid-write-loop and a
-        // cross-scope hook could read a not-yet-written scope value. Deferring
-        // to here is the only placement consistent with atomicity.)
+        const errors = createCommitErrors()
+
+        // Global peers are writes too. Apply them all before entering the hook
+        // phase, preserving the root-first hook/fan-out order of the plan.
+        const globalSets: DeferredGlobalSet[] = []
+        for (const entry of plan) globalSets.push(...entry.globalSets)
+        const globalUpdates = applyGlobalSets(globalSets, errors)
+
+        // Every value across the tree and every global peer is now applied.
+        // Hooks fire root-first, all are attempted, and their first error is
+        // retained until propagation and notification have also completed.
         for (const entry of plan) {
-            for (const [atom, value, data] of entry.onSets) {
-                atom.onSet!(value, data)
-            }
+            runOnSets(entry.onSets, errors)
         }
 
         // One propagation pass per store, root-first (ancestors before
@@ -564,20 +623,45 @@ export class Transaction {
         // notification fires its subscriber exactly once. See the warning on
         // NotifyTarget for why a dedup guard must not come back.
         const notify: NotifyTarget = new Map()
+        const globalSink =
+            globalUpdates.size > 0
+                ? createChangeSink(undefined, "set")
+                : undefined
+        const commitRoots = globalSink
+            ? beginGlobalCommit(this.data, globalUpdates)
+            : []
+        // Global fan-out retains its public direct-set metadata and precedes
+        // the originating transaction's reports, as it did when fan-out lived
+        // inside the global atom's onSet wrapper.
+        for (const [data, atoms] of globalUpdates) {
+            try {
+                propagateAtomUpdate(atoms, data, false, notify, globalSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
         for (const { data, updatedAtoms, deleted, unsetAtoms } of plan) {
             if (updatedAtoms.length > 0) {
-                propagateAtomUpdate(updatedAtoms, data, false, notify, sink)
+                try {
+                    propagateAtomUpdate(updatedAtoms, data, false, notify, sink)
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
             }
             if (deleted) {
-                propagateDeletedAtoms(
-                    deleted,
-                    data,
-                    undefined,
-                    undefined,
-                    undefined,
-                    notify,
-                    sink,
-                )
+                try {
+                    propagateDeletedAtoms(
+                        deleted,
+                        data,
+                        undefined,
+                        undefined,
+                        undefined,
+                        notify,
+                        sink,
+                    )
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
             }
             if (unsetAtoms && unsetAtoms.length > 0) {
                 // Atoms first (emitted as "unset" via reportUnsetAtom), then
@@ -594,20 +678,49 @@ export class Transaction {
                         )
                     }
                 }
-                propagateAtomUpdate(unsetAtoms, data, false, notify, sink, false, false)
+                try {
+                    propagateAtomUpdate(
+                        unsetAtoms,
+                        data,
+                        false,
+                        notify,
+                        sink,
+                        false,
+                        false,
+                    )
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
             }
         }
-        notifyDeferred(notify)
+        try {
+            notifyDeferred(notify)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        if (globalSink) {
+            try {
+                flushChangeSink(globalSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+            endGlobalCommit(commitRoots, errors)
+        }
         // Re-delegate AFTER firing (notifyDeferred): the scope-local callback
         // idempotently drops its delegate when it fires, so the fresh parent
         // delegate must be (re)established last.
         for (const { data, unsetAtoms } of plan) {
             if (unsetAtoms) {
                 for (const atom of unsetAtoms) {
-                    reDelegateScopeSubscriptions(atom, data)
+                    try {
+                        reDelegateScopeSubscriptions(atom, data)
+                    } catch (error) {
+                        recordCommitError(errors, error)
+                    }
                 }
             }
         }
+        throwCommitError(errors)
     }
 
     // Depth-first pre-order: this store, then each nested scope. Produces a
@@ -621,6 +734,7 @@ export class Transaction {
             deleted: undefined,
             unsetAtoms: undefined,
             onSets: [],
+            globalSets: [],
         })
         if (this._scopedTransactions) {
             for (const [, scopedTxn] of this._scopedTransactions) {

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -34,10 +34,9 @@ import {
     throwCommitError,
 } from "./commitErrors"
 import {
-    applyGlobalSets,
+    applyGlobalOnSets,
     beginGlobalCommit,
     endGlobalCommit,
-    type DeferredGlobalSet,
 } from "./globalAtomFanOut"
 import {
     cloneAtomFamilyIndex,
@@ -62,7 +61,6 @@ type CommitWrite = {
     deleted: AtomFamilyAtom<any, any>[] | undefined
     unsetAtoms: Atom[] | undefined
     onSets: DeferredOnSet[]
-    globalSets: DeferredGlobalSet[]
 }
 
 // const findDependencies = (
@@ -106,6 +104,10 @@ export class Transaction {
     private _selectorDependencies: any
     private _selectorCache: any
     private _atomMap: Map<any, any>
+    // Global atoms always carry an onSet marker, so this one bit covers every
+    // write that needs phased hook/fan-out handling. Transactions containing
+    // only ordinary atoms retain the original allocation-light commit path.
+    private _hasCommitEffects = false
     constructor(
         data: StoreData,
         parentTransaction?: Transaction,
@@ -226,6 +228,9 @@ export class Transaction {
         // does NOT resolve it — the promise is stored as-is and never validated.
         resolved = validateSchema(atom, resolved, this.data)
         this._atomMap.set(atom, resolved)
+        if (!this._hasCommitEffects && atom.onSet) {
+            this._hasCommitEffects = true
+        }
         // A set supersedes an unset of the same atom buffered earlier in this txn
         // (last write wins, regardless of order). Symmetric to `unset` dropping
         // any buffered set.
@@ -263,6 +268,9 @@ export class Transaction {
             // Validate like Transaction.set so this path can't become an
             // unvalidated hole (promises are skipped by validateSchema).
             this._atomMap.set(atom, validateSchema(atom, value, this.data))
+            if (!this._hasCommitEffects && atom.onSet) {
+                this._hasCommitEffects = true
+            }
             this._unsetSet?.delete(atom)
         }
         index.rendered = null
@@ -346,6 +354,9 @@ export class Transaction {
             this.initializedAtomsSet,
         ) as V | Promise<V>
         this._atomMap.set(atom, value)
+        if (!this._hasCommitEffects && atom.onSet) {
+            this._hasCommitEffects = true
+        }
         // reset writes the default; it supersedes a buffered unset of the atom.
         this._unsetSet?.delete(atom)
         return value
@@ -424,6 +435,7 @@ export class Transaction {
                     initializedAtomsSet,
                     false,
                     sink,
+                    this._hasCommitEffects,
                 )
                 return
             }
@@ -431,14 +443,12 @@ export class Transaction {
             // Deletes/unsets require multiple propagation passes. Complete ALL
             // mutations first, then hooks, then every propagation/notification.
             const onSets: DeferredOnSet[] = []
-            const globalSets: DeferredGlobalSet[] = []
             const updatedAtoms = writeAtoms(
                 this._atomMap,
                 this.data,
                 initializedAtomsSet,
                 false,
                 onSets,
-                globalSets,
             )
             const deleted = this._deleteSet?.size
                 ? [...this._deleteSet]
@@ -451,24 +461,32 @@ export class Transaction {
                 : []
 
             const errors = createCommitErrors()
-            const globalUpdates = applyGlobalSets(globalSets, errors)
+            const globalUpdates = applyGlobalOnSets(onSets, errors)
             runOnSets(onSets, errors)
 
             const notify: NotifyTarget = new Map()
             const globalSink =
-                globalUpdates.size > 0
+                globalUpdates && globalUpdates.size > 0
                     ? createChangeSink(undefined, "set")
                     : undefined
             const commitRoots = globalSink
-                ? beginGlobalCommit(this.data, globalUpdates)
+                ? beginGlobalCommit(this.data, globalUpdates!)
                 : []
             // Global peers historically surface as direct `set` changes and
             // report before the transaction origin.
-            for (const [peer, atoms] of globalUpdates) {
-                try {
-                    propagateAtomUpdate(atoms, peer, false, notify, globalSink)
-                } catch (error) {
-                    recordCommitError(errors, error)
+            if (globalUpdates) {
+                for (const [peer, atoms] of globalUpdates) {
+                    try {
+                        propagateAtomUpdate(
+                            atoms,
+                            peer,
+                            false,
+                            notify,
+                            globalSink,
+                        )
+                    } catch (error) {
+                        recordCommitError(errors, error)
+                    }
                 }
             }
             if (updatedAtoms.length > 0) {
@@ -578,7 +596,6 @@ export class Transaction {
                 new Set<Atom>(),
                 false,
                 entry.onSets,
-                entry.globalSets,
             )
             if (txn._deleteSet?.size) {
                 deleteAtomFamilyAtoms(txn._deleteSet, entry.data)
@@ -595,9 +612,14 @@ export class Transaction {
 
         // Global peers are writes too. Apply them all before entering the hook
         // phase, preserving the root-first hook/fan-out order of the plan.
-        const globalSets: DeferredGlobalSet[] = []
-        for (const entry of plan) globalSets.push(...entry.globalSets)
-        const globalUpdates = applyGlobalSets(globalSets, errors)
+        let globalUpdates
+        for (const entry of plan) {
+            globalUpdates = applyGlobalOnSets(
+                entry.onSets,
+                errors,
+                globalUpdates,
+            )
+        }
 
         // Every value across the tree and every global peer is now applied.
         // Hooks fire root-first, all are attempted, and their first error is
@@ -624,20 +646,28 @@ export class Transaction {
         // NotifyTarget for why a dedup guard must not come back.
         const notify: NotifyTarget = new Map()
         const globalSink =
-            globalUpdates.size > 0
+            globalUpdates && globalUpdates.size > 0
                 ? createChangeSink(undefined, "set")
                 : undefined
         const commitRoots = globalSink
-            ? beginGlobalCommit(this.data, globalUpdates)
+            ? beginGlobalCommit(this.data, globalUpdates!)
             : []
         // Global fan-out retains its public direct-set metadata and precedes
         // the originating transaction's reports, as it did when fan-out lived
         // inside the global atom's onSet wrapper.
-        for (const [data, atoms] of globalUpdates) {
-            try {
-                propagateAtomUpdate(atoms, data, false, notify, globalSink)
-            } catch (error) {
-                recordCommitError(errors, error)
+        if (globalUpdates) {
+            for (const [data, atoms] of globalUpdates) {
+                try {
+                    propagateAtomUpdate(
+                        atoms,
+                        data,
+                        false,
+                        notify,
+                        globalSink,
+                    )
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
             }
         }
         for (const { data, updatedAtoms, deleted, unsetAtoms } of plan) {
@@ -734,7 +764,6 @@ export class Transaction {
             deleted: undefined,
             unsetAtoms: undefined,
             onSets: [],
-            globalSets: [],
         })
         if (this._scopedTransactions) {
             for (const [, scopedTxn] of this._scopedTransactions) {

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -1,11 +1,9 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
-import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import type { CommitErrors } from "./commitErrors"
 import { recordCommitError } from "./commitErrors"
 import { getState } from "./getState"
-import type { DeferredGlobalSet } from "./globalAtomFanOut"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 
@@ -41,7 +39,6 @@ export const writeAtoms = (
     initializedAtomsSet: Set<Atom>,
     skipOnSet: boolean,
     onSetQueue: DeferredOnSet[],
-    globalSetQueue: DeferredGlobalSet[],
 ): Atom[] => {
     const updatedAtoms: Atom[] = []
     for (let [atom, value] of pairs) {
@@ -65,11 +62,11 @@ export const writeAtoms = (
             if (currentIsPromise && !isPromiseLike(value)) {
                 resolvePendingDefault(atom, data, value)
             }
-            if (!skipOnSet) {
-                if (isGlobalAtom(atom)) {
-                    globalSetQueue.push([atom, value])
-                }
-                if (atom.onSet) onSetQueue.push([atom, value, data])
+            // Global atoms always carry a no-op marker hook, so one existing
+            // property read identifies every write that needs the phased slow
+            // path. Ordinary atoms avoid an Object.hasOwn/global check here.
+            if (!skipOnSet && atom.onSet) {
+                onSetQueue.push([atom, value, data])
             }
         } else {
             // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -1,14 +1,27 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
+import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
+import type { CommitErrors } from "./commitErrors"
+import { recordCommitError } from "./commitErrors"
 import { getState } from "./getState"
+import type { DeferredGlobalSet } from "./globalAtomFanOut"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 
-/** A deferred onSet invocation: the hook, the written value, and the store it
- *  was written to. Collected during the write phase of a cross-scope commit so
- *  hooks fire only once the whole tree has been written. */
+/** A deferred onSet invocation: the atom, written value, and originating store. */
 export type DeferredOnSet = [Atom<any>, any, StoreData]
+
+/** Run every hook in insertion order, retaining the first failure. */
+export const runOnSets = (onSets: DeferredOnSet[], errors: CommitErrors) => {
+    for (const [atom, value, data] of onSets) {
+        try {
+            atom.onSet!(value, data)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+}
 
 /**
  * Write phase for a single store. Applies every value in `pairs` to
@@ -17,19 +30,18 @@ export type DeferredOnSet = [Atom<any>, any, StoreData]
  * equality checks. This does NOT propagate — see `setAtoms` (single-store
  * fast path) or `Transaction.commit` (cross-scope path) for the notify pass.
  *
- * onSet handling:
- *  - `skipOnSet` true     → never fire onSet.
- *  - `onSetQueue` given    → defer onSet by pushing `[atom, value, data]`. The
- *    cross-scope commit uses this so a hook never observes a half-applied
- *    transaction — it fires only after every store's writes have landed.
- *  - otherwise             → fire onSet inline (single-store path, unchanged).
+ * Hook and global handling are deliberately collection-only. The caller first
+ * completes every local/global write, then runs `onSetQueue`, then propagates.
+ * This keeps a throwing hook from interrupting either the write or propagation
+ * phase.
  */
 export const writeAtoms = (
     pairs: Map<Atom<any>, any>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    skipOnSet = false,
-    onSetQueue?: DeferredOnSet[],
+    skipOnSet: boolean,
+    onSetQueue: DeferredOnSet[],
+    globalSetQueue: DeferredGlobalSet[],
 ): Atom[] => {
     const updatedAtoms: Atom[] = []
     for (let [atom, value] of pairs) {
@@ -41,10 +53,6 @@ export const writeAtoms = (
         if (!areEqual) {
             updatedAtoms.push(atom)
             value = setValueInData(atom, value, data)
-            if (atom.onSet && !skipOnSet) {
-                if (onSetQueue) onSetQueue.push([atom, value, data])
-                else atom.onSet(value, data)
-            }
             // Landing a settled value over a suspense placeholder must resolve
             // the held promise, exactly as setAtom does. Two gates, both load-
             // bearing (see resolvePendingDefault's contract):
@@ -56,6 +64,12 @@ export const writeAtoms = (
             //     so a later settled write can still resolve it.
             if (currentIsPromise && !isPromiseLike(value)) {
                 resolvePendingDefault(atom, data, value)
+            }
+            if (!skipOnSet) {
+                if (isGlobalAtom(atom)) {
+                    globalSetQueue.push([atom, value])
+                }
+                if (atom.onSet) onSetQueue.push([atom, value, data])
             }
         } else {
             // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope


### PR DESCRIPTION
## Summary

- ensure throwing `onSet` hooks cannot leave committed atoms with stale subscribed selectors
- apply all writes, collect hook errors, propagate and notify, then rethrow the first error across direct sets, transactions, and global fan-out
- preserve allocation-light fast paths for ordinary atoms and transactions; deferred hook/error/global bookkeeping is only created when commit effects are present
- open global commit boundaries once per affected store tree, even when fan-out spans multiple scopes
- add regression coverage for direct, async, scoped, transactional, global, and commit-boundary paths, plus a patch changeset

## Testing

- `bun run --cwd packages/valdres test` — 734 pass, 1 todo
- `bun run --cwd packages/valdres typecheck:types`
- `bunx tsc -p packages/valdres/tsconfig.json --noEmit`
- `cd packages/valdres && NODE_ENV=production bun test --timeout 60000 --concurrency 1 ./test/performance/transaction.bench.ts` — 7 pass
- GitHub Bencher gates — Bun and Node pass
- `git diff --check`