### PR TITLE
fix(valdres): preserve family identity across stores

### DIFF
--- a/.changeset/stable-family-identity.md
+++ b/.changeset/stable-family-identity.md
@@ -1,0 +1,12 @@
+---
+"valdres": patch
+---
+
+Preserve atom-family member identity when a member is deleted from one store or
+scope but remains in another. `store.del(member)` now removes only that store's
+membership instead of globally releasing the family's shared identity, matching
+transactional deletion and preventing two member objects for the same logical
+key.
+
+Atom-family identity caches now hold members weakly, so keeping identities stable
+across stores does not make the family retain every unused member forever.

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -11,6 +11,38 @@ describe("atomFamily", () => {
         expect(userAtomFamily(1)).toEqual(userAtomFamily(1))
     })
 
+    test("deleting from one store preserves identity retained by another store", () => {
+        const family = atomFamily((id: string) => `default:${id}`)
+        const store1 = store()
+        const store2 = store()
+        const member = family("shared")
+
+        store1.set(member, "store 1")
+        store2.set(member, "store 2")
+        store1.del(member)
+
+        expect(family("shared")).toBe(member)
+        expect(store1.get(family)).toStrictEqual([])
+        expect(store2.get(family)).toStrictEqual([member])
+        expect(store2.get(family("shared"))).toBe("store 2")
+    })
+
+    test("deleting from a scope preserves identity retained by its parent", () => {
+        const family = atomFamily((id: string) => `default:${id}`)
+        const root = store()
+        const scope = root.scope("scope")
+        const member = family("shared")
+
+        root.set(member, "root")
+        scope.set(member, "scope")
+        scope.del(member)
+
+        expect(family("shared")).toBe(member)
+        expect(root.get(family)).toStrictEqual([member])
+        expect(root.get(family("shared"))).toBe("root")
+        expect(scope.get(family)).toStrictEqual([])
+    })
+
     test("Simple default value", () => {
         const store1 = store()
         const userAtomFamily = atomFamily<number, string>("Foo")
@@ -337,10 +369,11 @@ describe("atomFamily", () => {
         expect(
             store1.get(todosAtomFamily).map(atom => atom.familyArgsStringified),
         ).toStrictEqual(["2", "3"])
-        // store.del() now also releases the entry from the family map
+        // Deletion is store-local. The shared identity remains available so a
+        // different store or scope cannot be stranded on another member object.
         expect(
             todosAtomFamily.__valdresAtomFamilyMap.keys().toArray(),
-        ).toStrictEqual(["2", "3"])
+        ).toStrictEqual(["1", "2", "3"])
     })
 
     test("reading a deleted family member resolves the default factory, not the raw function", () => {

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -11,7 +11,7 @@ describe("atomFamily", () => {
         expect(userAtomFamily(1)).toEqual(userAtomFamily(1))
     })
 
-    test("deleting from one store preserves identity retained by another store", () => {
+    test("deleting from one store preserves identity retained by another store", async () => {
         const family = atomFamily((id: string) => `default:${id}`)
         const store1 = store()
         const store2 = store()
@@ -19,6 +19,9 @@ describe("atomFamily", () => {
 
         store1.set(member, "store 1")
         store2.set(member, "store 2")
+        // Let the family cache convert its new strong entry to a WeakRef before
+        // deletion exercises the cross-store identity guarantee.
+        await Promise.resolve()
         store1.del(member)
 
         expect(family("shared")).toBe(member)

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -343,7 +343,7 @@ describe("atomFamily", () => {
         })
     })
 
-    test("release an atomFamily memeber", () => {
+    test("release an atomFamily member", () => {
         const store1 = store()
         const todosAtomFamily = atomFamily((id: string) => ({
             id,
@@ -355,9 +355,12 @@ describe("atomFamily", () => {
         expect(store1.get(todosAtomFamily)).toStrictEqual([])
         todosAtomFamily.release("1")
         expect(store1.get(todosAtomFamily)).toStrictEqual([])
-        store1.get(todosAtomFamily("1"))
-        store1.get(todosAtomFamily("2"))
-        store1.get(todosAtomFamily("3"))
+        const todo1 = todosAtomFamily("1")
+        const todo2 = todosAtomFamily("2")
+        const todo3 = todosAtomFamily("3")
+        store1.get(todo1)
+        store1.get(todo2)
+        store1.get(todo3)
         /**
          * TODO: Have to figure out how to correctly do release, have to include
          * store to release from the keys atom
@@ -365,12 +368,15 @@ describe("atomFamily", () => {
         expect(
             store1.get(todosAtomFamily).map(atom => atom.familyArgsStringified),
         ).toStrictEqual(["1", "2", "3"])
-        store1.del(todosAtomFamily("1"))
+        store1.del(todo1)
         expect(
             store1.get(todosAtomFamily).map(atom => atom.familyArgsStringified),
         ).toStrictEqual(["2", "3"])
         // Deletion is store-local. The shared identity remains available so a
         // different store or scope cannot be stranded on another member object.
+        expect(todosAtomFamily("1")).toBe(todo1)
+        expect(todosAtomFamily("2")).toBe(todo2)
+        expect(todosAtomFamily("3")).toBe(todo3)
         expect(
             todosAtomFamily.__valdresAtomFamilyMap.keys().toArray(),
         ).toStrictEqual(["1", "2", "3"])

--- a/packages/valdres/src/indexConstructor.ts
+++ b/packages/valdres/src/indexConstructor.ts
@@ -39,12 +39,12 @@ export const index = <
         // `get(family)` on every evaluation makes each store read its own correct
         // membership, and the cache lookup is never undefined for a live member.
         //
-        // A WeakMap (not a Map) keyed by the family-atom object: deleting a
-        // member calls family.release(...), so a deleted-and-recreated key mints
-        // a fresh atom identity; a strong Map would retain one dead entry per
-        // create/delete/recreate cycle (unbounded under churn). The WeakMap lets
-        // a released member's entry (and its predicate selector) become
-        // GC-eligible, bounding the cache by live membership.
+        // A WeakMap (not a Map) keyed by the family-atom object: the family's
+        // identity cache is weak-valued, so an unused or explicitly released
+        // member can eventually be recreated. A strong Map here would retain
+        // one dead entry per collected identity (unbounded under churn). The
+        // WeakMap lets that member's predicate selector become GC-eligible too,
+        // bounding the cache by live identities.
         const predicateSelectors = new WeakMap<
             AtomFamilyAtom<Value, FamilyArgs>,
             Selector<boolean>

--- a/packages/valdres/src/lib/WeakValueMap.ts
+++ b/packages/valdres/src/lib/WeakValueMap.ts
@@ -10,14 +10,12 @@ export class WeakValueMap<K, V extends WeakKey> {
     readonly [Symbol.toStringTag] = "Map"
 
     private readonly refs = new Map<K, WeakRef<V>>()
-    private readonly cleanup = new FinalizationRegistry<{
-        key: K
-        ref: WeakRef<V>
-    }>(({ key, ref }) => {
+    private readonly cleanup = new FinalizationRegistry<K>((key) => {
         // A key may have been explicitly released and recreated before the old
-        // member is finalized. Only remove the entry if it still points at the
-        // finalized member's WeakRef.
-        if (this.refs.get(key) === ref) this.refs.delete(key)
+        // member is finalized. Re-read the current ref so a stale callback
+        // never removes a live replacement.
+        const ref = this.refs.get(key)
+        if (ref?.deref() === undefined) this.refs.delete(key)
     })
 
     get size() {
@@ -30,15 +28,11 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     clear() {
-        for (const ref of this.refs.values()) this.cleanup.unregister(ref)
         this.refs.clear()
     }
 
     delete(key: K) {
-        const ref = this.refs.get(key)
-        if (!ref) return false
-        this.deleteRef(key, ref)
-        return true
+        return this.refs.delete(key)
     }
 
     get(key: K): V | undefined {
@@ -54,12 +48,12 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     set(key: K, value: V) {
-        const previous = this.refs.get(key)
-        if (previous) this.cleanup.unregister(previous)
-
         const ref = new WeakRef(value)
         this.refs.set(key, ref)
-        this.cleanup.register(value, { key, ref }, ref)
+        // Deliberately omit an unregister token. Tokenized registration is
+        // costly in JavaScriptCore, and stale callbacks are safe because
+        // cleanup rechecks the current ref for this key.
+        this.cleanup.register(value, key)
         return this
     }
 
@@ -123,7 +117,6 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     private deleteRef(key: K, ref: WeakRef<V>) {
-        this.cleanup.unregister(ref)
         // Do not delete a replacement installed for the same key while an
         // iterator was suspended between dereferencing and cleanup.
         if (this.refs.get(key) === ref) this.refs.delete(key)

--- a/packages/valdres/src/lib/WeakValueMap.ts
+++ b/packages/valdres/src/lib/WeakValueMap.ts
@@ -4,23 +4,18 @@
  * Atom-family keys are primitive/serialized values, so a WeakMap cannot be used
  * directly. Keeping WeakRefs as the values preserves a member's identity for as
  * long as a caller or store membership still retains it, without making the
- * family itself the lifetime owner of every member it has ever created.
+ * family itself the lifetime owner of every member it has ever created. Dead
+ * entries are swept lazily by lookup, iteration, and size reads so finalization
+ * callbacks never add unpredictable work to unrelated code.
  */
 export class WeakValueMap<K, V extends WeakKey> {
     readonly [Symbol.toStringTag] = "Map"
 
     private readonly refs = new Map<K, WeakRef<V>>()
-    private readonly cleanup = new FinalizationRegistry<K>((key) => {
-        // A key may have been explicitly released and recreated before the old
-        // member is finalized. Re-read the current ref so a stale callback
-        // never removes a live replacement.
-        const ref = this.refs.get(key)
-        if (ref?.deref() === undefined) this.refs.delete(key)
-    })
 
     get size() {
-        // Finalization callbacks are deliberately eventual. Sweep here so the
-        // observable Map surface never counts entries whose values are gone.
+        // Sweep here so the observable Map surface never counts entries whose
+        // values are gone.
         for (const [key, ref] of this.refs) {
             if (ref.deref() === undefined) this.deleteRef(key, ref)
         }
@@ -50,10 +45,6 @@ export class WeakValueMap<K, V extends WeakKey> {
     set(key: K, value: V) {
         const ref = new WeakRef(value)
         this.refs.set(key, ref)
-        // Deliberately omit an unregister token. Tokenized registration is
-        // costly in JavaScriptCore, and stale callbacks are safe because
-        // cleanup rechecks the current ref for this key.
-        this.cleanup.register(value, key)
         return this
     }
 

--- a/packages/valdres/src/lib/WeakValueMap.ts
+++ b/packages/valdres/src/lib/WeakValueMap.ts
@@ -1,0 +1,131 @@
+/**
+ * A Map-shaped cache that keeps its values weakly.
+ *
+ * Atom-family keys are primitive/serialized values, so a WeakMap cannot be used
+ * directly. Keeping WeakRefs as the values preserves a member's identity for as
+ * long as a caller or store membership still retains it, without making the
+ * family itself the lifetime owner of every member it has ever created.
+ */
+export class WeakValueMap<K, V extends WeakKey> {
+    readonly [Symbol.toStringTag] = "Map"
+
+    private readonly refs = new Map<K, WeakRef<V>>()
+    private readonly cleanup = new FinalizationRegistry<{
+        key: K
+        ref: WeakRef<V>
+    }>(({ key, ref }) => {
+        // A key may have been explicitly released and recreated before the old
+        // member is finalized. Only remove the entry if it still points at the
+        // finalized member's WeakRef.
+        if (this.refs.get(key) === ref) this.refs.delete(key)
+    })
+
+    get size() {
+        // Finalization callbacks are deliberately eventual. Sweep here so the
+        // observable Map surface never counts entries whose values are gone.
+        for (const [key, ref] of this.refs) {
+            if (ref.deref() === undefined) this.deleteRef(key, ref)
+        }
+        return this.refs.size
+    }
+
+    clear() {
+        for (const ref of this.refs.values()) this.cleanup.unregister(ref)
+        this.refs.clear()
+    }
+
+    delete(key: K) {
+        const ref = this.refs.get(key)
+        if (!ref) return false
+        this.deleteRef(key, ref)
+        return true
+    }
+
+    get(key: K): V | undefined {
+        const ref = this.refs.get(key)
+        if (!ref) return undefined
+        const value = ref.deref()
+        if (value === undefined) this.deleteRef(key, ref)
+        return value
+    }
+
+    has(key: K) {
+        return this.get(key) !== undefined
+    }
+
+    set(key: K, value: V) {
+        const previous = this.refs.get(key)
+        if (previous) this.cleanup.unregister(previous)
+
+        const ref = new WeakRef(value)
+        this.refs.set(key, ref)
+        this.cleanup.register(value, { key, ref }, ref)
+        return this
+    }
+
+    getOrInsert(key: K, defaultValue: V) {
+        const existing = this.get(key)
+        if (existing !== undefined) return existing
+        this.set(key, defaultValue)
+        return defaultValue
+    }
+
+    getOrInsertComputed(key: K, callback: (key: K) => V) {
+        const existing = this.get(key)
+        if (existing !== undefined) return existing
+        const value = callback(key)
+        this.set(key, value)
+        return value
+    }
+
+    entries(): MapIterator<[K, V]> {
+        return this.iterateEntries() as MapIterator<[K, V]>
+    }
+
+    keys(): MapIterator<K> {
+        return this.iterateKeys() as MapIterator<K>
+    }
+
+    values(): MapIterator<V> {
+        return this.iterateValues() as MapIterator<V>
+    }
+
+    forEach(
+        callback: (value: V, key: K, map: WeakValueMap<K, V>) => void,
+        thisArg?: unknown,
+    ) {
+        for (const [key, value] of this.entries()) {
+            callback.call(thisArg, value, key, this)
+        }
+    }
+
+    [Symbol.iterator]() {
+        return this.entries()
+    }
+
+    private *iterateEntries(): IterableIterator<[K, V]> {
+        for (const [key, ref] of this.refs) {
+            const value = ref.deref()
+            if (value === undefined) {
+                this.deleteRef(key, ref)
+            } else {
+                yield [key, value]
+            }
+        }
+    }
+
+    private *iterateKeys(): IterableIterator<K> {
+        for (const [key] of this.entries()) yield key
+    }
+
+    private *iterateValues(): IterableIterator<V> {
+        for (const [, value] of this.entries()) yield value
+    }
+
+    private deleteRef(key: K, ref: WeakRef<V>) {
+        this.cleanup.unregister(ref)
+        // Do not delete a replacement installed for the same key while an
+        // iterator was suspended between dereferencing and cleanup.
+        if (this.refs.get(key) === ref) this.refs.delete(key)
+    }
+}

--- a/packages/valdres/src/lib/WeakValueMap.ts
+++ b/packages/valdres/src/lib/WeakValueMap.ts
@@ -2,22 +2,32 @@
  * A Map-shaped cache that keeps its values weakly.
  *
  * Atom-family keys are primitive/serialized values, so a WeakMap cannot be used
- * directly. Keeping WeakRefs as the values preserves a member's identity for as
- * long as a caller or store membership still retains it, without making the
- * family itself the lifetime owner of every member it has ever created. Dead
- * entries are swept lazily by lookup, iteration, and size reads so finalization
- * callbacks never add unpredictable work to unrelated code.
+ * directly. Keeping only WeakRefs after the current job preserves a member's
+ * identity for as long as a caller or store membership still retains it,
+ * without making the family itself the lifetime owner of every member it has
+ * ever created. Dead entries are swept lazily by lookup, iteration, and size
+ * reads so finalization callbacks never add unpredictable work to unrelated
+ * code.
+ *
+ * New values stay strong until the next microtask checkpoint, then are weakened
+ * in one batch. This keeps synchronous family creation on the normal Map.set
+ * path and performs weak-ref conversion in one tight loop; the ECMAScript
+ * WeakRef model keeps newly dereferenced targets alive for the current job
+ * either way.
  */
 export class WeakValueMap<K, V extends WeakKey> {
     readonly [Symbol.toStringTag] = "Map"
 
-    private readonly refs = new Map<K, WeakRef<V>>()
+    private readonly refs = new Map<K, V | WeakRef<V>>()
+    private weakeningScheduled = false
 
     get size() {
         // Sweep here so the observable Map surface never counts entries whose
         // values are gone.
-        for (const [key, ref] of this.refs) {
-            if (ref.deref() === undefined) this.deleteRef(key, ref)
+        for (const [key, entry] of this.refs) {
+            if (entry instanceof WeakRef && entry.deref() === undefined) {
+                this.deleteRef(key, entry)
+            }
         }
         return this.refs.size
     }
@@ -31,10 +41,11 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     get(key: K): V | undefined {
-        const ref = this.refs.get(key)
-        if (!ref) return undefined
-        const value = ref.deref()
-        if (value === undefined) this.deleteRef(key, ref)
+        const entry = this.refs.get(key)
+        if (entry === undefined) return undefined
+        if (!(entry instanceof WeakRef)) return entry
+        const value = entry.deref()
+        if (value === undefined) this.deleteRef(key, entry)
         return value
     }
 
@@ -43,8 +54,8 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     set(key: K, value: V) {
-        const ref = new WeakRef(value)
-        this.refs.set(key, ref)
+        this.refs.set(key, value)
+        this.scheduleWeakening()
         return this
     }
 
@@ -89,12 +100,16 @@ export class WeakValueMap<K, V extends WeakKey> {
     }
 
     private *iterateEntries(): IterableIterator<[K, V]> {
-        for (const [key, ref] of this.refs) {
-            const value = ref.deref()
-            if (value === undefined) {
-                this.deleteRef(key, ref)
+        for (const [key, entry] of this.refs) {
+            if (entry instanceof WeakRef) {
+                const value = entry.deref()
+                if (value === undefined) {
+                    this.deleteRef(key, entry)
+                } else {
+                    yield [key, value]
+                }
             } else {
-                yield [key, value]
+                yield [key, entry]
             }
         }
     }
@@ -105,6 +120,19 @@ export class WeakValueMap<K, V extends WeakKey> {
 
     private *iterateValues(): IterableIterator<V> {
         for (const [, value] of this.entries()) yield value
+    }
+
+    private scheduleWeakening() {
+        if (this.weakeningScheduled) return
+        this.weakeningScheduled = true
+        queueMicrotask(() => {
+            this.weakeningScheduled = false
+            for (const [key, entry] of this.refs) {
+                if (!(entry instanceof WeakRef)) {
+                    this.refs.set(key, new WeakRef(entry))
+                }
+            }
+        })
     }
 
     private deleteRef(key: K, ref: WeakRef<V>) {

--- a/packages/valdres/src/lib/createAtomFamily.ts
+++ b/packages/valdres/src/lib/createAtomFamily.ts
@@ -7,6 +7,7 @@ import { equal } from "./equal"
 import { familyKey, type FamilyKey } from "./familyKey"
 import { globalAtom } from "./globalAtom"
 import { registerName } from "./registerName"
+import { WeakValueMap } from "./WeakValueMap"
 
 export const createAtomFamily = <
     Value extends any,
@@ -15,7 +16,7 @@ export const createAtomFamily = <
     defaultValue: AtomFamilyDefaultValue<Value, Args>,
     options?: AtomOptions<Value>,
 ) => {
-    const map = new Map<FamilyKey, AtomFamilyAtom<Value, Args>>()
+    const map = new WeakValueMap<FamilyKey, AtomFamilyAtom<Value, Args>>()
     // Hoist type checks to family creation time — avoid per-call overhead
     const isSelectorFamilyDefault = isSelectorFamily(defaultValue)
     const isFunctionDefault =

--- a/packages/valdres/src/lib/deleteFamilyAtom.ts
+++ b/packages/valdres/src/lib/deleteFamilyAtom.ts
@@ -10,8 +10,16 @@ export const deleteFamilyAtom = <
     data: StoreData,
 ) => {
     data.values.delete(atom)
-    if (atom.family) {
-        atom.family.release(...atom.familyArgs)
-    }
-    propagateDeletedAtoms([atom], data, undefined, undefined, undefined, undefined, "delete")
+    // Membership is store-local, while the family's identity cache is shared.
+    // Releasing here could strand another store on this member while
+    // family(...args) starts returning a different object for the same key.
+    propagateDeletedAtoms(
+        [atom],
+        data,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "delete",
+    )
 }

--- a/packages/valdres/src/lib/scopeFamilyTxnFuzz.test.ts
+++ b/packages/valdres/src/lib/scopeFamilyTxnFuzz.test.ts
@@ -17,12 +17,11 @@ import { index } from "../indexConstructor"
 // audited paths (see audit notes):
 //  - member values are 1..9 (never the family default 0) so `set` is always an
 //    unambiguous create/update (no equality short-circuit);
-//  - a deleted key is retired (never re-created) because deleteFamilyAtom calls
-//    family.release(...), minting a fresh identity whose key↔identity mapping is
-//    ambiguous across stores;
-//  - each level owns a DISJOINT key range, so deleteFamilyAtom's GLOBAL release
-//    can never strand another level on a stale identity. The chain is linear, so
-//    a key owned by level j is visible at level j and all DEEPER levels
+//  - a deleted key is retired (never re-created) to keep this oracle focused on
+//    propagation rather than adding a second lifecycle model for re-creation;
+//  - each level owns a DISJOINT key range, giving every key exactly one writer.
+//    The chain is linear, so a key owned by level j is visible at level j and all
+//    DEEPER levels
 //    (descendants inherit) and at no ancestor — making membership at level i
 //    exactly "every existing key owned by levels 0..i", with a single owner per
 //    key so its value is unambiguous. Inheritance across the full chain (the

--- a/packages/valdres/src/types/AtomFamily.ts
+++ b/packages/valdres/src/types/AtomFamily.ts
@@ -21,5 +21,7 @@ export type AtomFamily<
      *  the State union's dynamic mount-check uniform without runtime casts. */
     onMount?: never
     __valdresOnMount?: never
+    /** Shared weak-value identity cache. Its Map-shaped iteration surface only
+     *  exposes members that are still strongly reachable by a caller/store. */
     __valdresAtomFamilyMap: Map<FamilyKey, AtomFamilyAtom<Value, Args>>
 }

--- a/packages/valdres/src/utils/dehydrate.ts
+++ b/packages/valdres/src/utils/dehydrate.ts
@@ -16,9 +16,11 @@ import { isPromiseLike } from "./isPromiseLike"
  * `atoms: [name, value]` entry and every `name`d atomFamily gets one
  * `families: [name, args, value]` entry per member — in both cases only when
  * the state holds an own value in THIS store, so a freshly created per-request
- * store dehydrates to exactly the state that request touched (family member
- * caches are module-global and outlive per-request stores; the per-store value
- * check is what keeps requests apart). Unnamed state is not transferable;
+ * store dehydrates to exactly the state that request touched (family identity
+ * caches are module-global and shared across per-request stores; the per-store
+ * value check is what keeps requests apart). The cache is weak-valued, so it
+ * does not become the lifetime owner of unused members.
+ * Unnamed state is not transferable;
  * selectors are never included (they re-derive from hydrated atoms).
  *
  * Promise-pending values (in-flight async sets or unresolved async defaults)

--- a/packages/valdres/test/memoryleaks.test.ts
+++ b/packages/valdres/test/memoryleaks.test.ts
@@ -262,17 +262,15 @@ describe("memory leaks (atom families)", () => {
         expect(await detector.isLeaking()).toBe(false)
     })
 
-    test("unreleased family atom is retained in map", async () => {
+    test("unreferenced family atom is collected from the weak identity cache", async () => {
         const family = atomFamily<{ name: string }, [string]>(
             (...args) => ({ name: args[0] }),
         )
         let familyAtom: any = family("bob")
         const detector = new LeakDetector(familyAtom)
         familyAtom = undefined
-        // Without release(), the Map holds a reference
-        expect(await detector.isLeaking()).toBe(true)
-        // Clean up
-        family.release("bob")
+        expect(await detector.isLeaking()).toBe(false)
+        expect(family.__valdresAtomFamilyMap.has("bob")).toBe(false)
     })
 
     test("family atom value is collected after release and unsubscribe", async () => {
@@ -289,13 +287,15 @@ describe("memory leaks (atom families)", () => {
         expect(await detector.isLeaking()).toBe(false)
     })
 
-    test("store.del() releases family atom from family map", async () => {
+    test("store.del() preserves the shared family identity", () => {
         const store1 = store()
         const family = atomFamily<object, [number]>(() => ({}))
-        store1.set(family(1), { value: 1 })
+        const member = family(1)
+        store1.set(member, { value: 1 })
         expect(family.__valdresAtomFamilyMap.has(1)).toBe(true)
-        store1.del(family(1))
-        expect(family.__valdresAtomFamilyMap.has(1)).toBe(false)
+        store1.del(member)
+        expect(family(1)).toBe(member)
+        expect(family.__valdresAtomFamilyMap.has(1)).toBe(true)
     })
 })
 


### PR DESCRIPTION
## Summary

- keep `store.del(member)` local to the deleting store instead of releasing the shared family definition
- preserve one member identity across independent stores and nested scopes
- use a weak-value family cache so unused identities can still be garbage-collected
- batch new-entry weakening at the next microtask and sweep dead entries lazily
- add cross-store, scope, memory, and post-weakening regression coverage plus a patch changeset
- make the cache-key test retain its asserted members explicitly, addressing Copilot review feedback

## Why

A direct store deletion released the family cache entry globally. If another store or scope still retained that member, the next `family(key)` call created a second atom object for the same logical key. The retaining store remained keyed by the old identity, so callers using the new identity observed the default value instead of the retained value. Transactional deletion already avoided the global release, making the two deletion paths inconsistent.

## Performance

New members stay strongly cached for the current job, then one microtask converts the batch to `WeakRef` entries. This matches the ECMAScript weak-reference guarantee that a newly referenced target remains alive through the current job, keeps synchronous creation on the normal `Map.set` path, and preserves weak ownership afterward.

The conversion work is deferred rather than removed, and dead key/weak-ref metadata is pruned on key lookup, iteration, and `size` reads. The cache deliberately avoids `FinalizationRegistry`, whose callback work can spill into unrelated operations.

Same-runner CI medians against the PR base:

- Bun `atomFamily(id)`: 181.93 ns to 181.41 ns (-0.29%)
- Bun `selectorFamily(id)`: 169.88 ns to 152.24 ns (-10.38%)
- Node `atomFamily(id)`: 113.28 ns to 145.87 ns (+28.77%)
- Node `selectorFamily(id)`: 165.85 ns to 199.52 ns (+20.30%)

All measurements remain below the +50% regression boundary, and the Bencher check passes.

## Verification

- forced-GC red test: the old cache-key assertion received `[]` instead of `["1", "2", "3"]`
- fixed forced-GC check: retained members preserve all three identities and keys
- `bun --filter valdres test` — 730 passed, 1 todo, 0 failed
- `bun test src/atomFamily.test.ts test/memoryleaks.test.ts` — 63 passed, 0 failed
- Bun full benchmark lane — 43 passed, 0 failed
- Node full benchmark lane — 43 passed, 0 failed
- `bunx tsc -p tsconfig.json --noEmit`
- `bun run typecheck:types`
- `bun run build`
- Prettier and `git diff --check`
- CI and Bencher checks green
