### PR TITLE
fix(valdres): unify transaction selector evaluation

### DIFF
--- a/.changeset/transaction-selector-evaluator.md
+++ b/.changeset/transaction-selector-evaluator.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Make transaction selector reads use the standard selector evaluation boundary,
+including schema validation, cycle detection, abort options, wrapped errors,
+and async dependency tracking. Keep selector bookkeeping isolated from committed
+store state, invalidate transaction selector caches for every write operation,
+and reject Promise-like transaction callbacks before automatic commit.

--- a/docs/content/guides/transactions.mdx
+++ b/docs/content/guides/transactions.mdx
@@ -42,6 +42,22 @@ myStore.txn(set => {
 // Now subscribers fire once with fullName = "Jane Smith"
 ```
 
+## Synchronous callbacks
+
+Transaction callbacks must be synchronous. Returning a Promise or other
+thenable throws and aborts the automatic commit, because writes after an
+`await` cannot be part of the same atomic commit. Perform asynchronous work
+before the transaction, then apply its result synchronously:
+
+```ts
+const user = await fetchUser()
+
+myStore.txn(({ set }) => {
+    set(userAtom, user)
+    set(statusAtom, "ready")
+})
+```
+
 ## Updater functions
 
 Inside a transaction, `set` works the same as outside — you can pass values or updater functions:

--- a/packages/valdres-svelte/src/transaction.mdx
+++ b/packages/valdres-svelte/src/transaction.mdx
@@ -16,6 +16,10 @@ description: Svelte function for batching multiple writes in one commit
 
 Returns a transaction runner bound to the current context store, captured at component initialization. That capture is what makes it safe to call from an event handler — Svelte throws `lifecycle_outside_component` if you call `getContext` inside a handler. Writes inside the callback commit together, so subscribers and selectors observe one atomic update. Forwards core's optional devtools `name`.
 
+Callbacks must be synchronous. Returning a Promise or other thenable throws
+without automatically committing staged writes; await asynchronous work before
+calling the transaction runner.
+
 ## Usage
 
 ```svelte

--- a/packages/valdres/src/lib/asyncWrite.test.ts
+++ b/packages/valdres/src/lib/asyncWrite.test.ts
@@ -41,7 +41,9 @@ const writeModes: WriteMode[] = [
         name: "transactional set",
         createStore: () => store(),
         write: (store1, valueAtom, value) => {
-            store1.txn(txn => txn.set(valueAtom, value))
+            store1.txn(txn => {
+                txn.set(valueAtom, value)
+            })
         },
     },
 ]

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -537,6 +537,31 @@ export const handleSelectorResult = <Value>(
     }
 }
 
+// Keep the committed call shape monomorphic: passing unused overlay/runtime
+// arguments measurably deoptimizes Bun's ordinary selector hot path. This is a
+// thin boundary only; both committed and transactional reads still delegate to
+// the same evaluator and result handler below.
+const evaluateCommittedSelectorValue = <V>(
+    selector: Selector<V>,
+    data: StoreData,
+    initializedAtomsSet: Set<Atom>,
+    circularDependencySet: WeakSet<Selector>,
+) => {
+    let value
+    try {
+        value = evaluateSelector(
+            selector,
+            data,
+            initializedAtomsSet,
+            circularDependencySet,
+        )
+    } catch (error) {
+        if (error instanceof SelectorEvaluationError) error.track(selector)
+        throw error
+    }
+    return handleSelectorResult(value, selector, data)
+}
+
 export const initSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
