### PR TITLE
fix(valdres): commit async selector settlements

### DIFF
--- a/.changeset/async-selector-commit.md
+++ b/.changeset/async-selector-commit.md
@@ -1,0 +1,7 @@
+---
+"valdres": patch
+---
+
+Treat successful async selector settlement as a commit. `onCommitEnd` now
+fires once after selector subscribers and `onChange`, while observer failures
+remain distinct from source-Promise rejection and are no longer swallowed.

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -35,6 +35,7 @@ import {
     hasSelectorChangeListener,
     reportSelectorChanges,
 } from "./notifyChangeListeners"
+import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import {
     propagateAtomUpdate,
     propagateDirtySelectors,
@@ -884,55 +885,68 @@ export const handleSelectorResult = <Value>(
                 cleanUpRejectedPromise(selector, data, value as Promise<any>)
                 return
             }
-            // @ts-ignore
-            setValueInData(selector, resolved, data)
-            const resolvedDependencies = data.stateDependencies.get(selector)
-            if (
-                resolvedDependencies &&
-                !data.selectorGraphActive.has(selector)
-            ) {
-                const current = recordColdSelectorCache(
-                    selector,
-                    resolvedDependencies,
-                    data,
-                    evalDependencyRevisions,
-                )
-                if (current) markColdSelectorCacheValidated(selector, data)
-            }
-            const dependents = data.stateDependents.get(selector)
-            const subs = data.subscriptions.get(selector)
-            if (
-                (subs && subs.size > 0) ||
-                (dependents && dependents.size > 0)
-            ) {
-                // Collect downstream selectors that recompute as a result, so a
-                // `{ selectors: true }` listener sees them alongside this
-                // selector. Off the hot path unless a selector listener exists on
-                // this store's chain (not merely some unrelated root store).
-                const changedSelectors =
-                    changeListenerRegistry.selectorCount !== 0 &&
-                    hasSelectorChangeListener(data)
-                        ? new Set<Selector>()
-                        : undefined
-                propagateDirtySelectors(
-                    [],
-                    new Set(dependents),
-                    data,
-                    new Set(subs),
-                    new Map(),
-                    false,
-                    undefined,
-                    changedSelectors,
-                )
-                if (changedSelectors) {
-                    // This selector itself just resolved from a pending promise
-                    // to `resolved` — a genuine value change. Report it (and the
-                    // downstream it triggered) as an "async-set" batch.
-                    changedSelectors.add(selector)
-                    reportSelectorChanges(changedSelectors, data, "async-set")
+            // Promise settlement is a standalone commit: the resolved value,
+            // downstream recomputation, subscribers, and onChange all precede
+            // one onCommitEnd notification. Preserve the zero-listener fast
+            // path used by synchronous propagation: one global counter read,
+            // with no root walk or tracking when nobody observes commit ends.
+            let commitRoot: StoreData | undefined
+            if (commitEndRegistry.count !== 0) commitRoot = beginCommit(data)
+            let completed = false
+            try {
+                // @ts-ignore
+                setValueInData(selector, resolved, data)
+                const resolvedDependencies = data.stateDependencies.get(selector)
+                if (
+                    resolvedDependencies &&
+                    !data.selectorGraphActive.has(selector)
+                ) {
+                    const current = recordColdSelectorCache(
+                        selector,
+                        resolvedDependencies,
+                        data,
+                        evalDependencyRevisions,
+                    )
+                    if (current) markColdSelectorCacheValidated(selector, data)
                 }
+                const dependents = data.stateDependents.get(selector)
+                const subs = data.subscriptions.get(selector)
+                if (
+                    (subs && subs.size > 0) ||
+                    (dependents && dependents.size > 0)
+                ) {
+                    // Collect downstream selectors that recompute as a result, so a
+                    // `{ selectors: true }` listener sees them alongside this
+                    // selector. Off the hot path unless a selector listener exists on
+                    // this store's chain (not merely some unrelated root store).
+                    const changedSelectors =
+                        changeListenerRegistry.selectorCount !== 0 &&
+                        hasSelectorChangeListener(data)
+                            ? new Set<Selector>()
+                            : undefined
+                    propagateDirtySelectors(
+                        [],
+                        new Set(dependents),
+                        data,
+                        new Set(subs),
+                        new Map(),
+                        false,
+                        undefined,
+                        changedSelectors,
+                    )
+                    if (changedSelectors) {
+                        // This selector itself just resolved from a pending promise
+                        // to `resolved` — a genuine value change. Report it (and the
+                        // downstream it triggered) as an "async-set" batch.
+                        changedSelectors.add(selector)
+                        reportSelectorChanges(changedSelectors, data, "async-set")
+                    }
+                }
+                completed = true
+            } finally {
+                if (commitRoot !== undefined) endCommit(commitRoot, !completed)
             }
-        }).catch(() => {
+        }, () => {
             if (evaluationContext) evaluationContext.asyncDeps = undefined
             if (evaluationContext)
                 evaluationContext.asyncDependencyRevisions = undefined

--- a/packages/valdres/src/lib/onCommitEnd.test.ts
+++ b/packages/valdres/src/lib/onCommitEnd.test.ts
@@ -283,4 +283,80 @@ describe("store.onCommitEnd", () => {
         expect(events).toEqual(["sub-selector", "commit-end"])
         unsub()
     })
+
+    test("async selector settlement is one commit after subscribers and onChange", async () => {
+        const store1 = store()
+        let resolve!: (value: number) => void
+        const asyncValue = selector(
+            () => new Promise<number>(r => (resolve = r)),
+        )
+        const events: string[] = []
+        const subscriberDepths: number[] = []
+        const unsubSelector = store1.sub(asyncValue, () => {
+            events.push("subscriber")
+            subscriberDepths.push(store1.data.commitDepth ?? 0)
+        })
+        const unsubChange = store1.onChange(() => events.push("onChange"), {
+            atoms: false,
+            selectors: true,
+        })
+        const unsubCommit = store1.onCommitEnd(() => events.push("commit-end"))
+
+        resolve(42)
+        await Promise.resolve()
+
+        expect(events).toEqual(["subscriber", "onChange", "commit-end"])
+        expect(subscriberDepths).toEqual([1])
+        expect(store1.get(asyncValue)).toBe(42)
+        unsubSelector()
+        unsubChange()
+        unsubCommit()
+    })
+
+    test("async selector observer errors are not handled as source-Promise rejection", () => {
+        const store1 = store()
+        let fulfill!: (value: number) => unknown
+        let rejectSource: ((error: unknown) => unknown) | undefined
+        let rejectChained: ((error: unknown) => unknown) | undefined
+        const chainedPromise = {
+            catch: (onRejected: (error: unknown) => unknown) => {
+                rejectChained = onRejected
+                return chainedPromise
+            },
+        }
+        const sourcePromise = {
+            then: (
+                onFulfilled: (value: number) => unknown,
+                onRejected?: (error: unknown) => unknown,
+            ) => {
+                fulfill = onFulfilled
+                rejectSource = onRejected
+                return chainedPromise
+            },
+        } as unknown as Promise<number>
+        const asyncValue = selector(() => sourcePromise)
+        const observerError = new Error("observer boom")
+        const unsub = store1.sub(asyncValue, () => {
+            throw observerError
+        })
+        let surfaced: unknown
+
+        try {
+            try {
+                fulfill(42)
+            } catch (error) {
+                // Model Promise reaction routing without creating an actual
+                // process-level unhandled rejection in the test runner.
+                if (rejectChained) rejectChained(error)
+                else surfaced = error
+            }
+
+            expect(rejectSource).toBeDefined()
+            expect(rejectChained).toBeUndefined()
+            expect(surfaced).toBe(observerError)
+            expect(store1.get(asyncValue)).toBe(42)
+        } finally {
+            unsub()
+        }
+    })
 })


### PR DESCRIPTION
## Summary

- route successful async selector settlement through the depth-aware commit coordinator
- fire `onCommitEnd` once, after selector subscribers and `onChange`
- attach rejection cleanup directly to the source Promise so observer failures are not swallowed
- preserve the no-listener fast path with the existing global count gate

## Test plan

- `bun --filter valdres test` — 834 passed, 1 todo
- `bunx tsc -p packages/valdres/tsconfig.json --noEmit`
- `bun --filter valdres typecheck:types`
- `bunx changeset status`