### PR TITLE
fix(valdres): settle batched promise writes

### DIFF
--- a/.changeset/schema-validation.md
+++ b/.changeset/schema-validation.md
@@ -55,9 +55,6 @@ Design:
 
 Known limitations:
 
-- A **promise set inside `store.txn()`** is stored as-is and not auto-resolved
-  by the transaction (pre-existing behavior), so it is not validated on resolve.
-  Validate before setting, or set outside a transaction.
 - An invalid **async default/selector** drops its value (so a re-read re-inits) —
   the same as a rejecting async default. Under React Suspense a component that
   keeps re-reading will re-init/re-fetch; validate at the data boundary rather

--- a/.changeset/settle-batched-promise-writes.md
+++ b/.changeset/settle-batched-promise-writes.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Settle Promise-like atom writes consistently in direct, batched, and explicit
+transaction writes. Batched stores now replace the pending Promise with its
+validated resolved value, roll back rejected or invalid writes, ignore stale
+settlements, and notify subscribed selectors without leaving them in a retry
+loop.

--- a/docs/content/guides/schema-validation.mdx
+++ b/docs/content/guides/schema-validation.mdx
@@ -201,9 +201,6 @@ with hundreds of atoms.
 
 ## Limitations
 
-- **Promises set inside a transaction** are stored as-is and not auto-resolved
-  by the transaction, so they aren't validated on resolve. Validate before
-  setting, or set async values outside transactions.
 - **Async defaults under React Suspense:** an invalid async default drops its
   value (like a rejected one), so a component that keeps re-reading will
   re-initialize and re-fetch. Validate at the fetch boundary rather than

