### PR TITLE
fix(valdres): route resets through shared commit pipeline

### DIFF
--- a/.changeset/fast-banks-end.md
+++ b/.changeset/fast-banks-end.md
@@ -1,0 +1,6 @@
+---
+"valdres": patch
+---
+
+Route direct atom resets through the shared transaction commit pipeline so
+hooks, global synchronization, and notifications match transactional resets.

--- a/packages/valdres/src/lib/resetAtom.test.ts
+++ b/packages/valdres/src/lib/resetAtom.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { SchemaValidationError } from "../errors/SchemaValidationError"
+import { selector } from "../selector"
+import { store } from "../store"
+
+describe("direct reset commit pipeline", () => {
+    test("selector defaults initialize and commit without a post-commit throw", () => {
+        const useSecond = atom(false)
+        const first = atom(1)
+        const second = atom(2)
+        const selectedDefault = selector(get =>
+            get(useSecond) ? get(second) : get(first),
+        )
+        const value = atom(selectedDefault)
+        const store1 = store()
+
+        store1.set(value, 10)
+        store1.set(useSecond, true)
+
+        expect(() => store1.reset(value)).not.toThrow()
+        expect(store1.get(value)).toBe(2)
+    })
+
+    test("a Promise reset notifies subscribers of the pending state", async () => {
+        let resolve!: (value: number) => void
+        const pending = new Promise<number>(done => {
+            resolve = done
+        })
+        const value = atom(() => pending)
+        const store1 = store()
+
+        store1.set(value, 2)
+        const subscriber = mock(() => {})
+        const unsubscribe = store1.sub(value, subscriber)
+
+        expect(store1.reset(value)).toBe(pending)
+        expect(store1.get(value)).toBe(pending)
+        expect(subscriber).toHaveBeenCalledTimes(1)
+
+        unsubscribe()
+        resolve(1)
+        await pending
+        await Promise.resolve()
+    })
+
+    test("runs onSet and finishes propagation before rethrowing its error", () => {
+        const hookError = new Error("reset onSet failed")
+        let throwFromHook = false
+        const onSet = mock((value: number) => {
+            if (throwFromHook) throw hookError
+        })
+        const value = atom(1, { onSet })
+        const doubled = selector(get => get(value) * 2)
+        const store1 = store()
+
+        store1.set(value, 2)
+        const seen: number[] = []
+        store1.sub(doubled, () => seen.push(store1.get(doubled)))
+        throwFromHook = true
+
+        let thrown: unknown
+        try {
+            store1.reset(value)
+        } catch (error) {
+            thrown = error
+        }
+
+        expect(thrown).toBe(hookError)
+        expect(onSet).toHaveBeenLastCalledWith(1, store1.data)
+        expect(store1.get(value)).toBe(1)
+        expect(store1.get(doubled)).toBe(2)
+        expect(seen).toEqual([2])
+    })
+
+    test("fans a global reset out to every initialized peer store", () => {
+        const value = atom(1, { global: true })
+        const source = store()
+        const peer = store()
+        const sourceSubscriber = mock(() => {})
+        const peerSubscriber = mock(() => {})
+
+        const unsubscribeSource = source.sub(value, sourceSubscriber)
+        const unsubscribePeer = peer.sub(value, peerSubscriber)
+        source.set(value, 2)
+        sourceSubscriber.mockClear()
+        peerSubscriber.mockClear()
+
+        source.reset(value)
+
+        expect(source.get(value)).toBe(1)
+        expect(peer.get(value)).toBe(1)
+        expect(sourceSubscriber).toHaveBeenCalledTimes(1)
+        expect(peerSubscriber).toHaveBeenCalledTimes(1)
+
+        unsubscribeSource()
+        unsubscribePeer()
+        source.dispose()
+        peer.dispose()
+    })
+
+    test("validates the default before replacing the committed value", () => {
+        let defaultValue: unknown = 1
+        const value = atom(() => defaultValue as number, {
+            schemaValidation: true,
+            schema: {
+                parse(candidate) {
+                    if (typeof candidate !== "number") {
+                        throw new Error("expected number")
+                    }
+                    return candidate
+                },
+            },
+        })
+        const store1 = store()
+
+        store1.set(value, 2)
+        defaultValue = "invalid"
+
+        expect(() => store1.reset(value)).toThrow(SchemaValidationError)
+        expect(store1.get(value)).toBe(2)
+    })
+})

