### PR TITLE
fix(valdres): validate maxAge revalidation writes

### DIFF
--- a/.changeset/khaki-ties-scream.md
+++ b/.changeset/khaki-ties-scream.md
@@ -1,0 +1,7 @@
+---
+"valdres": patch
+---
+
+Validate maxAge revalidation results against atom schemas, preserve the last
+valid cache value on validation failure, and suppress subscriber notifications
+for equal refreshes while updating freshness metadata.

--- a/packages/valdres/src/atom.test.ts
+++ b/packages/valdres/src/atom.test.ts
@@ -1,8 +1,17 @@
 import { describe, test, expect, mock, spyOn } from "bun:test"
 import { atom } from "./atom"
+import { cacheMeta } from "./cacheMeta"
+import { SchemaValidationError } from "./errors/SchemaValidationError"
 import { selector } from "./selector"
 import { store } from "./store"
 import { withFakeClock, mockAsyncSource } from "../test/utils/fakeClock"
+
+const numberSchema = {
+    parse: (value: unknown): number => {
+        if (typeof value !== "number") throw new Error("expected number")
+        return value
+    },
+}
 
 describe("atom", () => {
     test("is good", () => {
@@ -325,6 +334,171 @@ describe("atom", () => {
             expect(res).toHaveLength(2)
             setIntervalSpy.mockRestore()
             clearIntervalSpy.mockRestore()
+        }))
+
+    test("maxAge validates sync results and preserves the last good value", () =>
+        withFakeClock(async clock => {
+            const errorSpy = spyOn(console, "error").mockImplementation(
+                () => {},
+            )
+            let unsubscribe = () => {}
+            try {
+                const store1 = store({ schemaValidation: true })
+                let next: unknown = 1
+                const atom1 = atom<number>(() => next as number, {
+                    equal: () => true,
+                    maxAge: 20,
+                    schema: numberSchema,
+                })
+                const callback = mock(() => {})
+                unsubscribe = store1.sub(atom1, callback)
+
+                expect(store1.get(atom1)).toBe(1)
+                next = "bad"
+                await clock.advance(20)
+
+                expect(store1.get(atom1)).toBe(1)
+                expect(callback).not.toHaveBeenCalled()
+                expect(
+                    errorSpy.mock.calls.some(
+                        call => call[0] instanceof SchemaValidationError,
+                    ),
+                ).toBe(true)
+            } finally {
+                unsubscribe()
+                errorSpy.mockRestore()
+            }
+        }))
+
+    test("maxAge validates async results and restores the last good value", () =>
+        withFakeClock(async clock => {
+            const errorSpy = spyOn(console, "error").mockImplementation(
+                () => {},
+            )
+            let unsubscribe = () => {}
+            try {
+                const store1 = store({ schemaValidation: true })
+                const source = mockAsyncSource<unknown>()
+                const atom1 = atom<number>(source.fn as () => Promise<number>, {
+                    maxAge: 20,
+                    staleWhileRevalidate: 0,
+                    schema: numberSchema,
+                })
+                unsubscribe = store1.sub(atom1, () => {})
+
+                await source.resolve(1)
+                expect(store1.get(atom1)).toBe(1)
+
+                await clock.advance(20)
+                expect(store1.get(atom1)).toBeInstanceOf(Promise)
+                await source.resolve("bad")
+
+                expect(store1.get(atom1)).toBe(1)
+                expect(
+                    errorSpy.mock.calls.some(
+                        call => call[0] instanceof SchemaValidationError,
+                    ),
+                ).toBe(true)
+            } finally {
+                unsubscribe()
+                errorSpy.mockRestore()
+            }
+        }))
+
+    test("global maxAge validates when any attached store opts in", () =>
+        withFakeClock(async clock => {
+            const errorSpy = spyOn(console, "error").mockImplementation(
+                () => {},
+            )
+            let unsubscribeOff = () => {}
+            let unsubscribeOn = () => {}
+            try {
+                const validationOff = store()
+                const validationOn = store({ schemaValidation: true })
+                let next: unknown = 1
+                const atom1 = atom<number>(() => next as number, {
+                    global: true,
+                    maxAge: 20,
+                    schema: numberSchema,
+                })
+                unsubscribeOff = validationOff.sub(atom1, () => {})
+                unsubscribeOn = validationOn.sub(atom1, () => {})
+
+                next = "bad"
+                await clock.advance(20)
+
+                expect(validationOff.get(atom1)).toBe(1)
+                expect(validationOn.get(atom1)).toBe(1)
+                expect(
+                    errorSpy.mock.calls.some(
+                        call => call[0] instanceof SchemaValidationError,
+                    ),
+                ).toBe(true)
+            } finally {
+                unsubscribeOff()
+                unsubscribeOn()
+                errorSpy.mockRestore()
+            }
+        }))
+
+    test("equal sync maxAge result refreshes metadata without propagating", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            let callCount = 0
+            const atom1 = atom(
+                () => {
+                    callCount++
+                    return { id: 1, refresh: callCount }
+                },
+                {
+                    equal: (a, b) => a.id === b.id,
+                    maxAge: 20,
+                },
+            )
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+            const initialValue = store1.get(atom1)
+            const initialSuccessAt = store1.get(cacheMeta(atom1))!.lastSuccessAt
+
+            await clock.advance(20)
+
+            expect(store1.get(atom1)).toBe(initialValue)
+            expect(callback).not.toHaveBeenCalled()
+            expect(store1.get(cacheMeta(atom1))!.lastSuccessAt).toBeGreaterThan(
+                initialSuccessAt,
+            )
+            expect(callCount).toBe(2)
+
+            // Equal success also refreshes the internal freshness timestamp.
+            // Once unmounted, a read within the new maxAge window stays cached.
+            unsubscribe()
+            await clock.advance(10)
+            expect(store1.get(atom1)).toBe(initialValue)
+            expect(callCount).toBe(2)
+        }))
+
+    test("equal async maxAge result refreshes metadata without propagating", () =>
+        withFakeClock(async clock => {
+            const store1 = store()
+            const source = mockAsyncSource<{ value: number }>()
+            const atom1 = atom(source.fn, { maxAge: 20 })
+            const callback = mock(() => {})
+            const unsubscribe = store1.sub(atom1, callback)
+
+            await source.resolve({ value: 1 })
+            const initialValue = store1.get(atom1)
+            const initialSuccessAt = store1.get(cacheMeta(atom1))!.lastSuccessAt
+            const callsBeforeRevalidation = callback.mock.calls.length
+
+            await clock.advance(20)
+            await source.resolve({ value: 1 })
+
+            expect(store1.get(atom1)).toBe(initialValue)
+            expect(callback).toHaveBeenCalledTimes(callsBeforeRevalidation)
+            expect(store1.get(cacheMeta(atom1))!.lastSuccessAt).toBeGreaterThan(
+                initialSuccessAt,
+            )
+            unsubscribe()
         }))
 
     test("atom with maxAge async rejection does not cause unhandled rejection", () =>

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -21,6 +21,7 @@ import { setValueInData } from "./setValueInData"
 import { setMaxAgeCleanup } from "./maxAgeCleanups"
 import { mountTransitiveDeps, onFirstDirectSubscriber } from "./mountAtom"
 import { unsubscribe } from "./unsubscribe"
+import { validateResolvedValue } from "./validateResolvedValue"
 
 const initSubscribers = <V>(state: State<V> | Family<V>, data: StoreData) => {
     const set = new Set<Subscription>()
@@ -101,15 +102,65 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
         return elapsed >= getMaxAge() + getStaleIfError()
     }
 
-    const setAndPropagate = (atom: Atom, val: any) => {
+    const validateRevalidatedValue = (value: any): boolean => {
+        // Schema-less atoms are the dominant maxAge path. Keep them off the
+        // validation helper entirely; it would only rediscover this condition.
+        if (!state.schema) return true
+
+        // A global value is shared by every attached store. If validation is a
+        // per-atom override, one check is sufficient. Otherwise, validate when
+        // any attached store has opted in so the stores cannot diverge around
+        // one invalid refresh.
+        if (state.schemaValidation === false) return true
+        if (state.schemaValidation === true || !globalState) {
+            return validateResolvedValue(state, value, data)
+        }
+        for (const store of globalState.stores) {
+            if (store.schemaValidation) {
+                return validateResolvedValue(state, value, store)
+            }
+        }
+        return true
+    }
+
+    const writeRevalidatedValue = (
+        store: StoreData,
+        val: any,
+        valueIsPromise: boolean,
+        refreshedAt?: number,
+    ) => {
+        const currentValue = store.values.get(state)
+        // Avoid a second WeakMap lookup for the common defined-value case;
+        // `has` is only needed to distinguish a stored undefined from absence.
+        const hasCurrentValue =
+            currentValue !== undefined || store.values.has(state)
+        const areEqual =
+            hasCurrentValue &&
+            (valueIsPromise || isPromiseLike(currentValue)
+                ? currentValue === val
+                : state.equal(currentValue, val))
+        if (areEqual) {
+            // An equal successful refresh is still fresh. Preserve the
+            // canonical stored reference and subscriber silence, but move
+            // the lazy-revalidation timestamp forward so an unsubscribe
+            // followed by a read does not immediately fetch again.
+            if (refreshedAt !== undefined) {
+                store.lastValueWriteAt.set(state, refreshedAt)
+            }
+            return
+        }
+        setValueInData(state, val, store)
+        propagateAtomUpdate([state], store, false, undefined, "revalidate")
+    }
+
+    const setAndPropagate = (val: any, refreshedAt?: number) => {
+        const valueIsPromise = isPromiseLike(val)
         if (globalState) {
             for (const store of globalState.stores) {
-                setValueInData(atom, val, store)
-                propagateAtomUpdate([atom], store, false, undefined, "revalidate")
+                writeRevalidatedValue(store, val, valueIsPromise, refreshedAt)
             }
         } else {
-            setValueInData(atom, val, data)
-            propagateAtomUpdate([atom], data, false, undefined, "revalidate")
+            writeRevalidatedValue(data, val, valueIsPromise, refreshedAt)
         }
     }
 
@@ -143,9 +194,16 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
             const handleResolve = (resolved: any) => {
                 if (cancelled) return
                 revalidating = false
+                if (!validateRevalidatedValue(resolved)) {
+                    if (lastGoodValue !== NO_VALUE) {
+                        setAndPropagate(lastGoodValue)
+                    }
+                    updateMeta()
+                    return
+                }
                 lastSuccessTime = Date.now()
                 lastGoodValue = resolved
-                setAndPropagate(state, resolved)
+                setAndPropagate(resolved, lastSuccessTime)
                 updateMeta()
             }
 
@@ -156,9 +214,9 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
                     !isPastStaleIfErrorWindow() &&
                     lastGoodValue !== NO_VALUE
                 ) {
-                    setAndPropagate(state, lastGoodValue)
+                    setAndPropagate(lastGoodValue)
                 } else {
-                    setAndPropagate(state, value)
+                    setAndPropagate(value)
                 }
                 updateMeta()
             }
@@ -173,7 +231,7 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
                     timeoutRef = setTimeout(() => {
                         pendingTimeouts.delete(timeoutRef!)
                         if (cancelled || !revalidating) return
-                        setAndPropagate(state, value)
+                        setAndPropagate(value)
                     }, swr)
                     pendingTimeouts.add(timeoutRef)
                 }
