### PR TITLE
fix(valdres): share runtime across store facades

### DIFF
--- a/.changeset/share-storedata-runtime.md
+++ b/.changeset/share-storedata-runtime.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Share one internal runtime across every store facade backed by the same
+`StoreData`. Scope handles now act as lightweight detach leases over shared
+operations, so batched functional updates compose correctly, synchronous
+operations flush the common pending transaction, subscriber notifications
+coalesce once per microtask, and `onMount` writes participate in the same batch.

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -1,4 +1,5 @@
 import type { StoreData } from "../types/StoreData"
+import { STORE_RUNTIME } from "./storeRuntimeKey"
 
 let nextId = 0
 const generateId = () => "__valdres_store_" + nextId++
@@ -73,6 +74,9 @@ export function createStoreData(
     // allocate on first setAtom — eager just makes that explicit and avoids
     // touching the prototype getter on the hot path.
     data.pendingDefaults = new WeakMap()
+    // Reserve the private runtime slot eagerly to keep StoreData's hidden class
+    // stable. storeFromStoreData fills it immediately after creation.
+    data[STORE_RUNTIME] = undefined
     // Liveness-pass scratch, initialized here (not added lazily during the first
     // pass) so the StoreData hidden class is fixed at construction. Otherwise the
     // first getDefault/propagation pass adds these fields at runtime, transitions

--- a/packages/valdres/src/lib/sharedStoreRuntime.test.ts
+++ b/packages/valdres/src/lib/sharedStoreRuntime.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+
+const nextMicrotask = () =>
+    new Promise<void>(resolve => queueMicrotask(resolve))
+
+describe("shared StoreData runtime", () => {
+    test("scope consumers are leases over shared operations", () => {
+        const root = store()
+        const first = root.scope("shared")
+        const second = root.scope("shared")
+
+        expect(first.get).toBe(second.get)
+        expect(first.set).toBe(second.set)
+        expect(first.scope).toBe(second.scope)
+        expect(first.detach).not.toBe(second.detach)
+    })
+
+    test("scope leases compose functional updates in one pending transaction", async () => {
+        const root = store({ batchUpdates: true })
+        const first = root.scope("shared")
+        const second = root.scope("shared")
+        const count = atom(0)
+
+        first.set(count, current => current + 1)
+        second.set(count, current => current + 1)
+
+        expect(first.get(count)).toBe(2)
+        expect(second.get(count)).toBe(2)
+
+        await nextMicrotask()
+
+        expect(first.data.values.get(count)).toBe(2)
+    })
+
+    test("a synchronous operation through another lease flushes the shared transaction", async () => {
+        const root = store({ batchUpdates: true })
+        const first = root.scope("shared")
+        const second = root.scope("shared")
+        const count = atom(0)
+
+        first.set(count, 1)
+        second.reset(count)
+
+        await nextMicrotask()
+
+        expect(first.get(count)).toBe(0)
+    })
+
+    test("scope leases coalesce subscriber notifications", async () => {
+        const root = store({ batchUpdates: true })
+        const first = root.scope("shared")
+        const second = root.scope("shared")
+        const left = atom(0)
+        const right = atom(0)
+        const total = selector(get => get(left) + get(right))
+        const callback = mock(() => {})
+
+        first.sub(total, callback)
+        first.set(left, 1)
+        second.set(right, 1)
+
+        expect(callback).toHaveBeenCalledTimes(0)
+
+        await nextMicrotask()
+
+        expect(callback).toHaveBeenCalledTimes(1)
+        expect(first.get(total)).toBe(2)
+    })
+
+    test("nested lease reads share initialization coordination", () => {
+        const root = store()
+        const first = root.scope("shared")
+        const second = root.scope("shared")
+        const left = atom(1)
+        const right = atom(2)
+        const inner = selector(get => get(right))
+        const outer = selector(get => get(left) + second.get(inner))
+
+        expect(first.get(outer)).toBe(3)
+
+        // Init-only propagation keeps the public read target cached, but leaves
+        // another selector reached during the same initialization invalidated
+        // for lazy re-evaluation. The nested handle must not flush the shared
+        // init set before `outer` finishes installing its dependency edges.
+        expect(first.data.values.has(outer)).toBe(true)
+        expect(first.data.values.has(inner)).toBe(false)
+    })
+
+    test("the facade created for onMount shares pending writes", async () => {
+        const root = store({ batchUpdates: true })
+        const count = atom(0)
+        const mounted = atom(0)
+        mounted.onMount = mountedStore => {
+            mountedStore.set(count, current => current + 1)
+        }
+
+        root.set(count, current => current + 1)
+        const unsubscribe = root.sub(mounted, () => {})
+
+        await nextMicrotask()
+
+        expect(root.get(count)).toBe(2)
+        unsubscribe()
+    })
+})

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -28,6 +28,7 @@ import { resetAtom } from "./resetAtom"
 import { setAtom } from "./setAtom"
 import { setValueInData } from "./setValueInData"
 import { snapshot } from "./snapshot"
+import { STORE_RUNTIME } from "./storeRuntimeKey"
 import { subscribe } from "./subscribe"
 import { Transaction, transaction } from "./transaction"
 
@@ -76,11 +77,25 @@ export function storeFromStoreData(
     detach: () => void,
 ): ScopedStore
 export function storeFromStoreData(data: StoreData): Store
-export function storeFromStoreData(
-    data: StoreData,
-    detach?: () => void,
-) {
+export function storeFromStoreData(data: StoreData, detach?: () => void) {
+    const runtimeData = data as StoreData & { [STORE_RUNTIME]?: Store }
+    let runtime = runtimeData[STORE_RUNTIME]
+    if (!runtime) {
+        runtime = createStoreRuntime(data)
+        runtimeData[STORE_RUNTIME] = runtime
+    }
+    return detach ? createScopeLease(runtime, detach) : runtime
+}
+
+/**
+ * One facade runtime per StoreData. Besides avoiding a full set of method
+ * closures for every scope consumer, this makes the closure-owned init set and
+ * implicit transaction authoritative for every handle that reaches the same
+ * store data (including the internal handle mountAtom requests).
+ */
+const createStoreRuntime = (data: StoreData): Store => {
     const _initSet = new Set<Atom>()
+    let _initDepth = 0
 
     // --- Batched mode (implicit transaction) ---
     // When data.batchUpdates is true, sequential store.set() calls within
@@ -137,10 +152,17 @@ export function storeFromStoreData(
         // cache-miss path reaches here; cache hits returned above.
         const ownsLivenessSeeds = beginLivenessPass(data)
         let seedsToReconcile: Set<State> | null = null
+        _initDepth++
         try {
             res = getState(state, data, _initSet)
         } finally {
-            if (_initSet.size) {
+            _initDepth--
+            // A selector may call another handle for this same StoreData while
+            // it is evaluating. Keep every atom initialized by that nested read
+            // in the shared set until the outermost get has installed all of its
+            // dependency edges; propagating from the nested read would clear the
+            // set too early and miss those not-yet-committed edges.
+            if (_initDepth === 0 && _initSet.size) {
                 const atoms = [..._initSet]
                 _initSet.clear()
                 propagateAtomUpdate(atoms, data, true)
@@ -321,36 +343,35 @@ export function storeFromStoreData(
         }
     }) as ScopeFn
 
-    if (detach) {
-        return {
-            get,
-            set,
-            sub,
-            txn,
-            reset,
-            del,
-            unset,
-            data,
-            scope,
-            onChange,
-            onCommitEnd: storeOnCommitEnd,
-            snapshot: storeSnapshot,
-            detach,
-        } as ScopedStore
-    } else {
-        return {
-            get,
-            set,
-            sub,
-            txn,
-            reset,
-            del,
-            unset,
-            data,
-            scope,
-            onChange,
-            onCommitEnd: storeOnCommitEnd,
-            snapshot: storeSnapshot,
-        } as Store
+    return {
+        get,
+        set,
+        sub,
+        txn,
+        reset,
+        del,
+        unset,
+        data,
+        scope,
+        onChange,
+        onCommitEnd: storeOnCommitEnd,
+        snapshot: storeSnapshot,
     }
 }
+
+/** A scope consumer owns only its detach lease; all operations share runtime. */
+const createScopeLease = (runtime: Store, detach: () => void): ScopedStore => ({
+    get: runtime.get,
+    set: runtime.set,
+    sub: runtime.sub,
+    txn: runtime.txn,
+    reset: runtime.reset,
+    del: runtime.del,
+    unset: runtime.unset,
+    data: runtime.data,
+    scope: runtime.scope,
+    onChange: runtime.onChange,
+    onCommitEnd: runtime.onCommitEnd,
+    snapshot: runtime.snapshot,
+    detach,
+})

--- a/packages/valdres/src/lib/storeRuntimeKey.ts
+++ b/packages/valdres/src/lib/storeRuntimeKey.ts
@@ -1,0 +1,2 @@
+/** Private StoreData slot for the canonical facade/runtime. */
+export const STORE_RUNTIME = Symbol("valdres.storeRuntime")

--- a/packages/valdres/test/performance/scope.bench.ts
+++ b/packages/valdres/test/performance/scope.bench.ts
@@ -10,6 +10,18 @@ import { store as valdresCreateStore } from "../../src/store"
 // tracks and t-test-gates them like the rest of the suite, rather than only
 // printing to the console.
 describe("scope propagation", () => {
+    test("acquire and detach another handle for an existing scope", async () => {
+        const root = valdresCreateStore()
+        const anchor = root.scope("shared")
+
+        await measureOne("scope: acquire + detach existing scope lease", () => {
+            const lease = root.scope("shared")
+            lease.detach()
+        })
+
+        anchor.detach()
+    })
+
     test("set atom in root with 100 child scopes (no shadowing)", async () => {
         const root = valdresCreateStore()
         const a = valdresAtom(0)


### PR DESCRIPTION
## Summary

- keep one canonical facade runtime per StoreData
- share implicit batching and nested initialization coordination across scope handles and mount callbacks
- model scope consumers as lightweight operation leases with independent detach ownership
- add red-first regressions plus a Bencher metric for existing-scope lease acquisition
- add the required Valdres patch changeset

## Staff engineering review

Reviewed runtime ownership, nested read and error behavior, scope detach lifecycle, adapter facade overrides, garbage collection, hidden-class stability, and hot-path allocation. The review found and resolved the missing changeset and missing lease-allocation benchmark. No outstanding findings.

## Validation

- Core Valdres suite: 780 passed, 0 failed
- React bindings: 47 passed, 0 failed
- Jotai adapter: 117 passed, 0 failed
- Recoil adapter: 60 passed, 0 failed
- Full build and declaration build passed
- Type-level tests and changeset status passed
- Scope performance suite: 7 passed; existing-scope lease acquisition measured at 77ns locally