@@ -544,11 +569,10 @@ export const initSelector = <V>(
     circularDependencySet: WeakSet<Selector> = data.circularDepSet,
 ): boolean => {
     const existingValue = data.values.get(selector)
-    const updatedValue = evaluateSelectorValue(
+    const updatedValue = evaluateCommittedSelectorValue(
         selector,
         data,
         initializedAtomsSet,
-        undefined,
         circularDependencySet,
     )
 

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -2,6 +2,7 @@ import { SchemaValidationError } from "../errors/SchemaValidationError"
 import { SelectorCircularDependencyError } from "../errors/SelectorCircularDependencyError"
 import { SelectorEvaluationError } from "../errors/SelectorEvaluationError"
 import type { Atom } from "../types/Atom"
+import type { GetValue } from "../types/GetValue"
 import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type {
@@ -64,14 +65,28 @@ export type DepsChange = {
     removed?: Set<State>
 }
 
+/** Selector bookkeeping owned by a read overlay rather than the committed
+ * store. Transactions keep this state local so an aborted speculative read
+ * cannot rewrite the store's dependency graph or publish an async result. */
+export type SelectorEvaluationRuntime = {
+    abortControllers: Map<Selector, AbortController | false>
+    latestEvalContext: Map<Selector, SelectorEvaluationContext>
+    stateDependencies: Map<Selector, Set<State>>
+    readOverlayActive: boolean
+}
+
 export const evaluateSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     circularDependencySet: WeakSet<Selector> = data.circularDepSet,
     depsChangeOut?: DepsChange,
+    readOverlay?: GetValue,
+    runtime?: SelectorEvaluationRuntime,
 ) => {
-    const currentDependencies = data.stateDependencies.get(selector)
+    const stateDependencies = runtime?.stateDependencies ?? data.stateDependencies
+    const abortControllers = runtime?.abortControllers ?? data.abortControllers
+    const currentDependencies = stateDependencies.get(selector)
     // Deduped set of deps read this evaluation. Using a Set (not an array)
     // makes change-detection robust to a dependency read MORE THAN ONCE in one
     // evaluation (e.g. `cond ? get(a) + get(b) : get(a) + get(a)`): comparing
@@ -85,7 +100,7 @@ export const evaluateSelector = <V>(
 
     // Revoke any previous late-binding closure for this selector so that
     // deferred get calls from old evaluations become read-only.
-    const latestEvalContext = data.latestEvalContext
+    const latestEvalContext = runtime?.latestEvalContext ?? data.latestEvalContext
     const prevCtx = latestEvalContext.get(selector)
     if (prevCtx) prevCtx.revoked = true
     const evalCtx: SelectorEvaluationContext = {
@@ -122,7 +137,7 @@ export const evaluateSelector = <V>(
         if ((selector.get as (...args: any[]) => any).length < 2) {
             options = getSyncOptions(data)
         } else {
-            const prev = data.abortControllers.get(selector)
+            const prev = abortControllers.get(selector)
             if (prev === false) {
                 // Known-sync selector — use cached options, no allocation
                 options = getSyncOptions(data)
@@ -144,7 +159,7 @@ export const evaluateSelector = <V>(
                                     controller.abort()
                                 }
                             } else {
-                                data.abortControllers.set(selector, controller)
+                                abortControllers.set(selector, controller)
                             }
                         }
                         return controller.signal
@@ -163,6 +178,14 @@ export const evaluateSelector = <V>(
                     if (!evalCtx.revoked && evalCtx.asyncDeps) {
                         evalCtx.asyncDeps.add(state)
                     }
+                    if (runtime) {
+                        if (!evalCtx.revoked) {
+                            runtime.stateDependencies.get(selector)?.add(state)
+                        }
+                        return readOverlay && runtime.readOverlayActive
+                            ? readOverlay(state)
+                            : getState(state, data, new Set<Atom>())
+                    }
                     if (evalCtx.revoked) {
                         // Stale closure — the selector has been re-evaluated since
                         // this closure was created. Read the value without
@@ -171,12 +194,14 @@ export const evaluateSelector = <V>(
                     }
                     return lateGet(state, selector, data)
                 }
-                const value = getState(
-                    state,
-                    data,
-                    initializedAtomsSet,
-                    circularDependencySet,
-                )
+                const value = readOverlay
+                    ? readOverlay(state)
+                    : getState(
+                          state,
+                          data,
+                          initializedAtomsSet,
+                          circularDependencySet,
+                      )
                 updatedDeps.add(state)
                 if (!depsChanged && (!currentDependencies || !currentDependencies.has(state))) {
                     depsChanged = true
@@ -208,7 +233,21 @@ export const evaluateSelector = <V>(
             depsChanged = true
         }
 
-        if (depsChanged || !currentDependencies) {
+        if (runtime && (depsChanged || !currentDependencies)) {
+            // The overlay graph tracks async dependencies and re-evaluations,
+            // but deliberately has no committed reverse edges or liveness.
+            const updatedDependencies = isAsyncResult
+                ? new Set<State<any>>(updatedDeps)
+                : updatedDeps
+            if (isAsyncResult && currentDependencies) {
+                for (const dep of currentDependencies) {
+                    updatedDependencies.add(dep)
+                }
+            }
+            stateDependencies.set(selector, updatedDependencies)
+        }
+
+        if (!runtime && (depsChanged || !currentDependencies)) {
             // Invalidate topology-sensitive teardown caches once for this
             // dependency-set materialization or change (including an empty
             // selector re-materialized after cleanup).
@@ -318,8 +357,13 @@ export const handleSelectorResult = <Value>(
     value: Value | Promise<Value> | SuspendAndWaitForResolveError,
     selector: Selector<Value>,
     data: StoreData,
+    runtime?: SelectorEvaluationRuntime,
 ) => {
     if (value instanceof SuspendAndWaitForResolveError) {
+        if (runtime) {
+            runtime.abortControllers.delete(selector)
+            return value.promise
+        }
         // The selector was suspended — it threw before completing, so no
         // meaningful async work was started with the current signal. Clear
         // the AbortController so that when the dependency resolves and
@@ -358,6 +402,32 @@ export const handleSelectorResult = <Value>(
         })
         return promise
     } else if (isPromiseLike(value)) {
+        if (runtime) {
+            const evaluationContext = runtime.latestEvalContext.get(selector)
+            value.then(resolved => {
+                const evalDeps = evaluationContext?.asyncDeps
+                if (evaluationContext) evaluationContext.asyncDeps = undefined
+                if (
+                    !evaluationContext ||
+                    evaluationContext.revoked ||
+                    runtime.latestEvalContext.get(selector) !== evaluationContext
+                ) return
+
+                // Reconcile carried async dependencies in the private graph.
+                if (evalDeps) {
+                    const currentDeps = runtime.stateDependencies.get(selector)
+                    if (currentDeps) {
+                        for (const dep of currentDeps) {
+                            if (!evalDeps.has(dep)) currentDeps.delete(dep)
+                        }
+                    }
+                }
+                validateResolvedValue(selector, resolved, data)
+            }).catch(() => {
+                if (evaluationContext) evaluationContext.asyncDeps = undefined
+            })
+            return value
+        }
         // When a promise is returned when initializing a selector we suspend,
         // then we retry when the promise resolves.
         const evaluationContext = data.latestEvalContext.get(selector)
@@ -458,7 +528,10 @@ export const handleSelectorResult = <Value>(
         // selectors that read options (arity >= 2); arity-<2 selectors bypass
         // the abortControllers path entirely, so don't pollute the map.
         if ((selector.get as (...args: any[]) => any).length >= 2) {
-            data.abortControllers.set(selector, false)
+            ;(runtime?.abortControllers ?? data.abortControllers).set(
+                selector,
+                false,
+            )
         }
         return validateSchema(selector, value, data)
     }
@@ -471,10 +544,11 @@ export const initSelector = <V>(
     circularDependencySet: WeakSet<Selector> = data.circularDepSet,
 ): boolean => {
     const existingValue = data.values.get(selector)
-    const updatedValue = evaluate(
+    const updatedValue = evaluateSelectorValue(
         selector,
         data,
         initializedAtomsSet,
+        undefined,
         circularDependencySet,
     )
 
@@ -492,23 +566,30 @@ export const initSelector = <V>(
     }
 }
 
-const evaluate = <V>(
+/** Evaluate through the store selector boundary, optionally using a read
+ * overlay and private bookkeeping for transactional reads. */
+export const evaluateSelectorValue = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    circularDependencySet: WeakSet<Selector>,
+    readOverlay?: GetValue,
+    circularDependencySet: WeakSet<Selector> = data.circularDepSet,
+    runtime?: SelectorEvaluationRuntime,
 ) => {
-    let tmpValue
+    let value
     try {
-        tmpValue = evaluateSelector(
+        value = evaluateSelector(
             selector,
             data,
             initializedAtomsSet,
             circularDependencySet,
+            undefined,
+            readOverlay,
+            runtime,
         )
-    } catch (e) {
-        if (e instanceof SelectorEvaluationError) e.track(selector)
-        throw e
+    } catch (error) {
+        if (error instanceof SelectorEvaluationError) error.track(selector)
+        throw error
     }
-    return handleSelectorResult<V>(tmpValue, selector, data)
+    return handleSelectorResult(value, selector, data, runtime)
 }

--- a/packages/valdres/src/lib/schemaValidation.test.ts
+++ b/packages/valdres/src/lib/schemaValidation.test.ts
@@ -481,7 +481,9 @@ describe("schema validation", () => {
                 const errors = await captureConsoleErrors(() => {
                     const invalid = Promise.resolve(123 as any)
                     if (mode === "batched") store1.set(nameAtom, invalid)
-                    else store1.txn(txn => txn.set(nameAtom, invalid))
+                    else store1.txn(txn => {
+                        txn.set(nameAtom, invalid)
+                    })
                 })
                 expect(
                     errors.some(e => e instanceof SchemaValidationError),

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -5,6 +5,9 @@ import { selector } from "../selector"
 import { store } from "../store"
 import { transaction } from "./transaction"
 import { index } from "../indexConstructor"
+import { SchemaValidationError } from "../errors/SchemaValidationError"
+import { SelectorCircularDependencyError } from "../errors/SelectorCircularDependencyError"
+import { SelectorEvaluationError } from "../errors/SelectorEvaluationError"
 
 /** Resolve to a promise's value if it settles within `ms`, else report it
  *  still pending — a bounded race so a hung suspense promise fails fast
@@ -144,6 +147,231 @@ describe("transaction", () => {
             expect(selectorCb1).toHaveBeenCalledTimes(4)
             expect(selectorCb2).toHaveBeenCalledTimes(2)
         })
+    })
+
+    test("transaction selectors use the normal options, validation, and error boundaries", () => {
+        const store1 = store()
+        let receivedOptions: any
+        const optionsSelector = selector((_get, options) => {
+            receivedOptions = options
+            return 1
+        })
+        const schemaFailure = new Error("not a number")
+        const invalidSelector = selector(() => "wrong", {
+            name: "invalid transaction selector",
+            schemaValidation: true,
+            schema: {
+                parse() {
+                    throw schemaFailure
+                },
+            },
+        })
+        const evaluationFailure = new Error("selector exploded")
+        const throwingSelector = selector(
+            () => {
+                throw evaluationFailure
+            },
+            { name: "throwing transaction selector" },
+        )
+
+        store1.txn(({ get }) => {
+            expect(get(optionsSelector)).toBe(1)
+            expect(receivedOptions).toEqual({
+                signal: expect.any(AbortSignal),
+                storeId: store1.data.id,
+            })
+
+            try {
+                get(invalidSelector)
+                throw new Error("expected selector validation to fail")
+            } catch (error) {
+                expect(error).toBeInstanceOf(SchemaValidationError)
+                expect((error as SchemaValidationError).cause).toBe(
+                    schemaFailure,
+                )
+            }
+
+            try {
+                get(throwingSelector)
+                throw new Error("expected selector evaluation to fail")
+            } catch (error) {
+                expect(error).toBeInstanceOf(SelectorEvaluationError)
+                expect((error as SelectorEvaluationError).cause).toBe(
+                    evaluationFailure,
+                )
+            }
+        })
+    })
+
+    test("transaction selector cycles use the normal cycle error", () => {
+        const store1 = store()
+        let circular: ReturnType<typeof selector>
+        circular = selector(get => get(circular), {
+            name: "transaction cycle",
+        })
+
+        expect(() =>
+            store1.txn(({ get }) => {
+                get(circular)
+            }),
+        ).toThrow(SelectorCircularDependencyError)
+    })
+
+    test("aborted transaction selector reads do not mutate committed selector state", async () => {
+        const store1 = store()
+        const useLeft = atom(false)
+        const left = atom("left")
+        const right = atom("right")
+        const selected = selector(get =>
+            get(useLeft) ? get(left) : get(right),
+        )
+        const asyncSelected = selector(get => Promise.resolve(get(selected)))
+
+        expect(store1.get(selected)).toBe("right")
+        const committedDependencies = new Set(
+            store1.data.stateDependencies.get(selected),
+        )
+
+        expect(() =>
+            store1.txn(txn => {
+                txn.set(useLeft, true)
+                expect(txn.get(selected)).toBe("left")
+                txn.get(asyncSelected)
+                throw new Error("abort")
+            }),
+        ).toThrow("abort")
+
+        await Promise.resolve()
+        expect(store1.get(useLeft)).toBe(false)
+        expect(store1.get(selected)).toBe("right")
+        expect(store1.data.stateDependencies.get(selected)).toEqual(
+            committedDependencies,
+        )
+        expect(store1.data.stateDependencies.has(asyncSelected)).toBe(false)
+        expect(store1.data.values.has(asyncSelected)).toBe(false)
+    })
+
+    test("transaction evaluator tracks async dependencies and aborts superseded work locally", async () => {
+        const store1 = store()
+        const count = atom(1)
+        let release!: () => void
+        const gate = new Promise<void>(resolve => {
+            release = resolve
+        })
+        const signals: AbortSignal[] = []
+        const asyncCount = selector((get, { signal }) => {
+            signals.push(signal)
+            return gate.then(() => get(count))
+        })
+        let transactionRef: any
+        let latest!: Promise<number>
+
+        store1.txn(txn => {
+            transactionRef = txn
+            txn.get(asyncCount)
+            txn.set(count, 2)
+            latest = txn.get(asyncCount) as Promise<number>
+        })
+
+        expect(signals).toHaveLength(2)
+        expect(signals[0].aborted).toBe(true)
+        expect(signals[1].aborted).toBe(false)
+
+        release()
+        expect(await latest).toBe(2)
+        expect(
+            transactionRef._selectorRuntime.stateDependencies
+                .get(asyncCount)
+                .has(count),
+        ).toBe(true)
+        expect(store1.data.stateDependencies.has(asyncCount)).toBe(false)
+        expect(store1.data.values.has(asyncCount)).toBe(false)
+    })
+
+    test("transaction selector continuations read current committed state", async () => {
+        const store1 = store()
+        const count = atom(1)
+        let release!: () => void
+        const gate = new Promise<void>(resolve => {
+            release = resolve
+        })
+        const asyncCount = selector(get => gate.then(() => get(count)))
+        let pending!: Promise<number>
+
+        store1.txn(txn => {
+            txn.set(count, 2)
+            pending = txn.get(asyncCount) as Promise<number>
+        })
+        store1.set(count, 3)
+        release()
+
+        expect(await pending).toBe(3)
+    })
+
+    test("every transaction write invalidates cached selector reads", () => {
+        const store1 = store()
+        const count = atom(1)
+        const users = atomFamily<string, [number]>()
+        const firstUser = users(1)
+        const secondUser = users(2)
+        const doubled = selector(get => get(count) * 2)
+        const userSummary = selector(get =>
+            get(users)
+                .map(member => get(member))
+                .join(","),
+        )
+
+        store1.set(count, 3)
+        store1.set(firstUser, "one")
+
+        store1.txn(txn => {
+            expect(txn.get(doubled)).toBe(6)
+            txn.reset(count)
+            expect(txn.get(doubled)).toBe(2)
+
+            txn.set(count, 4)
+            expect(txn.get(doubled)).toBe(8)
+            txn.unset(count)
+            expect(txn.get(doubled)).toBe(2)
+
+            expect(txn.get(userSummary)).toBe("one")
+            txn.batchSetFamilyAtoms(users, [[secondUser, "two"]])
+            expect(txn.get(userSummary)).toBe("one,two")
+            txn.del(firstUser)
+            expect(txn.get(userSummary)).toBe("two")
+        })
+    })
+
+    test("thenable transaction callbacks throw synchronously and never commit", async () => {
+        const store1 = store()
+        const count = atom(0)
+
+        expect(() =>
+            store1.txn(txn => {
+                txn.set(count, 1)
+                return { then() {} }
+            }),
+        ).toThrow("Transaction callbacks must be synchronous")
+        expect(store1.get(count)).toBe(0)
+
+        expect(() =>
+            store1.txn(txn => {
+                txn.set(count, 2)
+                return Promise.resolve()
+            }),
+        ).toThrow("Transaction callbacks must be synchronous")
+        expect(store1.get(count)).toBe(0)
+
+        expect(() =>
+            store1.txn(async txn => {
+                txn.set(count, 3)
+                await Promise.resolve()
+                txn.set(count, 4)
+            }),
+        ).toThrow("Transaction callbacks must be synchronous")
+
+        await Promise.resolve()
+        expect(store1.get(count)).toBe(0)
     })
 
     test("uninitialized selector reads txn state", () => {
@@ -523,7 +751,9 @@ describe("transaction", () => {
         })
 
         expect(store1.data.values.get(doc1)).toStrictEqual([1, 2])
-        expect(store1.data.scopes.get("foo")!.values.get(doc1)).toStrictEqual([1, 2, 3])
+        expect(store1.data.scopes.get("foo")!.values.get(doc1)).toStrictEqual([
+            1, 2, 3,
+        ])
         expect(
             store1.data.scopes.get("foo")!.scopes.get("bar")!.values.get(doc1),
         ).toStrictEqual([1, 2, 3, 4])

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -11,6 +11,7 @@ import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isSelector } from "../utils/isSelector"
+import { isPromiseLike } from "../utils/isPromiseLike"
 import {
     detachOwnValue,
     effectiveValueAfterUnset,
@@ -51,6 +52,10 @@ import {
 } from "./propagateUpdatedAtoms"
 import { setAtoms } from "./setAtoms"
 import { runOnSets, writeAtoms, type DeferredOnSet } from "./writeAtoms"
+import {
+    evaluateSelectorValue,
+    type SelectorEvaluationRuntime,
+} from "./initSelector"
 
 /** One store's slot in a cross-scope commit. Collected root-first; written
  *  leaf-first (see commit) but notified root-first. */
@@ -101,8 +106,9 @@ export class Transaction {
     private _initializedAtomsSet: any
     private _deleteSet: any
     private _unsetSet: Set<Atom<any>> | undefined
-    private _selectorDependencies: any
     private _selectorCache: any
+    private _selectorRuntime: SelectorEvaluationRuntime | undefined
+    private _selectorCircularDependencySet: WeakSet<any> | undefined
     private _atomMap: Map<any, any>
     // Global atoms always carry an onSet marker, so this one bit covers every
     // write that needs phased hook/fan-out handling. Transactions containing
@@ -181,21 +187,20 @@ export class Transaction {
         } else if (isSelector(state)) {
             if (this.dirty) {
                 this.selectorCache.clear()
-                this.selectorDependencies.clear()
                 this.dirty = false
             } else if (this.selectorCache.has(state)) {
                 // If the selector is cached and not dirty, return the cached value
                 return this.selectorCache.get(state)
             }
 
-            // @ts-ignore
-            const res = state.get(s => {
-                // Could we optimize this even further? Could we better track selector dependencies and if any of the deps are touched by the transaction?
-                if (!this.selectorDependencies.has(s)) {
-                    this.selectorDependencies.add(s)
-                }
-                return this.get(s)
-            }, this.data.id)
+            const res = evaluateSelectorValue(
+                state,
+                this.data,
+                this.initializedAtomsSet,
+                this.get,
+                this.selectorCircularDependencySet,
+                this.selectorRuntime,
+            )
             this.selectorCache.set(state, res)
             return res
         } else {
@@ -235,7 +240,7 @@ export class Transaction {
         // (last write wins, regardless of order). Symmetric to `unset` dropping
         // any buffered set.
         this._unsetSet?.delete(atom)
-        if (!this.dirty) this.dirty = true
+        this.invalidateSelectorCache()
 
         if (isFamilyAtom(atom)) {
             if (!this._atomMap.has(atom.family)) {
@@ -258,6 +263,7 @@ export class Transaction {
             // @ts-ignore
             this.cloneFamilyIntoTxn(family)
         }
+        this.invalidateSelectorCache()
         const index = this._atomMap.get(family).__index
         for (const [atom, value] of pairs) {
             if (atom.family !== family) {
@@ -296,6 +302,7 @@ export class Transaction {
         if (this._atomMap.has(atom)) {
             this._atomMap.delete(atom)
         }
+        this.invalidateSelectorCache()
     }
 
     unset = (atom: Atom) => {
@@ -306,6 +313,7 @@ export class Transaction {
         this._atomMap.delete(atom)
         if (!this._unsetSet) this._unsetSet = new Set()
         this._unsetSet.add(atom)
+        this.invalidateSelectorCache()
     }
 
     // Detach the own value + bookkeeping for each unset atom that actually had
@@ -359,13 +367,32 @@ export class Transaction {
         }
         // reset writes the default; it supersedes a buffered unset of the atom.
         this._unsetSet?.delete(atom)
+        this.invalidateSelectorCache()
         return value
     }
 
     execute = (callback: TransactionFn, autoCommit = true) => {
-        const result = callback(this)
-        if (autoCommit) this.txnCommit()
-        return result
+        // Reject native async callbacks before their synchronous prefix runs.
+        // The thenable check also covers transpiled async functions.
+        if (callback.constructor?.name === "AsyncFunction") {
+            throw new Error("Transaction callbacks must be synchronous")
+        }
+        if (this._selectorRuntime) this._selectorRuntime.readOverlayActive = true
+        try {
+            const result = callback(this)
+            if (isPromiseLike(result)) {
+                // Do not commit writes staged before the thenable was returned.
+                // Observe native Promise rejection to avoid an unhandled rejection.
+                if (result instanceof Promise) result.catch(() => {})
+                throw new Error("Transaction callbacks must be synchronous")
+            }
+            if (autoCommit) this.txnCommit()
+            return result
+        } finally {
+            if (this._selectorRuntime) {
+                this._selectorRuntime.readOverlayActive = false
+            }
+        }
     }
 
     private txnCommit = () => {
@@ -777,9 +804,27 @@ export class Transaction {
         return this._selectorCache
     }
 
-    private get selectorDependencies() {
-        if (!this._selectorDependencies) this._selectorDependencies = new Set()
-        return this._selectorDependencies
+    private invalidateSelectorCache() {
+        if (!this.dirty) this.dirty = true
+    }
+
+    private get selectorRuntime(): SelectorEvaluationRuntime {
+        if (!this._selectorRuntime) {
+            this._selectorRuntime = {
+                abortControllers: new Map(),
+                latestEvalContext: new Map(),
+                stateDependencies: new Map(),
+                readOverlayActive: true,
+            }
+        }
+        return this._selectorRuntime
+    }
+
+    private get selectorCircularDependencySet() {
+        if (!this._selectorCircularDependencySet) {
+            this._selectorCircularDependencySet = new WeakSet()
+        }
+        return this._selectorCircularDependencySet
     }
     private get deleteSet() {
         if (!this._deleteSet) this._deleteSet = new Set()

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -371,7 +371,10 @@ export class Transaction {
         return value
     }
 
-    execute = (callback: TransactionFn, autoCommit = true) => {
+    execute = <Callback extends TransactionFn>(
+        callback: Callback,
+        autoCommit = true,
+    ): ReturnType<Callback> => {
         // Reject native async callbacks before their synchronous prefix runs.
         // The thenable check also covers transpiled async functions.
         if (callback.constructor?.name === "AsyncFunction") {
@@ -379,7 +382,7 @@ export class Transaction {
         }
         if (this._selectorRuntime) this._selectorRuntime.readOverlayActive = true
         try {
-            const result = callback(this)
+            const result = callback(this) as ReturnType<Callback>
             if (isPromiseLike(result)) {
                 // Do not commit writes staged before the thenable was returned.
                 // Observe native Promise rejection to avoid an unhandled rejection.

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -13,7 +13,6 @@ import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
-import { isPromiseLike } from "../utils/isPromiseLike"
 import {
     detachOwnValue,
     effectiveValueAfterUnset,

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -382,11 +382,6 @@ export class Transaction {
         callback: Callback,
         autoCommit = true,
     ): ReturnType<Callback> => {
-        // Reject native async callbacks before their synchronous prefix runs.
-        // The thenable check also covers transpiled async functions.
-        if (callback.constructor?.name === "AsyncFunction") {
-            throw new Error("Transaction callbacks must be synchronous")
-        }
         if (this._selectorRuntime) this._selectorRuntime.readOverlayActive = true
         try {
             const result = callback(this) as ReturnType<Callback>

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -54,8 +54,9 @@ export type Store<T = StoreData> = {
      *  on a scope, reverts to the default on a root); no-op when the store holds
      *  no own value. See `UnsetAtom`. */
     unset: UnsetAtom
-    /** Run a transaction. An optional `name` is surfaced on the `meta` argument
-     *  of `store.onChange` callbacks for this commit (useful for dev tools). */
+    /** Run a synchronous transaction. Promise/thenable callbacks are rejected.
+     *  An optional `name` is surfaced on the `meta` argument of `store.onChange`
+     *  callbacks for this commit (useful for dev tools). */
     txn: (callback: TransactionFn, name?: string) => void
     scope: ScopeFn
     /** Subscribe to changes in this store and its descendant scopes. The callback

--- a/packages/valdres/src/types/TransactionFn.ts
+++ b/packages/valdres/src/types/TransactionFn.ts
@@ -1,3 +1,6 @@
 import type { Transaction } from "../lib/transaction"
 
-export type TransactionFn = (args: Transaction) => any
+/** A transaction callback runs to completion before its writes commit.
+ * Promise/thenable returns are rejected at runtime so writes after an `await`
+ * cannot be silently lost. */
+export type TransactionFn = (args: Transaction) => unknown

--- a/packages/valdres/test/performance/transaction.bench.ts
+++ b/packages/valdres/test/performance/transaction.bench.ts
@@ -4,9 +4,23 @@ import { createStore as jotaiCreateStore, atom as jotaiAtom } from "jotai"
 import { atom as valdresAtom } from "../../src/atom"
 import { selector as valdresSelector } from "../../src/selector"
 import { store as valdresCreateStore } from "../../src/store"
-import { compare } from "./bench-utils"
+import { compare, measureOne } from "./bench-utils"
 
 describe("transaction", () => {
+    test("staged write followed by selector read", async () => {
+        const vStore = valdresCreateStore()
+        const vAtom = valdresAtom(0)
+        const vSelector = valdresSelector(get => get(vAtom) + 1)
+        let value = 0
+
+        await measureOne("txn: staged set + selector read", () => {
+            vStore.txn(txn => {
+                txn.set(vAtom, ++value)
+                do_not_optimize(txn.get(vSelector))
+            })
+        })
+    })
+
     test("10 atoms × 10 selectors each, batch set + read all", async () => {
         const atomCount = 10
         const selectorsPerAtom = 10


### PR DESCRIPTION
## Summary

- route transaction selector reads through the standard selector evaluation boundary with a transactional read overlay
- keep dependency, abort, and async bookkeeping transaction-local so aborted reads cannot contaminate committed store state
- invalidate transaction selector caches for reset, unset, delete, and bulk family writes
- reject async and Promise-like transaction callbacks before automatic commit
- document the synchronous callback contract and add a patch changeset

## Staff engineering review

Confirmed this is a real correctness bug on `origin/main`: transaction reads passed a string as selector options, cycles overflowed the stack, non-set writes returned stale cached selector values, and Promise-like callbacks partially committed. Review also found and fixed a late-binding edge case so async selector continuations read current committed state after the transaction closes.

The shared evaluator uses private transaction bookkeeping rather than the committed selector graph, preserving transaction abort isolation while retaining validation, wrapped errors, cycle detection, abort handling, and async dependency tracking.

## Performance

- added `txn: staged set + selector read` to the benchmark suite
- measured the new path at ~792 ns/op locally
- three-run comparisons of the existing selector and transaction benchmarks against an untouched `origin/main` worktree showed no consistent hot-path regression; median movements were within normal local benchmark noise
- transaction selector reads are expected to cost more than the incomplete old path because they now perform the missing correctness work

## Verification

- `bun test --reporter=dots` — 744 pass, 1 existing todo
- `bunx tsc -p packages/valdres/tsconfig.json --noEmit`
- `bun run --cwd packages/valdres typecheck:types`
- `bun run docs:build`
- focused transaction regression suite — 36 pass, 1 existing todo
- transaction performance benchmark — 8 pass