### PR TITLE
fix(valdres): propagate selector defaults on subscribe

### DIFF
--- a/.changeset/fresh-selector-default-subscriptions.md
+++ b/.changeset/fresh-selector-default-subscriptions.md
@@ -1,0 +1,6 @@
+---
+"valdres": patch
+---
+
+Fix fresh atom subscriptions whose selector defaults initialize other atoms by
+finishing nested initialization through the normal init-only propagation path.

--- a/.changeset/fresh-selector-default-subscriptions.md
+++ b/.changeset/fresh-selector-default-subscriptions.md
@@ -4,3 +4,5 @@
 
 Fix fresh atom subscriptions whose selector defaults initialize other atoms by
 finishing nested initialization through the normal init-only propagation path.
+Also register atom-family members initialized by their first subscription in
+the family index, matching initialization through `store.get`.

--- a/packages/valdres/src/lib/deleteFamilyAtom.test.ts
+++ b/packages/valdres/src/lib/deleteFamilyAtom.test.ts
@@ -38,7 +38,7 @@ describe("deleteFamilyAtom", () => {
         const user = atomFamily<{ id: number; gender: string }, [number]>(null)
         const allUsers = selector(get => get(user).map(atom => get(atom)))
         const allWomenAtoms = selector(get =>
-            get(user).filter(atom => get(atom).gender === "woman"),
+            get(user).filter(atom => get(atom)?.gender === "woman"),
         )
         const allWomen = selector(get => get(allWomenAtoms).map(get))
         const callback = mock(() => {})

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
@@ -149,6 +149,14 @@ test("propagateUpdatedAtoms", () => {
     // rootStore.sub(userAgeSelector, usersAgeUpdatedCallback)
     rootStore.sub(user1, user1UpdatedCallback)
 
+    // Subscribing the fresh family member initializes it and registers its
+    // membership, matching store.get(user1). Aggregates that read the pending
+    // no-default member become pending and their subscribers observe that
+    // membership transition.
+    expect(userUpdatedCallback).toHaveBeenCalledTimes(1)
+    expect(norwegianUserAddedCallback).toHaveBeenCalledTimes(1)
+    expect(age21UserAddedCallback).toHaveBeenCalledTimes(1)
+
     expect(rootStore.get(userSettingsFamily(1))).toStrictEqual({
         id: 1,
         enabled: true,
@@ -158,16 +166,17 @@ test("propagateUpdatedAtoms", () => {
     // rootStore
 
     expect(rootStore.get(user1)).toBeInstanceOf(Promise)
-    expect(rootStore.get(usersByCountry("Norway"))).toStrictEqual([])
-    expect(rootStore.get(allUserSummariesSelector)).toStrictEqual([])
+    expect(rootStore.get(usersByCountry("Norway"))).toBeInstanceOf(Promise)
+    expect(rootStore.get(usersByAge(21))).toBeInstanceOf(Promise)
+    expect(rootStore.get(allUserSummariesSelector)).toBeInstanceOf(Promise)
 
     rootStore.set(user1, { name: "Foo", age: 21, country: "Norway" })
 
     expect(user1UpdatedCallback).toHaveBeenCalledTimes(1)
-    expect(userUpdatedCallback).toHaveBeenCalledTimes(1)
-    expect(norwegianUserAddedCallback).toHaveBeenCalledTimes(1)
+    expect(userUpdatedCallback).toHaveBeenCalledTimes(2)
+    expect(norwegianUserAddedCallback).toHaveBeenCalledTimes(2)
 
-    expect(age21UserAddedCallback).toHaveBeenCalledTimes(1)
+    expect(age21UserAddedCallback).toHaveBeenCalledTimes(2)
     expect(rootStore.get(usersByAge(21))).toStrictEqual([user1])
     expect(rootStore.get(usersByCountry("Norway"))).toStrictEqual([user1])
     expect(usersByAge.callback).toHaveBeenCalledTimes(1)

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -15,6 +15,26 @@ describe("subscribe", () => {
         expect(callback).toHaveBeenCalledTimes(1)
     })
 
+    test("fresh atom subscription propagates selector-default initialization", () => {
+        const store1 = store()
+        const sourceFamily = atomFamily((id: number) => id)
+        const source = sourceFamily(1)
+        const defaultSelector = selector(get => get(source) + 1)
+        const target = atom(defaultSelector)
+        const callback = mock(() => {})
+
+        const unsubscribe = store1.sub(target, callback)
+
+        expect(store1.get(source)).toBe(1)
+        expect(store1.get(sourceFamily)).toStrictEqual([source])
+        expect(store1.get(target)).toBe(2)
+        expect(callback).toHaveBeenCalledTimes(0)
+
+        store1.set(target, 3)
+        expect(callback).toHaveBeenCalledTimes(1)
+        unsubscribe()
+    })
+
     test("Subscribe to un-mounted selector", () => {
         const store1 = store()
         const atom1 = atom([1, 2, 3]) // sum 6

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -15,12 +15,27 @@ describe("subscribe", () => {
         expect(callback).toHaveBeenCalledTimes(1)
     })
 
-    test("fresh atom subscription propagates selector-default initialization", () => {
+    test("fresh family-member subscription registers a plain-default member", () => {
+        const store1 = store()
+        const family = atomFamily("default")
+        const member = family("member")
+        const callback = mock(() => {})
+
+        const unsubscribe = store1.sub(member, callback)
+
+        expect(store1.get(member)).toBe("default")
+        expect(store1.get(family)).toStrictEqual([member])
+        expect(callback).toHaveBeenCalledTimes(0)
+        unsubscribe()
+    })
+
+    test("fresh family-member subscription propagates selector-default initialization", () => {
         const store1 = store()
         const sourceFamily = atomFamily((id: number) => id)
         const source = sourceFamily(1)
         const defaultSelector = selector(get => get(source) + 1)
-        const target = atom(defaultSelector)
+        const targetFamily = atomFamily(defaultSelector)
+        const target = targetFamily("target")
         const callback = mock(() => {})
 
         const unsubscribe = store1.sub(target, callback)
@@ -28,6 +43,7 @@ describe("subscribe", () => {
         expect(store1.get(source)).toBe(1)
         expect(store1.get(sourceFamily)).toStrictEqual([source])
         expect(store1.get(target)).toBe(2)
+        expect(store1.get(targetFamily)).toStrictEqual([target])
         expect(callback).toHaveBeenCalledTimes(0)
 
         store1.set(target, 3)

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -325,7 +325,7 @@ export const subscribe = <V>(
         const initializedAtomsSet = new Set<Atom>()
         initAtom(state, data, initializedAtomsSet)
         if (initializedAtomsSet.size) {
-            throw new Error("This should not be possible")
+            propagateAtomUpdate([...initializedAtomsSet], data, true)
         }
     }
     // A selector may have a revision-validated cold cache. Read through

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -6,6 +6,7 @@ import type { Subscription } from "../types/Subscription"
 import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { isFamily } from "../utils/isFamily"
+import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
@@ -384,7 +385,10 @@ export const subscribe = <V>(
         const initializedAtomsSet = new Set<Atom>()
         initAtom(state, data, initializedAtomsSet)
         if (initializedAtomsSet.size) {
+            initializedAtomsSet.add(state)
             propagateAtomUpdate([...initializedAtomsSet], data, true)
+        } else if (isFamilyAtom(state)) {
+            propagateAtomUpdate([state], data, true)
         }
     }
     // A selector may have a revision-validated cold cache. Read through


### PR DESCRIPTION
## Summary

- complete fresh atom subscriptions whose selector defaults initialize other atoms
- register family members initialized by their first subscription, matching store.get initialization
- include the subscribed target in nested init-only propagation while preserving the ordinary initialized-subscription path

## Regression coverage

- red-first coverage for plain-default family members created through sub(member)
- red-first coverage for selector-default family members that initialize another family member
- existing aggregate tests now document pending membership and notification semantics shared with store.get

## Performance

- cold first-subscription A/B benchmark: 291 ns before; 291 ns after
- the family check only runs when a fresh atom initialized no nested atoms

## Validation

- bun test --reporter=dots in packages/valdres: 853 passed, 1 todo
- bun run typecheck:types
- bun run build
- bun run docs:build
- bun run scripts/gen-readmes.ts --check
- bunx changeset status --since=origin/main