--- a/packages/valdres/src/lib/asyncWrite.test.ts
+++ b/packages/valdres/src/lib/asyncWrite.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+import type { Atom } from "../types/Atom"
+import type { Store } from "../types/Store"
+import { isPromiseLike } from "../utils/isPromiseLike"
+
+const flushMicrotasks = async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+}
+
+type WriteMode = {
+    name: string
+    createStore: () => Store
+    write: (
+        store1: Store,
+        valueAtom: Atom<number>,
+        value: number | PromiseLike<number>,
+    ) => void
+}
+
+const writeModes: WriteMode[] = [
+    {
+        name: "direct set",
+        createStore: () => store(),
+        write: (store1, valueAtom, value) => {
+            store1.set(valueAtom, value)
+        },
+    },
+    {
+        name: "batched set",
+        createStore: () => store({ batchUpdates: true }),
+        write: (store1, valueAtom, value) => {
+            store1.set(valueAtom, value)
+        },
+    },
+    {
+        name: "transactional set",
+        createStore: () => store(),
+        write: (store1, valueAtom, value) => {
+            store1.txn(txn => txn.set(valueAtom, value))
+        },
+    },
+]
+
+describe("async writes", () => {
+    test("batched set settles the atom and its subscribed selector", async () => {
+        const store1 = store({ batchUpdates: true })
+        const valueAtom = atom(1)
+        let evaluations = 0
+        const selectedValue = selector(get => {
+            evaluations++
+            return get(valueAtom)
+        })
+        expect(store1.get(selectedValue)).toBe(1)
+
+        const callback = mock(() => {})
+        const unsubscribe = store1.sub(selectedValue, callback)
+        let resolve!: (value: number) => void
+        const pending = new Promise<number>(done => {
+            resolve = done
+        })
+
+        store1.set(valueAtom, pending)
+        await flushMicrotasks()
+        expect(store1.get(valueAtom)).toBe(pending)
+        expect(isPromiseLike(store1.get(selectedValue))).toBe(true)
+
+        resolve(2)
+        await pending
+        await flushMicrotasks()
+
+        expect(store1.get(valueAtom)).toBe(2)
+        expect(store1.get(selectedValue)).toBe(2)
+        const settledEvaluations = evaluations
+        await flushMicrotasks()
+        expect(evaluations).toBe(settledEvaluations)
+        unsubscribe()
+    })
+
+    test("transactional set settles a promise value", async () => {
+        const store1 = store()
+        const valueAtom = atom(1)
+        const pending = Promise.resolve(2)
+
+        store1.txn(txn => {
+            // Transaction writes support the same Promise-like values as set().
+            txn.set(valueAtom, pending)
+        })
+        expect(store1.get(valueAtom)).toBe(pending)
+
+        await pending
+        await flushMicrotasks()
+
+        expect(store1.get(valueAtom)).toBe(2)
+    })
+
+    test("transactional async updater settles its returned promise", async () => {
+        const store1 = store()
+        const valueAtom = atom(1)
+
+        store1.txn(txn => {
+            txn.set(valueAtom, current => Promise.resolve(current + 1))
+        })
+        await flushMicrotasks()
+
+        expect(store1.get(valueAtom)).toBe(2)
+    })
+
+    test("an explicit commit adopts a bare thenable only once", async () => {
+        const store1 = store()
+        const valueAtom = atom(1)
+        let adoptions = 0
+        const thenable: PromiseLike<number> = {
+            then(onFulfilled) {
+                adoptions++
+                return Promise.resolve(
+                    onFulfilled ? onFulfilled(2) : (2 as any),
+                ) as any
+            },
+        }
+
+        store1.txn(txn => {
+            txn.set(valueAtom, thenable)
+            txn.commit()
+        })
+        await flushMicrotasks()
+
+        expect(adoptions).toBe(1)
+        expect(store1.get(valueAtom)).toBe(2)
+    })
+
+    for (const mode of writeModes) {
+        test(`${mode.name} rolls back rejection and ignores stale settlement`, async () => {
+            const store1 = mode.createStore()
+            const valueAtom = atom(1)
+            let reject!: (reason: Error) => void
+            const rejected = new Promise<number>((_, fail) => {
+                reject = fail
+            })
+
+            mode.write(store1, valueAtom, rejected)
+            await flushMicrotasks()
+            reject(new Error("boom"))
+            await rejected.catch(() => {})
+            await flushMicrotasks()
+            expect(store1.get(valueAtom)).toBe(1)
+
+            let resolve!: (value: number) => void
+            const stale = new Promise<number>(done => {
+                resolve = done
+            })
+            mode.write(store1, valueAtom, stale)
+            await flushMicrotasks()
+            mode.write(store1, valueAtom, 3)
+            await flushMicrotasks()
+            resolve(2)
+            await stale
+            await flushMicrotasks()
+            expect(store1.get(valueAtom)).toBe(3)
+        })
+
+        test(`${mode.name} calls onSet with only the resolved value`, async () => {
+            const onSet = mock(() => {})
+            const store1 = mode.createStore()
+            const valueAtom = atom(1, { onSet })
+            let resolve!: (value: number) => void
+            const pending = new Promise<number>(done => {
+                resolve = done
+            })
+
+            mode.write(store1, valueAtom, pending)
+            await flushMicrotasks()
+            expect(onSet).not.toHaveBeenCalled()
+
+            resolve(2)
+            await pending
+            await flushMicrotasks()
+            expect(onSet).toHaveBeenCalledTimes(1)
+            expect(onSet).toHaveBeenCalledWith(2, store1.data)
+        })
+
+        test(`${mode.name} adopts a bare thenable`, async () => {
+            const store1 = mode.createStore()
+            const valueAtom = atom(1)
+            const thenable: PromiseLike<number> & { adopted: boolean } = {
+                adopted: false,
+                then(onFulfilled) {
+                    this.adopted = true
+                    return Promise.resolve(
+                        onFulfilled ? onFulfilled(2) : (2 as any),
+                    ) as any
+                },
+            }
+
+            mode.write(store1, valueAtom, thenable)
+            await flushMicrotasks()
+
+            expect(store1.get(valueAtom)).toBe(2)
+            expect(thenable.adopted).toBe(true)
+        })
+
+        test(`${mode.name} settles an equal Promise pinned in a scope`, async () => {
+            const root = mode.createStore()
+            const scoped = root.scope("child")
+            const valueAtom = atom(1)
+            let resolve!: (value: number) => void
+            const pending = new Promise<number>(done => {
+                resolve = done
+            })
+
+            mode.write(root, valueAtom, pending)
+            await flushMicrotasks()
+            mode.write(scoped, valueAtom, pending)
+            await flushMicrotasks()
+
+            resolve(2)
+            await pending
+            await flushMicrotasks()
+            mode.write(root, valueAtom, 3)
+            await flushMicrotasks()
+
+            expect(root.get(valueAtom)).toBe(3)
+            expect(scoped.get(valueAtom)).toBe(2)
+        })
+
+        test(`${mode.name} re-inherits when an equal scoped Promise rejects`, async () => {
+            const root = mode.createStore()
+            const scoped = root.scope("child")
+            const valueAtom = atom(1)
+            let reject!: (reason: Error) => void
+            const pending = new Promise<number>((_, fail) => {
+                reject = fail
+            })
+
+            mode.write(root, valueAtom, pending)
+            await flushMicrotasks()
+            mode.write(scoped, valueAtom, pending)
+            await flushMicrotasks()
+
+            reject(new Error("boom"))
+            await pending.catch(() => {})
+            await flushMicrotasks()
+            expect(root.get(valueAtom)).toBe(1)
+            expect(scoped.get(valueAtom)).toBe(1)
+
+            mode.write(root, valueAtom, 3)
+            await flushMicrotasks()
+            expect(scoped.get(valueAtom)).toBe(3)
+        })
+    }
+})