--- a/packages/valdres/src/lib/resetAtom.ts
+++ b/packages/valdres/src/lib/resetAtom.ts
@@ -1,22 +1,16 @@
 import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
-import { isPromiseLike } from "../utils/isPromiseLike"
-import { getAtomInitValue } from "./initAtom"
-import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
-import { setValueInData } from "./setValueInData"
+import { Transaction } from "./transaction"
 
 export const resetAtom = <V>(
     atom: Atom<V>,
     data: StoreData,
 ): V | Promise<V> => {
-    const initializedAtomsSet = new Set<Atom>()
-    let value = getAtomInitValue(atom, data, initializedAtomsSet)
-    setValueInData(atom, value, data)
-    if (!isPromiseLike(value)) {
-        propagateAtomUpdate([atom], data, false, undefined, "reset")
-    }
-    if (initializedAtomsSet.size > 0) {
-        throw new Error("Todo - propagateAtomUpdate on reset")
-    }
+    // Keep direct reset on the exact transaction write/commit path. Besides
+    // preventing a second implementation from drifting, constructing the
+    // transaction explicitly avoids the callback allocation of transaction().
+    const txn = new Transaction(data)
+    const value = txn.reset(atom)
+    txn.commit("reset")
     return value
 }

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -5,6 +5,7 @@ import type { GetValue } from "../types/GetValue"
 import type { State } from "../types/State"
 import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
+import type { StoreChangeSource } from "../types/StoreChangeSource"
 import type { TransactionFn } from "../types/TransactionFn"
 import { SchemaValidationError } from "../errors/SchemaValidationError"
 import { deepFreeze } from "../utils/deepFreeze"
@@ -495,7 +496,7 @@ export class Transaction {
         }
     }
 
-    commit = () => {
+    commit = (source?: StoreChangeSource) => {
         // Commit boundary for store.onCommitEnd: listeners fire once, when the
         // outermost boundary closes — after every subscriber callback and after
         // the onChange flush below. The inner propagation passes also open
@@ -520,7 +521,7 @@ export class Transaction {
             // simply owns its own sink — no save/restore. Flush in `finally` so
             // observers still see the (already-applied) changes if a subscriber
             // throws during commit.
-            const sink = createChangeSink(this.name)
+            const sink = createChangeSink(this.name, source)
             try {
                 this.commitWork(sink)
             } catch (error) {


### PR DESCRIPTION
## Summary

- route direct `store.reset()` calls through `Transaction.reset()` and the shared commit pipeline
- preserve the public `reset` change source while reusing validation, hooks, global fanout, propagation, notification, and commit error handling
- add red-first regressions for selector-backed defaults, pending Promise notification, throwing `onSet`, global peer convergence, and validation-before-commit

## Staff engineering review

No blocking findings. The implementation avoids a callback allocation for direct resets, keeps the source default off the unwatched transaction hot path, preserves global peer `set` metadata, and introduces no new module cycle.

## Validation

- `packages/valdres: bun test --reporter=dots` — 837 passed, 1 existing todo
- source and public type-test checks passed
- `bun run docs:build` — 194 pages built
- `bun run scripts/gen-readmes.ts --check` — all 33 READMEs current
- `bunx changeset status --since=origin/main` — `valdres` patch recognized
- transaction benchmark suite — 8 passed; staged set + selector read 1.6µs
