### PR TITLE
fix(valdres): preserve atom family identity on release

### DIFF
--- a/.changeset/stable-family-identity.md
+++ b/.changeset/stable-family-identity.md
@@ -8,5 +8,8 @@ membership instead of globally releasing the family's shared identity, matching
 transactional deletion and preventing two member objects for the same logical
 key.
 
-Atom-family identity caches now hold members weakly, so keeping identities stable
-across stores does not make the family retain every unused member forever.
+Atom-family identity caches now hold members weakly, so keeping identities
+stable across stores does not make the family retain every unused member
+forever. The legacy `atomFamily.release()` method is now a deprecated no-op:
+explicit eviction is unnecessary with the weak cache and could create a second
+live member for arguments whose original member is still retained by a store.

--- a/packages/valdres/src/atomFamily.mdx
+++ b/packages/valdres/src/atomFamily.mdx
@@ -64,7 +64,12 @@ const entityAtom = atomFamily<Entity, [Entity]>(entity => entity, {
 ```
 
 `keyOf` receives the same argument tuple as the family factory. Its result is
-run through the same canonical codec, and `release(...args)` uses it as well.
+run through the same canonical codec.
+
+The legacy `release(...args)` method is deprecated and has no effect. Family
+members leave the weak identity cache automatically once no caller or store can
+reach them. Manual eviction could otherwise create two live member objects for
+the same arguments and split their values across stores.
 
 ## Subscribing to all keys
 

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -46,6 +46,26 @@ describe("atomFamily", () => {
         expect(scope.get(family)).toStrictEqual([])
     })
 
+    test("release preserves identity retained by a store", async () => {
+        const family = atomFamily((_id: string) => 0)
+        const store1 = store()
+        const member = family("shared")
+
+        store1.set(member, 1)
+        // Exercise the weak-cache path rather than its same-job strong entry.
+        await Promise.resolve()
+        family.release("shared")
+
+        const releasedMember = family("shared")
+        expect(releasedMember).toBe(member)
+
+        store1.set(releasedMember, 2)
+        expect(store1.get(family)).toStrictEqual([member])
+        expect(store1.get(family).map(atom => store1.get(atom))).toStrictEqual([
+            2,
+        ])
+    })
+
     test("Simple default value", () => {
         const store1 = store()
         const userAtomFamily = atomFamily<number, string>("Foo")
@@ -286,7 +306,7 @@ describe("atomFamily", () => {
         expect(family(b)).toBe(first)
         expect("keyOf" in first).toBe(false)
         family.release(a)
-        expect(family(b)).not.toBe(first)
+        expect(family(b)).toBe(first)
     })
 
     test("get an entire atom family", () => {
@@ -385,7 +405,7 @@ describe("atomFamily", () => {
         })
     })
 
-    test("release an atomFamily member", () => {
+    test("deprecated release does not remove an atomFamily member", () => {
         const store1 = store()
         const todosAtomFamily = atomFamily((id: string) => ({
             id,

--- a/packages/valdres/src/lib/createAtomFamily.ts
+++ b/packages/valdres/src/lib/createAtomFamily.ts
@@ -10,6 +10,10 @@ import { globalAtom } from "./globalAtom"
 import { registerName } from "./registerName"
 import { WeakValueMap } from "./WeakValueMap"
 
+// Kept as a shared compatibility function so deprecated `release()` neither
+// allocates per family nor can evict an identity that a store still retains.
+const releaseAtomFamilyMember = () => {}
+
 export const createAtomFamily = <
     Value extends any,
     Args extends [any, ...any[]] = [any, ...any[]],
@@ -164,17 +168,7 @@ export const createAtomFamily = <
 
     const family = Object.assign(callable, {
         __valdresAtomFamilyMap: map,
-        release: (...args: Args) => {
-            if (
-                keyOf === undefined &&
-                args.length === 1 &&
-                typeof args[0] === "string"
-            ) {
-                stringMap.delete(args[0])
-            }
-            const keyArgs = keyOf === undefined ? args : [keyOf(...args)]
-            map.delete(familyKey(keyArgs))
-        },
+        release: releaseAtomFamilyMember,
         equal,
         // Exposed on the family object too (members carry them via ...options)
         // so a consumer (devtools, sync) can read a family's schema without

--- a/packages/valdres/src/types/AtomFamily.ts
+++ b/packages/valdres/src/types/AtomFamily.ts
@@ -8,6 +8,12 @@ export type AtomFamily<
     Args extends [any, ...any[]] = [any, ...any[]],
 > = {
     (...args: Args): AtomFamilyAtom<Value, Args>
+    /**
+     * @deprecated Atom-family members leave the weak identity cache
+     * automatically once nothing retains them. This compatibility method is a
+     * no-op because manually evicting a live member would break shared identity
+     * across stores.
+     */
     release: (...args: Args) => void
     equal: EqualFunc<Value>
     name?: string

--- a/packages/valdres/test/memoryleaks.test.ts
+++ b/packages/valdres/test/memoryleaks.test.ts
@@ -307,7 +307,7 @@ describe("memory leaks (subscriptions)", () => {
 })
 
 describe("memory leaks (atom families)", () => {
-    test("released family atom is collected", async () => {
+    test("store-retained family atom is collected with its store", async () => {
         const detector = (() => {
             let s: any = store()
             let family: any = atomFamily<{ name: string }, [string]>(
@@ -316,7 +316,6 @@ describe("memory leaks (atom families)", () => {
             let familyAtom: any = family("alice")
             const d = new LeakDetector(familyAtom)
             s.get(familyAtom)
-            family.release("alice")
             // Clear the local owner chain explicitly before returning the
             // detector; JSC's conservative scan can otherwise treat the ended
             // scope's store/index slots as roots for the whole bounded window.
@@ -341,7 +340,7 @@ describe("memory leaks (atom families)", () => {
         )
     })
 
-    test("family atom value is collected after release and unsubscribe", async () => {
+    test("family atom value is collected after unsubscribe", async () => {
         const detector = (() => {
             const s = store()
             const family = atomFamily<object, [string]>(() => ({}))
@@ -349,7 +348,6 @@ describe("memory leaks (atom families)", () => {
             const d = new LeakDetector(s.get(familyAtom))
             const unsub = s.sub(familyAtom, () => {})
             unsub()
-            family.release("charlie")
             return d
         })()
         expect(await detector.isLeaking()).toBe(false)


### PR DESCRIPTION
## Summary

- deprecate `atomFamily.release()` and retain it as a compatibility no-op so it cannot evict an identity still retained by a store
- add a regression that crosses the weak-cache checkpoint and verifies recreating the same arguments updates one member instead of producing values `[1, 2]`
- document automatic weak-cache collection and remove stale GC-test reliance on manual release

## Staff engineering review

- **Correctness:** preserves the invariant that one live atom-family member object exists per canonical argument key across every store and scope
- **Compatibility:** keeps the public method and its `void` return shape while marking it deprecated; callers that used it only for cache cleanup no longer need it
- **Lifecycle:** confirms store-retained members stay stable while unreachable members and values are still collected automatically
- **Performance:** uses one shared zero-work compatibility function per module; atom-family cache-hit code is unchanged
- **Intentional behavior change:** callers can no longer force a fresh member identity while the old member remains live, because that behavior split state for one logical key

## Validation

- `bun --filter valdres test` — 840 passed, 1 existing todo, 0 failed
- `bun run typecheck:types`
- `bun run build:types`
- atom-family performance benchmark — numeric cache hit ~11 ns; string cache hit ~34 ns
- `git diff --check origin/main...HEAD`