--- a/packages/valdres/src/lib/coordinateAsyncWrite.ts
+++ b/packages/valdres/src/lib/coordinateAsyncWrite.ts
@@ -1,0 +1,68 @@
+import type { Atom } from "../types/Atom"
+import type { StoreData } from "../types/StoreData"
+import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
+import { resolvePendingDefault } from "./resolvePendingDefault"
+import { setValueInData } from "./setValueInData"
+import { unsetValue } from "./unsetValue"
+import { validateResolvedValue } from "./validateResolvedValue"
+
+/**
+ * Install and settle one asynchronous atom write.
+ *
+ * Both the direct set path and transaction commits route through here so
+ * Promise-like normalization, stale-write protection, rollback, resolved-value
+ * validation, onSet timing, suspense resolution, and propagation stay in lockstep.
+ * Callers remain responsible for the initial propagation of the pending value.
+ */
+export const coordinateAsyncWrite = <Value>(
+    atom: Atom<Value>,
+    value: PromiseLike<Value>,
+    currentValue: Value,
+    data: StoreData,
+    skipOnSet: boolean,
+): Promise<Value> => {
+    // Promise.resolve(realPromise) preserves the reference; bare thenables are
+    // normalized so the chained rejection handler below is always available.
+    const promise = Promise.resolve(value)
+    // An explicit scope write can equal the Promise it currently inherits. It
+    // still pins a local shadow, but if that Promise fails there is no settled
+    // fallback to pin; restore the pre-write structure by re-inheriting instead.
+    const rollbackInheritedWrite =
+        !!data.parent && !data.values.has(atom) && currentValue === value
+    setValueInData(atom, promise as Value, data)
+    const rollback = () => {
+        if (data.values.get(atom) !== promise) return
+        if (rollbackInheritedWrite) {
+            // Promise reactions run in registration order. Defer the unset one
+            // turn so the ancestor coordinator gets to restore its own fallback
+            // first even when a cross-scope transaction registered this child
+            // coordinator before the parent's (writes are leaf-first).
+            queueMicrotask(() => {
+                if (data.values.get(atom) === promise) unsetValue(atom, data)
+            })
+            return
+        }
+        setValueInData(atom, currentValue, data)
+        propagateAtomUpdate([atom], data, false, undefined, "async-set")
+    }
+    promise
+        .then(resolvedValue => {
+            // Last write wins, not last Promise to settle.
+            if (data.values.get(atom) !== promise) return
+            // Async validation cannot throw back to the original caller. Report
+            // the error and restore the value observed before this write.
+            if (!validateResolvedValue(atom, resolvedValue, data)) {
+                rollback()
+                return
+            }
+            setValueInData(atom, resolvedValue, data)
+            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
+            resolvePendingDefault(atom, data, resolvedValue)
+            propagateAtomUpdate([atom], data, false, undefined, "async-set")
+        })
+        // Chaining catch also contains errors from the fulfilled handler (for
+        // example, an onSet hook throwing) instead of leaking an unhandled
+        // rejection. Only an unresolved current write is eligible for rollback.
+        .catch(rollback)
+    return promise
+}

--- a/packages/valdres/src/lib/schemaValidation.test.ts
+++ b/packages/valdres/src/lib/schemaValidation.test.ts
@@ -469,6 +469,27 @@ describe("schema validation", () => {
             expect(store1.get(nameAtom)).toBe("hello")
         })
 
