### PR TITLE
fix(valdres): isolate async deps per evaluation

### DIFF
--- a/.changeset/async-shared-promise-deps.md
+++ b/.changeset/async-shared-promise-deps.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Keep async selector dependency reconciliation isolated per evaluation when
+multiple selectors or stores return the same Promise. Dependency data now lives
+on the existing evaluation context instead of a Promise-keyed global WeakMap,
+preventing one resolution handler from removing another evaluation's real edge
+while also reducing async tracking overhead.

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -242,9 +242,9 @@ describe("atom", () => {
         expect(callback.mock.calls.length).toBe(callCountAfterEval2)
     })
 
-    test("async selector: rejection cleans up pendingAsyncDeps", async () => {
+    test("async selector: rejection cleans up evaluation dependencies", async () => {
         // If an async selector rejects, the .catch() handler must clean up
-        // the pendingAsyncDeps entry so it doesn't leak. Verify by checking
+        // its evaluation dependency set so it doesn't leak. Verify by checking
         // that subsequent evaluations work correctly.
         const store1 = store()
         const onUnmount = mock(() => {})

--- a/packages/valdres/src/lib/asyncDependencyTracking.ts
+++ b/packages/valdres/src/lib/asyncDependencyTracking.ts
@@ -6,11 +6,6 @@ import { getState } from "./getState"
 import { isLive, mountTransitiveDeps, noteDependencyAdded, onLiveDependencyAdded } from "./mountAtom"
 import { noteDependencyGraphChanged } from "./noteDependencyGraphChanged"
 
-// Tracks all deps (sync + async) for each pending async selector evaluation.
-// Keyed by the Promise returned by the async selector. When the promise
-// resolves, handleSelectorResult reads this to reconcile stale deps.
-export const pendingAsyncDeps = new WeakMap<Promise<any>, Set<State>>()
-
 export class SuspendAndWaitForResolveError extends Error {
     promise: Promise<any>
     constructor(promise: Promise<any>) {

--- a/packages/valdres/src/lib/initSelector.crossStore.test.ts
+++ b/packages/valdres/src/lib/initSelector.crossStore.test.ts
@@ -81,4 +81,31 @@ describe("cross-store selector eval — module-level state audit", () => {
         expect(deps).toBeDefined()
         expect(deps!.has(b)).toBe(true)
     })
+
+    test("shared Promise keeps async dependency reconciliation isolated per store", async () => {
+        const dep1 = atom(1)
+        const dep2 = atom(2)
+        const s1 = store()
+        const s2 = store()
+        let resolve!: (value: number) => void
+        const sharedPromise = new Promise<number>(r => (resolve = r))
+        const sel = selector((get, { storeId }) => {
+            get(storeId === s1.data.id ? dep1 : dep2)
+            return sharedPromise
+        })
+
+        expect(s1.get(sel)).toBe(sharedPromise)
+        expect(s2.get(sel)).toBe(sharedPromise)
+
+        resolve(3)
+        await sharedPromise
+        await Promise.resolve()
+
+        const deps1 = s1.data.stateDependencies.get(sel) as Set<unknown>
+        const deps2 = s2.data.stateDependencies.get(sel) as Set<unknown>
+        expect(deps1.has(dep1)).toBe(true)
+        expect(deps1.has(dep2)).toBe(false)
+        expect(deps2.has(dep1)).toBe(false)
+        expect(deps2.has(dep2)).toBe(true)
+    })
 })

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -4,7 +4,10 @@ import { SelectorEvaluationError } from "../errors/SelectorEvaluationError"
 import type { Atom } from "../types/Atom"
 import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
+import type {
+    SelectorEvaluationContext,
+    StoreData,
+} from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
 import {
@@ -12,7 +15,6 @@ import {
     cleanUpRejectedPromise,
     getOrInitDependentsSet,
     lateGet,
-    pendingAsyncDeps,
 } from "./asyncDependencyTracking"
 import { getState } from "./getState"
 import { isLive, noteDependencyAdded, onLiveDependencyRemoved, unmountOrphanedDeps } from "./mountAtom"
@@ -86,7 +88,10 @@ export const evaluateSelector = <V>(
     const latestEvalContext = data.latestEvalContext
     const prevCtx = latestEvalContext.get(selector)
     if (prevCtx) prevCtx.revoked = true
-    const evalCtx = { revoked: false, preserveSignalOnRevoke: false }
+    const evalCtx: SelectorEvaluationContext = {
+        revoked: false,
+        preserveSignalOnRevoke: false,
+    }
     latestEvalContext.set(selector, evalCtx)
 
     if (circularDependencySet.has(selector)) {
@@ -148,10 +153,6 @@ export const evaluateSelector = <V>(
             }
         }
 
-        // Lazily populated: tracks ALL deps read during this evaluation (sync +
-        // async). Only allocated when the result turns out to be a promise.
-        let allDepsThisEval: Set<State> | undefined
-
         let result
         try {
             // @ts-ignore, @ts-todo
@@ -159,8 +160,8 @@ export const evaluateSelector = <V>(
                 // Deferred get calls (setTimeout, after await) use late binding
                 if (evaluationComplete) {
                     // Track for reconciliation (unless this is a stale closure)
-                    if (!evalCtx.revoked && allDepsThisEval) {
-                        allDepsThisEval.add(state)
+                    if (!evalCtx.revoked && evalCtx.asyncDeps) {
+                        evalCtx.asyncDeps.add(state)
                     }
                     if (evalCtx.revoked) {
                         // Stale closure — the selector has been re-evaluated since
@@ -290,14 +291,16 @@ export const evaluateSelector = <V>(
             data.stateDependencies.set(selector, updatedDependencies)
         }
 
-        // Store tracking set so handleSelectorResult can reconcile when the
-        // promise resolves. Only needed for native-promise selectors —
-        // SuspendAndWaitForResolveError re-evaluates via initSelector instead.
+        // Store the tracking set on this evaluation's identity so
+        // handleSelectorResult can reconcile when the promise resolves. A
+        // Promise may be shared by selectors or stores, so Promise identity is
+        // not a safe owner for this data. Only needed for native-promise
+        // selectors — SuspendAndWaitForResolveError re-evaluates via
+        // initSelector instead.
         if (isPromiseLike(result)) {
             // Build the tracking set from sync deps discovered so far. Late
             // `get` calls (after await) will add to this set dynamically.
-            allDepsThisEval = new Set<State>(updatedDeps)
-            pendingAsyncDeps.set(result, allDepsThisEval)
+            evalCtx.asyncDeps = new Set<State>(updatedDeps)
         }
 
         return result
@@ -359,32 +362,27 @@ export const handleSelectorResult = <Value>(
         // then we retry when the promise resolves.
         const evaluationContext = data.latestEvalContext.get(selector)
         value.then(resolved => {
+            // Take and clear this evaluation's dependency set up front. The
+            // latest context remains cached after resolution, so retaining the
+            // Set there would keep its dependency states alive unnecessarily.
+            const evalDeps = evaluationContext?.asyncDeps
+            if (evaluationContext) evaluationContext.asyncDeps = undefined
+
             // A graph entry can be recreated after this Promise was superseded;
             // use per-evaluation identity as the primary stale-result guard.
             if (
                 !evaluationContext ||
                 evaluationContext.revoked ||
                 data.latestEvalContext.get(selector) !== evaluationContext
-            ) {
-                pendingAsyncDeps.delete(value)
-                return
-            }
+            ) return
             // Guard: selector was cleaned up by unsubscribe GC
-            if (!data.stateDependencies.has(selector)) {
-                pendingAsyncDeps.delete(value)
-                return
-            }
+            if (!data.stateDependencies.has(selector)) return
             // Guard against stale promise
-            if (data.values.has(selector) && data.values.get(selector) !== value) {
-                pendingAsyncDeps.delete(value)
-                return
-            }
+            if (data.values.has(selector) && data.values.get(selector) !== value) return
 
             // Reconcile deps: remove any that were carried forward from a
             // previous evaluation but not read in this one.
-            const evalDeps = pendingAsyncDeps.get(value)
             if (evalDeps) {
-                pendingAsyncDeps.delete(value)
                 const currentDeps = data.stateDependencies.get(selector)
                 if (currentDeps) {
                     const selectorIsLive = isLive(selector, data)
@@ -411,7 +409,6 @@ export const handleSelectorResult = <Value>(
             // reported and we clean up so the invalid value never commits.
             // Consistent with the atom async paths.
             if (!validateResolvedValue(selector, resolved, data)) {
-                pendingAsyncDeps.delete(value as Promise<any>)
                 cleanUpRejectedPromise(selector, data, value as Promise<any>)
                 return
             }
@@ -451,7 +448,7 @@ export const handleSelectorResult = <Value>(
                 }
             }
         }).catch(() => {
-            pendingAsyncDeps.delete(value as Promise<any>)
+            if (evaluationContext) evaluationContext.asyncDeps = undefined
             cleanUpRejectedPromise(selector, data, value as Promise<any>)
         })
         return value

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -1,7 +1,16 @@
 import type { Selector } from "./Selector"
+import type { State } from "./State"
 import type { Store } from "./Store"
 import type { StoreChangeCallback } from "./StoreChangeCallback"
 import type { Subscription } from "./Subscription"
+
+export type SelectorEvaluationContext = {
+    revoked: boolean
+    preserveSignalOnRevoke: boolean
+    /** All dependencies read by this async evaluation. Kept on the evaluation
+     *  identity so two stores/selectors may safely return the same Promise. */
+    asyncDeps?: Set<State>
+}
 
 export type StoreData = {
     id: string
@@ -113,14 +122,11 @@ export type StoreData = {
      *  stores doesn't trigger a spurious cycle. Add at evaluateSelector
      *  entry, delete in `finally` — balanced over synchronous eval. */
     circularDepSet: WeakSet<Selector>
-    /** Latest evaluation context per selector for revoking deferred (post-
-     *  await) `get` calls from superseded evaluations. Per-store so that
-     *  store2 evaluating a shared selector doesn't silently strip dep
-     *  registration from store1's in-flight async eval. */
-    latestEvalContext: WeakMap<
-        Selector,
-        { revoked: boolean; preserveSignalOnRevoke: boolean }
-    >
+    /** Latest evaluation context per selector for owning async dependencies and
+     *  revoking deferred (post-await) `get` calls from superseded evaluations.
+     *  Per-store so one store evaluating a shared selector cannot interfere
+     *  with another store's in-flight async evaluation. */
+    latestEvalContext: WeakMap<Selector, SelectorEvaluationContext>
     /** Per-atom timestamp of the last value write, used for lazy
      *  maxAge revalidation when the atom is unmounted (no active timer
      *  to keep the cache fresh). Only populated for atoms with `maxAge`. */


### PR DESCRIPTION
## Summary

- move pending async selector dependencies from a Promise-keyed global `WeakMap` onto the existing per-evaluation context
- keep resolution, rejection, stale-evaluation, and unmount cleanup isolated when stores or selectors share a Promise
- add focused cross-store regression coverage and a patch changeset

## Staff engineering review

- **Correctness:** each resolution handler captures its own evaluation identity; existing stale/revoked/value guards remain intact, and dependency reconciliation still updates both graph directions and liveness
- **Lifetime:** the dependency set is cleared as soon as the evaluation settles, including rejection and stale-result paths
- **Performance:** the synchronous selector path has no runtime change; the async lifecycle removes the global `WeakMap.set/get/delete` traffic

## Verification

- `bun test --reporter=dots` — 729 passed, 1 existing todo
- `bun run build`
- `bun run build:types`
- `bun run typecheck:types`
- selector benchmark suite — 8 passed
- `bunx changeset status`
