### PR TITLE
fix(valdres): make selector abort signals evaluation-local

### DIFF
--- a/.changeset/local-selector-signals.md
+++ b/.changeset/local-selector-signals.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Give every selector evaluation its own lazily-created abort signal. Selectors
+using default or rest option parameters now receive abortable signals, and a
+selector may switch from a synchronous result to an asynchronous result without
+being permanently classified as synchronous.

--- a/packages/valdres/src/lib/abortSignal.test.ts
+++ b/packages/valdres/src/lib/abortSignal.test.ts
@@ -76,6 +76,76 @@ describe("abort signal support for async selectors", () => {
         expect(signals[1]!.aborted).toBe(false)
     })
 
+    test("defaulted options receive an evaluation-local signal", () => {
+        const store1 = store()
+        const countAtom = atom(1)
+        const signals: AbortSignal[] = []
+
+        const asyncSelector = selector((get, options: any = {}) => {
+            get(countAtom)
+            signals.push(options.signal)
+            return new Promise<number>(() => {})
+        })
+
+        store1.get(asyncSelector)
+        store1.set(countAtom, 2)
+        store1.get(asyncSelector)
+
+        expect(signals).toHaveLength(2)
+        expect(signals[0]).not.toBe(signals[1])
+        expect(signals[0]!.aborted).toBe(true)
+        expect(signals[1]!.aborted).toBe(false)
+    })
+
+    test("rest options receive an evaluation-local signal", () => {
+        const store1 = store()
+        const countAtom = atom(1)
+        const signals: AbortSignal[] = []
+
+        const asyncSelector = selector((get, ...rest: any[]) => {
+            get(countAtom)
+            signals.push(rest[0].signal)
+            return new Promise<number>(() => {})
+        })
+
+        store1.get(asyncSelector)
+        store1.set(countAtom, 2)
+        store1.get(asyncSelector)
+
+        expect(signals).toHaveLength(2)
+        expect(signals[0]).not.toBe(signals[1])
+        expect(signals[0]!.aborted).toBe(true)
+        expect(signals[1]!.aborted).toBe(false)
+    })
+
+    test("a selector can become async after returning synchronously", () => {
+        const store1 = store()
+        const asyncModeAtom = atom(false)
+        const countAtom = atom(1)
+        const signals: AbortSignal[] = []
+
+        const sometimesAsyncSelector = selector((get, { signal }) => {
+            const asyncMode = get(asyncModeAtom)
+            const count = get(countAtom)
+            signals.push(signal)
+            return asyncMode ? new Promise<number>(() => {}) : count
+        })
+
+        expect(store1.get(sometimesAsyncSelector)).toBe(1)
+
+        store1.set(asyncModeAtom, true)
+        store1.get(sometimesAsyncSelector)
+        store1.set(countAtom, 2)
+        store1.get(sometimesAsyncSelector)
+
+        expect(signals).toHaveLength(3)
+        expect(signals[0]).not.toBe(signals[1])
+        expect(signals[1]).not.toBe(signals[2])
+        expect(signals[0]!.aborted).toBe(true)
+        expect(signals[1]!.aborted).toBe(true)
+        expect(signals[2]!.aborted).toBe(false)
+    })
+
     test("signal is not aborted when unsubscribe cleanup drains", async () => {
         const store1 = store()
         const countAtom = atom(1)

--- a/packages/valdres/src/lib/cleanupOrphanedDeps.ts
+++ b/packages/valdres/src/lib/cleanupOrphanedDeps.ts
@@ -43,8 +43,8 @@ export const cleanupOrphanedDeps = (state: State, data: StoreData) => {
                 // Unmount invalidates store ownership but intentionally keeps
                 // the public AbortSignal alive. Re-evaluation still aborts the
                 // superseded signal through evaluateSelector's normal path.
-                evaluationContext.preserveSignalOnRevoke = true
-                evaluationContext.revoked = true
+                evaluationContext.preserveSignal()
+                evaluationContext.revoke()
             }
             data.latestEvalContext.delete(selector)
 

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -52,22 +52,73 @@ import { validateSchema } from "./validateSchema"
 
 export { isSuspendError } from "./asyncDependencyTracking"
 
-// Static signal for known-sync selectors — avoids AbortController allocation.
-const neverAbortedSignal = new AbortController().signal
+/**
+ * The selector's public options object and its internal evaluation identity are
+ * the same allocation. Controller/lifecycle state stays in private fields, so
+ * making signals evaluation-local doesn't add a second object to the ordinary
+ * selector hot path. The controller itself remains lazy.
+ */
+class SelectorEvaluation implements SelectorEvaluationContext {
+    readonly #selector: Selector
+    readonly #data: StoreData
+    readonly #runtimeAbortControllers?: Map<Selector, AbortController>
+    #revoked = false
+    #preserveSignalOnRevoke = false
+    #abortController?: AbortController
 
-// Per-store options object reused whenever a selector evaluation needs no
-// live AbortController — i.e. known-sync selectors and selectors that don't
-// declare the options parameter. Carries the real `storeId` and a permanently
-// non-aborted `signal`. Cached per store so reuse costs one WeakMap lookup
-// instead of an allocation.
-const syncOptionsCache = new WeakMap<StoreData, { signal: AbortSignal; storeId: string }>()
-const getSyncOptions = (data: StoreData) => {
-    let cached = syncOptionsCache.get(data)
-    if (!cached) {
-        cached = { signal: neverAbortedSignal, storeId: data.id }
-        syncOptionsCache.set(data, cached)
+    declare asyncDeps?: Set<State>
+    declare asyncDependencyRevisions?: Map<State, number>
+
+    constructor(
+        selector: Selector,
+        data: StoreData,
+        runtimeAbortControllers?: Map<Selector, AbortController>,
+    ) {
+        this.#selector = selector
+        this.#data = data
+        this.#runtimeAbortControllers = runtimeAbortControllers
     }
-    return cached
+
+    get storeId() {
+        return this.#data.id
+    }
+
+    get revoked() {
+        return this.#revoked
+    }
+
+    get signal() {
+        let controller = this.#abortController
+        if (!controller) {
+            controller = new AbortController()
+            this.#abortController = controller
+            if (this.#revoked) {
+                if (!this.#preserveSignalOnRevoke) controller.abort()
+            } else if (!this.#preserveSignalOnRevoke) {
+                this.#abortControllers.set(this.#selector, controller)
+            }
+        }
+        return controller.signal
+    }
+
+    revoke() {
+        this.#revoked = true
+        if (!this.#preserveSignalOnRevoke && this.#abortController) {
+            this.#abortController.abort()
+            this.#abortControllers.delete(this.#selector)
+        }
+    }
+
+    preserveSignal() {
+        this.#preserveSignalOnRevoke = true
+        if (this.#abortController) {
+            this.#abortControllers.delete(this.#selector)
+        }
+    }
+
+    get #abortControllers() {
+        return this.#runtimeAbortControllers ?? this.#data.abortControllers
+    }
 }
 
 const rollbackFreshSelectorActivation = (
@@ -152,7 +203,7 @@ export type DepsChange = {
  * store. Transactions keep this state local so an aborted speculative read
  * cannot rewrite the store's dependency graph or publish an async result. */
 export type SelectorEvaluationRuntime = {
-    abortControllers: Map<Selector, AbortController | false>
+    abortControllers: Map<Selector, AbortController>
     latestEvalContext: Map<Selector, SelectorEvaluationContext>
     stateDependencies: Map<Selector, Set<State>>
     readOverlayActive: boolean
@@ -164,7 +215,6 @@ export type SelectorEvaluationRuntime = {
  * live reverse graph, so none of the cold/live mode branches are needed.
  * Keeping this code shape separate lets JavaScriptCore tier it like the
  * pre-cold-cache evaluator instead of compiling the larger mixed-mode path.
- * Getters that declare the options argument stay on the full evaluator below.
  */
 const evaluateLiveOnlySelector = <V>(
     selector: Selector<V>,
@@ -179,11 +229,8 @@ const evaluateLiveOnlySelector = <V>(
     let activatedDuringEvaluation: Selector | Selector[] | undefined
 
     const prevCtx = data.latestEvalContext.get(selector)
-    if (prevCtx) prevCtx.revoked = true
-    const evalCtx: SelectorEvaluationContext = {
-        revoked: false,
-        preserveSignalOnRevoke: false,
-    }
+    if (prevCtx) prevCtx.revoke()
+    const evalCtx = new SelectorEvaluation(selector, data)
     data.latestEvalContext.set(selector, evalCtx)
 
     if (circularDependencySet.has(selector)) {
@@ -249,7 +296,7 @@ const evaluateLiveOnlySelector = <V>(
                     throw new SuspendAndWaitForResolveError(value)
                 }
                 return value
-            }, getSyncOptions(data))
+            }, evalCtx)
         } catch (error) {
             if (error instanceof SuspendAndWaitForResolveError) {
                 result = error
@@ -337,7 +384,6 @@ export const evaluateSelector = <V>(
     runtime?: SelectorEvaluationRuntime,
 ) => {
     const stateDependencies = runtime?.stateDependencies ?? data.stateDependencies
-    const abortControllers = runtime?.abortControllers ?? data.abortControllers
     const currentDependencies = stateDependencies.get(selector)
     const tracksReverseEdges = !runtime && selectorGraphActive
     // A store that has never materialized a cold selector needs neither cache
@@ -364,11 +410,12 @@ export const evaluateSelector = <V>(
     // deferred get calls from old evaluations become read-only.
     const latestEvalContext = runtime?.latestEvalContext ?? data.latestEvalContext
     const prevCtx = latestEvalContext.get(selector)
-    if (prevCtx) prevCtx.revoked = true
-    const evalCtx: SelectorEvaluationContext = {
-        revoked: false,
-        preserveSignalOnRevoke: false,
-    }
+    if (prevCtx) prevCtx.revoke()
+    const evalCtx = new SelectorEvaluation(
+        selector,
+        data,
+        runtime?.abortControllers,
+    )
     latestEvalContext.set(selector, evalCtx)
 
     if (circularDependencySet.has(selector)) {
@@ -377,59 +424,6 @@ export const evaluateSelector = <V>(
     circularDependencySet.add(selector)
 
     try {
-        // Abort signal support: `options.signal` is a lazy getter that only
-        // allocates an AbortController when the selector body reads it. Most
-        // selectors don't, so first eval pays nothing extra. After eval,
-        // handleSelectorResult marks the entry as `false` for sync results,
-        // letting subsequent evaluations reuse a shared cached options object.
-        // For async results the controller stays, and re-evaluation aborts it.
-        let options: { signal: AbortSignal; storeId: string }
-        // Fast path for selectors that don't declare a second (options)
-        // parameter. `get.length < 2` is a heuristic for "doesn't use options",
-        // not a guarantee: it's true for `(get) => …`, but NOT for an options
-        // param written with a default value (`(get, opts = {})`) or as a rest
-        // param, and it can't see a body that reaches `arguments[1]`. In every
-        // such case the selector still receives a valid options object with the
-        // correct `storeId` — only `signal` is a permanently non-abortable
-        // placeholder. Selectors that need a live abort signal must declare
-        // options positionally or via destructuring (`(get, opts)`,
-        // `(get, { signal })`), which is arity 2 and takes the full path below.
-        // The fast path avoids the per-eval accessor-object allocation and the
-        // abortControllers WeakMap traffic for the common case.
-        if ((selector.get as (...args: any[]) => any).length < 2) {
-            options = getSyncOptions(data)
-        } else {
-            const prev = abortControllers.get(selector)
-            if (prev === false) {
-                // Known-sync selector — use cached options, no allocation
-                options = getSyncOptions(data)
-            } else {
-                if (prev) prev.abort()
-                let controller: AbortController | undefined
-                // Capture this eval's context so that if `signal` is read after
-                // the selector has already been superseded by a re-eval, we
-                // return a pre-aborted signal. This preserves abort semantics
-                // for selectors that touch `opts.signal` only after an await.
-                const myEvalCtx = evalCtx
-                options = {
-                    storeId: data.id,
-                    get signal() {
-                        if (!controller) {
-                            controller = new AbortController()
-                            if (myEvalCtx.revoked) {
-                                if (!myEvalCtx.preserveSignalOnRevoke) {
-                                    controller.abort()
-                                }
-                            } else {
-                                abortControllers.set(selector, controller)
-                            }
-                        }
-                        return controller.signal
-                    },
-                }
-            }
-        }
-
         let result
         try {
             // @ts-ignore, @ts-todo
@@ -553,7 +547,7 @@ export const evaluateSelector = <V>(
                     throw new SuspendAndWaitForResolveError(value)
 
                 return value
-            }, options)
+            }, evalCtx)
         } catch (error) {
             if (error instanceof SuspendAndWaitForResolveError) {
                 result = error
@@ -750,7 +744,12 @@ export const handleSelectorResult = <Value>(
         (selectorGraphActive ?? data.selectorGraphActive.has(selector))
     if (value instanceof SuspendAndWaitForResolveError) {
         if (runtime) {
-            runtime.abortControllers.delete(selector)
+            const evaluationContext = runtime.latestEvalContext.get(selector)
+            if (evaluationContext) {
+                evaluationContext.preserveSignal()
+            } else {
+                runtime.abortControllers.delete(selector)
+            }
             return value.promise
         }
         // The selector was suspended — it threw before completing, so no
@@ -758,9 +757,13 @@ export const handleSelectorResult = <Value>(
         // the AbortController so that when the dependency resolves and
         // propagation re-evaluates this selector, it won't spuriously
         // abort the signal.
-        data.abortControllers.delete(selector)
         const promise = value.promise
         const evaluationContext = data.latestEvalContext.get(selector)
+        if (evaluationContext) {
+            evaluationContext.preserveSignal()
+        } else {
+            data.abortControllers.delete(selector)
+        }
         promise.then(() => {
             // Dependency presence alone is not an evaluation identity: a stale
             // late `get` or a newer evaluation can recreate the selector's graph.
@@ -945,16 +948,6 @@ export const handleSelectorResult = <Value>(
         }
         return value
     } else {
-        // Sync result — mark as known-sync so subsequent evaluations skip
-        // AbortController allocation on the hot path. Only meaningful for
-        // selectors that read options (arity >= 2); arity-<2 selectors bypass
-        // the abortControllers path entirely, so don't pollute the map.
-        if ((selector.get as (...args: any[]) => any).length >= 2) {
-            ;(runtime?.abortControllers ?? data.abortControllers).set(
-                selector,
-                false,
-            )
-        }
         const validated = validateSchema(selector, value, data)
         // Transaction selector evaluation uses private dependency bookkeeping.
         // It must not refresh metadata for the committed value/graph.
@@ -983,8 +976,7 @@ const evaluateCommittedSelectorValue = <V>(
     try {
         value =
             selectorGraphActive &&
-            !data.coldSelectorCachesEnabled &&
-            (selector.get as (...args: any[]) => any).length < 2
+            !data.coldSelectorCachesEnabled
                 ? evaluateLiveOnlySelector(
                       selector,
                       data,

--- a/packages/valdres/src/lib/selectorOptions.test.ts
+++ b/packages/valdres/src/lib/selectorOptions.test.ts
@@ -2,41 +2,35 @@ import { describe, expect, test } from "bun:test"
 import { selector } from "../selector"
 import { store } from "../store"
 
-// Regression guard for the options-allocation fast path in evaluateSelector.
-// Selectors whose `get` has arity < 2 reuse a shared per-store options object
-// (the "fast path") instead of building a per-eval one (the "full path",
-// arity >= 2). Either way the selector must receive a correct `options`: the
-// real `storeId` and a valid `signal` (a non-abortable placeholder on the fast
-// path). The arity-1 cases below cover the patterns where `get.length` is 1 but
-// the body still reaches the options object.
+// Selector options are valid regardless of the callback's reported arity.
+// Default and rest parameters make Function.length unsuitable for deciding
+// whether a selector can use its options object.
 describe("selector options object", () => {
-    test("full path (arity 2): options.storeId is the real store id", () => {
+    test("options.storeId is the real store id", () => {
         const s = store()
         const sel = selector((_get, opts) => opts.storeId)
         expect(s.get(sel)).toBe(s.data.id)
     })
 
-    // `opts = {}` / rest params make `get.length === 1`, so the selector takes
-    // the fast path — but must still see the real storeId, never `undefined`.
-    test("fast path (defaulted options param): real store id", () => {
+    test("defaulted options param receives the real store id", () => {
         const s = store()
         const sel = selector((_get, opts: any = {}) => opts.storeId)
         expect(s.get(sel)).toBe(s.data.id)
     })
 
-    test("fast path (rest options param): real store id", () => {
+    test("rest options param receives the real store id", () => {
         const s = store()
         const sel = selector((_get, ...rest: any[]) => rest[0].storeId)
         expect(s.get(sel)).toBe(s.data.id)
     })
 
-    test("fast path: signal is a valid, non-aborted placeholder", () => {
+    test("defaulted options param receives a valid signal", () => {
         const s = store()
         const sel = selector((_get, opts: any = {}) => opts.signal.aborted)
         expect(s.get(sel)).toBe(false)
     })
 
-    test("fast path: each store reading storeId gets its own id", () => {
+    test("each store reading storeId gets its own id", () => {
         const a = store()
         const b = store()
         const sel = selector((_get, opts: any = {}) => opts.storeId)

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -176,10 +176,8 @@ describe("transaction", () => {
 
         store1.txn(({ get }) => {
             expect(get(optionsSelector)).toBe(1)
-            expect(receivedOptions).toEqual({
-                signal: expect.any(AbortSignal),
-                storeId: store1.data.id,
-            })
+            expect(receivedOptions.signal).toBeInstanceOf(AbortSignal)
+            expect(receivedOptions.storeId).toBe(store1.data.id)
 
             try {
                 get(invalidSelector)

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -5,8 +5,12 @@ import type { StoreChangeCallback } from "./StoreChangeCallback"
 import type { Subscription } from "./Subscription"
 
 export type SelectorEvaluationContext = {
-    revoked: boolean
-    preserveSignalOnRevoke: boolean
+    readonly revoked: boolean
+    /** Revoke deferred reads and abort work owned by this evaluation unless
+     * its signal was explicitly preserved for suspension/unmount cleanup. */
+    revoke(): void
+    /** Detach this evaluation's signal from cancellation without aborting it. */
+    preserveSignal(): void
     /** All dependencies read by this async evaluation. Kept on the evaluation
      *  identity so two stores/selectors may safely return the same Promise. */
     asyncDeps?: Set<State>
@@ -157,7 +161,7 @@ export type StoreData = {
      *  re-init can mis-count even an acyclic graph because the incremental path
      *  never ran for it. Lazy re-inits are off the hot path, so this is cheap. */
     livenessLazyArmed?: boolean
-    abortControllers: WeakMap<WeakKey, AbortController | false>
+    abortControllers: WeakMap<WeakKey, AbortController>
     /** Selectors currently mid-evaluation in this store. Used for cycle
      *  detection. Per-store so that the same selector evaluated in two
      *  stores doesn't trigger a spurious cycle. Add at evaluateSelector


### PR DESCRIPTION
## Summary

- give every selector evaluation its own lazily-created abort signal
- remove abortability inference from callback arity and the permanent known-sync sentinel
- preserve signals during suspension retries and unsubscribe cleanup while keeping transaction evaluation isolated
- cover default parameters, rest parameters, and selectors that transition from sync to async

## Performance

The selector options view now shares the evaluation-context allocation already required for deferred dependency tracking. AbortController creation and registry traffic remain lazy until signal is actually read. Focused selector benchmarks were run under Bun/JSC and Node/V8 after the change.

## Testing

- bun test --reporter=dots — 835 passed, 1 existing todo
- bun run build
- bun run build:types
- bun run typecheck:types
- Bun/JSC selector benchmark suite
- Node/V8 selector benchmark suite
- changeset status --since=origin/main
