### PR TITLE
fix(valdres): make subscription lifecycle exception-safe

### DIFF
--- a/.changeset/exception-safe-subscriptions.md
+++ b/.changeset/exception-safe-subscriptions.md
@@ -1,0 +1,7 @@
+---
+"valdres": patch
+---
+
+Roll back subscription and liveness state when `onMount` throws so a later
+subscription retries the mount. Keep orphaned selector graph and cache cleanup
+queued when lifecycle cleanup throws during unsubscribe.

--- a/packages/valdres/src/lib/livenessReconcileMountCleanup.test.ts
+++ b/packages/valdres/src/lib/livenessReconcileMountCleanup.test.ts
@@ -115,6 +115,44 @@ test("a nested cyclic region is collected when its subscribed parent leaves", ()
     expect(cleanups).toBe(1)
 })
 
+test("a throwing cyclic cleanup still queues orphaned graph cleanup", async () => {
+    const tracked = atom(0, {
+        name: "throwing-cycle.tracked",
+        onMount: () => () => {
+            throw new Error("cleanup boom")
+        },
+    })
+    const closeCycle = atom(false, { name: "throwing-cycle.close" })
+
+    let y: any
+    const x = selector(
+        get => {
+            get(tracked)
+            return get(y)
+        },
+        { name: "throwing-cycle.x" },
+    )
+    y = selector(get => (get(closeCycle) ? get(x) : 0), {
+        name: "throwing-cycle.y",
+    })
+    const root = selector(get => get(x), { name: "throwing-cycle.root" })
+    const s = store("throwing-cycle")
+    const unsubscribe = s.sub(root, () => {}, false)
+    s.set(closeCycle, true)
+
+    expect(s.data.stateDependencies.get(x)).toContain(y)
+    expect(s.data.stateDependencies.get(y)).toContain(x)
+    expect(() => unsubscribe()).toThrow("cleanup boom")
+
+    await Promise.resolve()
+    expect(s.data.stateDependencies.has(root)).toBe(false)
+    expect(s.data.stateDependencies.has(x)).toBe(false)
+    expect(s.data.stateDependencies.has(y)).toBe(false)
+    expect(s.data.values.has(root)).toBe(false)
+    expect(s.data.values.has(x)).toBe(false)
+    expect(s.data.values.has(y)).toBe(false)
+})
+
 test("acyclic dependency removals skip the exact cycle DFS", async () => {
     const chooseLeft = atom(true, { name: "cycle-gate.choose-left" })
     const source = atom(1, { name: "cycle-gate.source" })

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -474,6 +474,58 @@ describe("subscribe", () => {
         expect(rootStore.data.values.has(derived)).toBe(false)
     })
 
+    test("a failed mount rolls back the subscription so retry mounts again", () => {
+        const rootStore = store()
+        let mountCalls = 0
+        let cleanupCalls = 0
+        let shouldThrow = true
+        const mounted = atom(1, {
+            name: "failed-mount-rollback",
+            onMount: () => {
+                mountCalls++
+                if (shouldThrow) throw new Error("mount boom")
+                return () => {
+                    cleanupCalls++
+                }
+            },
+        })
+
+        expect(() => rootStore.sub(mounted, () => {})).toThrow("mount boom")
+        expect(rootStore.data.subscriptions.get(mounted)).toBeUndefined()
+
+        shouldThrow = false
+        const unsubscribe = rootStore.sub(mounted, () => {})
+        expect(mountCalls).toBe(2)
+
+        unsubscribe()
+        expect(cleanupCalls).toBe(1)
+    })
+
+    test("a throwing cleanup still queues orphaned graph cleanup", async () => {
+        const rootStore = store()
+        const mounted = atom(1, {
+            name: "throwing-cleanup-mounted",
+            onMount: () => () => {
+                throw new Error("cleanup boom")
+            },
+        })
+        const derived = selector(get => get(mounted) + 1, {
+            name: "throwing-cleanup-derived",
+        })
+
+        const unsubscribe = rootStore.sub(derived, () => {}, false)
+        expect(rootStore.data.stateDependencies.has(derived)).toBe(true)
+
+        expect(() => unsubscribe()).toThrow("cleanup boom")
+        await Promise.resolve()
+
+        expect(rootStore.data.stateDependencies.has(derived)).toBe(false)
+        expect(rootStore.data.values.has(derived)).toBe(false)
+        expect(rootStore.data.stateDependents.get(mounted)).not.toContain(
+            derived,
+        )
+    })
+
     test("unsubscribe cleans deep orphaned selector chains iteratively", async () => {
         const rootStore = store()
         const source = atom(1)

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -358,26 +358,48 @@ export const subscribe = <V>(
         }
     }
     subscribers.add(subscription)
-    if (subscribers.size === 1) {
-        // Skip scope-local timer installation: reaching the non-delegating
-        // branch in a scope means the atom was shadowed via `set()`, which
-        // we treat as a deliberate pin. Running an extra timer here would
-        // overwrite the shadow on the next tick and double the work for
-        // non-global maxAge atoms (which lack the refCount sharing that
-        // installMaxAgeTimer uses for global atoms).
-        if (isAtom(state) && state.maxAge !== undefined && !data.parent) {
-            installMaxAgeTimer(state, data)
+    const unsubscribeSubscription = () => {
+        if (!parentUnsubscribe) {
+            unsubscribe(state, subscription, data)
+            return
         }
-        // First direct subscriber: bump liveness through the dep graph.
-        // Selectors track this via stateDependencies; families have none.
-        if (!isFamily(state)) {
-            // First direct subscriber is an ADDITIVE liveness change — the
-            // incremental walk is correct here, including through cycles (each
-            // live dependent is counted once; the prev===0 guard visits each
-            // node the single time it flips live). Deps built lazily via get()
-            // after this subscribe are reconciled by getDefault's own pass.
-            onFirstDirectSubscriber(state as State, data)
-            mountTransitiveDeps(state, data)
+        // A delegated parent cleanup is user code and may throw. The local
+        // subscription still has to unwind in that case.
+        try {
+            parentUnsubscribe()
+        } finally {
+            unsubscribe(state, subscription, data)
+        }
+    }
+    if (subscribers.size === 1) {
+        try {
+            // Skip scope-local timer installation: reaching the non-delegating
+            // branch in a scope means the atom was shadowed via `set()`, which
+            // we treat as a deliberate pin. Running an extra timer here would
+            // overwrite the shadow on the next tick and double the work for
+            // non-global maxAge atoms (which lack the refCount sharing that
+            // installMaxAgeTimer uses for global atoms).
+            if (isAtom(state) && state.maxAge !== undefined && !data.parent) {
+                installMaxAgeTimer(state, data)
+            }
+            // First direct subscriber: bump liveness through the dep graph.
+            // Selectors track this via stateDependencies; families have none.
+            if (!isFamily(state)) {
+                // First direct subscriber is an ADDITIVE liveness change — the
+                // incremental walk is correct here, including through cycles (each
+                // live dependent is counted once; the prev===0 guard visits each
+                // node the single time it flips live). Deps built lazily via get()
+                // after this subscribe are reconciled by getDefault's own pass.
+                onFirstDirectSubscriber(state as State, data)
+                mountTransitiveDeps(state, data)
+            }
+        } catch (error) {
+            // Preserve the mount error if rollback encounters a secondary
+            // cleanup error.
+            try {
+                unsubscribeSubscription()
+            } catch {}
+            throw error
         }
     }
 
@@ -388,10 +410,5 @@ export const subscribe = <V>(
         data.subscriptionsRequireEqualCheck.set(state, true)
     }
 
-    return () => {
-        if (parentUnsubscribe) {
-            parentUnsubscribe()
-        }
-        unsubscribe(state, subscription, data)
-    }
+    return unsubscribeSubscription
 }

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -54,19 +54,35 @@ export const unsubscribe = <V>(
                 data.cycleRiskInClosure.has(state as State<V>) &&
                 regionHasCycle(state as State<V>, data)
             ) {
-                reconcileLivenessAfterChurn(new Set([state as State<V>]), data)
+                // Reconciliation can synchronously unmount a cyclic region, so
+                // its user cleanup needs the same exception-safe graph queue.
+                try {
+                    reconcileLivenessAfterChurn(
+                        new Set([state as State<V>]),
+                        data,
+                    )
+                } catch (error) {
+                    if (!isLive(state as State<V>, data)) {
+                        queueOrphanCleanup(state as State<V>, data)
+                    }
+                    throw error
+                }
             }
             // A live state keeps its full downward dependency closure live, so
             // neither orphan walk can do work. This is especially important for
             // wide fan-in: sibling subscriptions disappear while an aggregator
             // still keeps every shared branch live.
             if (!isLive(state as State<V>, data)) {
-                // User-visible lifecycle cleanup stays synchronous.
-                unmountOrphanedDeps(state as State<V>, data)
-                // Graph/value cleanup is intentionally microtask-batched so
-                // sibling roots share completed visits. Every public store
-                // operation flushes it first, preserving API-level cache reads.
-                queueOrphanCleanup(state as State<V>, data)
+                try {
+                    // User-visible lifecycle cleanup stays synchronous.
+                    unmountOrphanedDeps(state as State<V>, data)
+                } finally {
+                    // Graph/value cleanup is intentionally microtask-batched so
+                    // sibling roots share completed visits. Every public store
+                    // operation flushes it first, preserving API-level cache
+                    // reads. Queue even when user lifecycle cleanup throws.
+                    queueOrphanCleanup(state as State<V>, data)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Roll back a newly registered subscription through the normal disposer when first-mount work throws, preserving the original mount error and unwinding delegated scope subscriptions.
- Queue orphaned selector graph and cache cleanup even when synchronous lifecycle cleanup throws, including cyclic liveness reconciliation.
- Add red-first regressions for failed-mount retry and throwing cleanup, plus cyclic coverage and a patch changeset.

## Staff engineering review

- No outstanding correctness findings after review of error precedence, subscription/liveness invariants, scoped teardown, cyclic graphs, and re-entrancy.
- Common root-store disposal remains a direct call; exception handling is limited to first-mount and last-orphan paths.
- Plain atoms retain the zero-allocation orphan-cleanup fast path, and unsubscribe scaling tests pass.

## Testing

- `bun --filter valdres test` — 767 passed, 1 existing todo, 0 failed
- `bunx tsgo -p packages/valdres/tsconfig.json --noEmit --emitDeclarationOnly false`
- `bun --filter valdres typecheck:types`
- `bun --filter valdres build`