@@ -196,13 +254,14 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
             } else {
                 // swr === 0: opt out of stale-while-revalidate; show
                 // pending promise immediately on revalidate.
-                setAndPropagate(state, value)
+                setAndPropagate(value)
                 value.then(handleResolve, handleReject)
             }
         } else {
+            if (!validateRevalidatedValue(value)) return
             lastSuccessTime = Date.now()
             lastGoodValue = value
-            setAndPropagate(state, value)
+            setAndPropagate(value, lastSuccessTime)
             updateMeta()
         }
     }


### PR DESCRIPTION
## Summary

- route synchronous and asynchronous `maxAge` revalidation results through atom schema validation
- preserve the last valid cache value when revalidation fails validation
- honor `atom.equal` before writes, suppressing value propagation for equal refreshes while advancing public and lazy-cache freshness metadata
- validate shared global refreshes when any attached store opts into schema validation

## Staff engineering review

- no blocking findings after reviewing validation ordering, Promise identity, stale-value restoration, global fan-out, cancellation, and cache timestamp behavior
- schema-less atoms retain an early fast path, and equal refreshes avoid both the write and propagation-array allocation
- regression coverage includes sync and async validation, custom equality, metadata refresh, lazy freshness, and mixed-validation global stores

## Verification

- `bun test --reporter=dots` — 837 passed, 1 todo, 0 failed
- `bun run typecheck:types`
- `bunx changeset status --since=origin/main`
- `git diff --check`