+        for (const mode of ["batched", "transactional"] as const) {
+            test(`${mode} async atom set is validated on resolve`, async () => {
+                const store1 = store(
+                    mode === "batched"
+                        ? { batchUpdates: true, schemaValidation: true }
+                        : { schemaValidation: true },
+                )
+                const nameAtom = atom("hello", { schema: z.string() })
+                store1.get(nameAtom)
+                const errors = await captureConsoleErrors(() => {
+                    const invalid = Promise.resolve(123 as any)
+                    if (mode === "batched") store1.set(nameAtom, invalid)
+                    else store1.txn(txn => txn.set(nameAtom, invalid))
+                })
+                expect(
+                    errors.some(e => e instanceof SchemaValidationError),
+                ).toBe(true)
+                expect(store1.get(nameAtom)).toBe("hello")
+            })
+        }
+
         test("async atom default: invalid resolved value is reported", async () => {
             const store1 = store({ schemaValidation: true })
             const nameAtom = atom(() => Promise.resolve(123 as any), {

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -2,52 +2,13 @@ import type { Atom } from "../types/Atom"
 import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
+import { coordinateAsyncWrite } from "./coordinateAsyncWrite"
 import { getState } from "./getState"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { isFunction } from "./isFunction"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
-import { validateResolvedValue } from "./validateResolvedValue"
 import { validateSchema } from "./validateSchema"
-
-const handlePromise = <Value>(
-    atom: Atom<Value>,
-    promise: Promise<Value>,
-    currentValue: Value,
-    data: StoreData,
-    skipOnSet: boolean,
-) => {
-    setValueInData(atom, promise as Value, data)
-    promise
-        .then(resolvedValue => {
-            // Stale promise guard: if another set() overwrote us, bail
-            if (data.values.get(atom) !== promise) return
-            // Async validation can't throw to the original caller (the promise
-            // was already returned), so it's reported and we revert — the
-            // invalid value never lands. Sync sets throw from store.set directly.
-            if (!validateResolvedValue(atom, resolvedValue, data)) {
-                if (data.values.get(atom) === promise) {
-                    setValueInData(atom, currentValue, data)
-                    propagateAtomUpdate([atom], data, false, undefined, "async-set")
-                }
-                return
-            }
-            setValueInData(atom, resolvedValue, data)
-            if (atom.onSet && !skipOnSet) atom.onSet(resolvedValue, data)
-            resolvePendingDefault(atom, data, resolvedValue)
-            propagateAtomUpdate([atom], data, false, undefined, "async-set")
-        })
-        // Chained .catch so errors thrown inside the fulfilled handler
-        // (e.g. from atom.onSet) don't surface as unhandled rejections.
-        .catch(() => {
-            // Only revert if the promise is still the current in-flight value;
-            // if a fulfilled handler partially updated state, the guard below
-            // lets us avoid clobbering it.
-            if (data.values.get(atom) !== promise) return
-            setValueInData(atom, currentValue, data)
-            propagateAtomUpdate([atom], data, false, undefined, "async-set")
-        })
-}
 
 export const setAtom = <Value = any>(
     atom: Atom<Value>,
@@ -72,9 +33,16 @@ export const setAtom = <Value = any>(
         // Promise.resolve(realPromise) returns the same reference, so this
         // is a no-op allocation for the common case.
         const promise = Promise.resolve(newValue) as Promise<Value>
-        // Same promise reference — no-op (matches equality check below)
-        if (currentValue === promise) return promise as Value
-        handlePromise(atom, promise, currentValue, data, skipOnSet)
+        // Same own promise reference is a no-op. In a scope that still reads
+        // through to its parent, however, an explicit equal set must pin a local
+        // shadow just like the settled-value branch below.
+        if (currentValue === promise) {
+            if (data.parent && !data.values.has(atom)) {
+                coordinateAsyncWrite(atom, promise, currentValue, data, skipOnSet)
+            }
+            return promise as Value
+        }
+        coordinateAsyncWrite(atom, promise, currentValue, data, skipOnSet)
         if (initializedAtomsSet && initializedAtomsSet.size > 0) {
             initializedAtomsSet.add(atom)
             propagateAtomUpdate([...initializedAtomsSet], data, false, undefined, "set")

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -715,11 +715,9 @@ describe("transaction", () => {
         expect(settled).toEqual({ kind: "resolved", value: "hello" })
     })
 
-    // Demonstrates the `!isPromiseLike(value)` half of the writeAtoms gate.
-    // The txn path does no async resolution, so storing an in-flight promise
-    // must NOT resolve the placeholder by adoption — that would consume it and
-    // strand it on a promise that never settles, so a later settled write
-    // could never resolve it. The placeholder must survive until a settled
+    // Storing an in-flight promise must NOT resolve the placeholder by adoption
+    // before that write settles — that would consume it and strand it if the
+    // user promise never resolves. The placeholder survives until a settled
     // value lands. Mirrors lib/setAtom.test.ts "sync set after in-flight async
     // set on empty atom resolves suspense promise" for the transaction path.
     test("txn set: in-flight promise does not consume the suspense placeholder", async () => {

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -3,6 +3,7 @@ import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { GetValue } from "../types/GetValue"
 import type { State } from "../types/State"
+import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import type { TransactionFn } from "../types/TransactionFn"
 import { deepFreeze } from "../utils/deepFreeze"
@@ -10,6 +11,7 @@ import { validateSchema } from "./validateSchema"
 import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
+import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
 import {
     detachOwnValue,
@@ -189,29 +191,35 @@ export class Transaction {
         }
     }
 
-    set = <V>(atom: Atom<V>, value: V | ((currentValue: V) => V)): V => {
+    set = <V>(atom: Atom<V>, value: SetAtomValue<V>): V => {
         if (!isAtom(atom)) throw new Error("Not an atom")
-        let resolved: V
+        let resolved: V | PromiseLike<V>
         if (isFunction(value)) {
             const currentValue = this.get(atom) as V
-            resolved = (value as (current: V) => V)(currentValue)
+            resolved = value(currentValue)
         } else {
             resolved = value
         }
 
-        // Freeze non-primitives so values are immutable within the transaction.
-        // Respect atom.mutable and production mode. Kept in sync with the inline
-        // freeze decision in setValueInData.ts (not shared, to avoid a call on the
-        // write hot path) — change both together.
-        if (!atom.mutable && !IS_PROD && resolved !== null && (typeof resolved === "object" || typeof resolved === "function")) {
-            resolved = deepFreeze(resolved) as V
+        // Freeze settled non-primitives so values are immutable within the
+        // transaction. Promise-like inputs are normalized by the async-write
+        // coordinator at commit and must remain usable until then. Respect
+        // atom.mutable and production mode. Kept inline (not shared, to avoid a
+        // call on the write hot path).
+        if (
+            !atom.mutable &&
+            !IS_PROD &&
+            resolved !== null &&
+            (typeof resolved === "object" || typeof resolved === "function") &&
+            !isPromiseLike(resolved)
+        ) {
+            resolved = deepFreeze(resolved)
         }
         // Validate at staging time (inside the txn body), not at commit: a
         // failure throws here, so the user's callback aborts and commit never
-        // runs — the transaction stays atomic. This also covers batched stores,
-        // whose set() routes through here. Caveat: a PROMISE value is skipped by
-        // validateSchema, and (unlike the non-txn setAtom path) the txn commit
-        // does NOT resolve it — the promise is stored as-is and never validated.
+        // runs — the transaction stays atomic. Promise-like values are skipped
+        // here and validated after settlement by coordinateAsyncWrite during the
+        // commit path. This also covers stores using implicit batched txns.
         resolved = validateSchema(atom, resolved, this.data)
         this._atomMap.set(atom, resolved)
         // A set supersedes an unset of the same atom buffered earlier in this txn
@@ -232,7 +240,7 @@ export class Transaction {
             index.renderedArray = null
             this.recursivelyUpdateAtomFamilyIndexes(atom.family)
         }
-        return resolved
+        return resolved as V
     }
 
     // @ts-ignore

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -1,6 +1,7 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isPromiseLike } from "../utils/isPromiseLike"
+import { coordinateAsyncWrite } from "./coordinateAsyncWrite"
 import { getState } from "./getState"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
@@ -35,35 +36,59 @@ export const writeAtoms = (
     for (let [atom, value] of pairs) {
         const currentValue = getState(atom, data, initializedAtomsSet)
         const currentIsPromise = isPromiseLike(currentValue)
-        const areEqual = currentIsPromise || isPromiseLike(value)
-            ? currentValue === value
-            : atom.equal(currentValue, value)
+        const valueIsPromise = isPromiseLike(value)
+        const areEqual =
+            currentIsPromise || valueIsPromise
+                ? currentValue === value
+                : atom.equal(currentValue, value)
         if (!areEqual) {
             updatedAtoms.push(atom)
-            value = setValueInData(atom, value, data)
-            if (atom.onSet && !skipOnSet) {
-                if (onSetQueue) onSetQueue.push([atom, value, data])
-                else atom.onSet(value, data)
-            }
-            // Landing a settled value over a suspense placeholder must resolve
-            // the held promise, exactly as setAtom does. Two gates, both load-
-            // bearing (see resolvePendingDefault's contract):
-            //   currentIsPromise   — a placeholder is always a promise, so a
-            //     non-promise prior value can't have one; skips the chain walk
-            //     on the common (non-promise) write, i.e. the benchmark hot path.
-            //   !isPromiseLike(value) — only resolve with a settled value;
-            //     storing an in-flight promise must not consume the placeholder,
-            //     so a later settled write can still resolve it.
-            if (currentIsPromise && !isPromiseLike(value)) {
-                resolvePendingDefault(atom, data, value)
+            if (valueIsPromise) {
+                const promise = coordinateAsyncWrite(
+                    atom,
+                    value,
+                    currentValue,
+                    data,
+                    skipOnSet,
+                )
+                // A bare thenable normalizes to a different Promise. Keep the
+                // transaction's staged entry in sync so an explicit commit
+                // followed by execute()'s auto-commit cannot adopt it twice.
+                if (promise !== value) pairs.set(atom, promise)
+                value = promise
+            } else {
+                value = setValueInData(atom, value, data)
+                if (atom.onSet && !skipOnSet) {
+                    if (onSetQueue) onSetQueue.push([atom, value, data])
+                    else atom.onSet(value, data)
+                }
+                // Landing a settled value over a suspense placeholder must
+                // resolve the held promise, exactly as setAtom does. The
+                // currentIsPromise gate keeps the common write path from walking
+                // the scope chain; an in-flight value took the async branch.
+                if (currentIsPromise) {
+                    resolvePendingDefault(atom, data, value)
+                }
             }
         } else {
             // We do this to ensure that if an atom was set in a scoped transaction but was the same we still override it in that scope
-            setValueInData(atom, value, data)
-            // No placeholder to resolve here: areEqual with a settled value
-            // means there was none (a placeholder is a promise, never equal to
-            // a settled value), and equal promises are the same reference — a
-            // no-op set, not a value landing.
+            if (valueIsPromise && data.parent && !data.values.has(atom)) {
+                // Pinning an inherited in-flight value creates a scope-local
+                // write. Give that shadow its own settlement coordinator; the
+                // ancestor's stale guard only updates the ancestor store.
+                const promise = coordinateAsyncWrite(
+                    atom,
+                    value,
+                    currentValue,
+                    data,
+                    skipOnSet,
+                )
+                if (promise !== value) pairs.set(atom, promise)
+            } else {
+                setValueInData(atom, value, data)
+            }
+            // No placeholder to resolve here: equal settled values have none,
+            // and an equal own promise is already coordinated by its first write.
         }
     }
     // Merge updatedAtoms and initializedAtomsSet without extra Set+spread

--- a/packages/valdres/src/types/TransactionInterface.ts
+++ b/packages/valdres/src/types/TransactionInterface.ts
@@ -2,12 +2,12 @@ import type { Atom } from "./Atom"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
 import type { GetValue } from "./GetValue"
 import type { ResetAtom } from "./ResetAtom"
+import type { SetAtom } from "./SetAtom"
 import type { StoreData } from "./StoreData"
-import type { SyncSetAtom } from "./SyncSetAtom"
 import type { TransactionFn } from "./TransactionFn"
 
 export type TransactionInterface = {
-    set: SyncSetAtom
+    set: SetAtom
     get: GetValue
     del: (atom: AtomFamilyAtom<any, any>) => void
     reset: ResetAtom


### PR DESCRIPTION
## Summary

- route Promise-like atom writes from direct sets, implicit batches, and explicit transactions through one async-write coordinator
- normalize thenables once, settle resolved values, validate before commit, roll back rejected or invalid writes, and ignore stale settlements
- preserve `onSet`, Suspense, selector propagation, and scoped-store semantics while keeping coordination off the synchronous production path

## Staff engineering review

- added the reported batched-store reproduction as a failing test before implementation
- found and fixed a second edge case where an explicit `txn.commit()` followed by `execute()`'s automatic commit adopted a bare thenable twice
- reviewed async ordering, last-write-wins behavior, scope inheritance, schema validation, public transaction types, and the synchronous transaction hot path; no remaining blockers

## Verification

- `bun run test`
- `bun run build`
- `bun run build:types`
- `bun --filter 'valdres' typecheck:types`
- `bun --filter 'valdres-svelte' lint:publish`
- `DRY_RUN=1 bash scripts/ci-publish.sh`
- production transaction benchmark: 7 passed, 0 failed

