### PR TITLE
fix(valdres): return immutable family snapshots

### DIFF
--- a/.changeset/immutable-family-snapshots.md
+++ b/.changeset/immutable-family-snapshots.md
@@ -1,0 +1,7 @@
+---
+"valdres": patch
+---
+
+Return atom-family membership as cached, frozen, readonly snapshots and keep
+internal index metadata non-enumerable, preventing callers from corrupting later
+family reads.

--- a/packages/valdres/src/atomFamily.test.ts
+++ b/packages/valdres/src/atomFamily.test.ts
@@ -11,6 +11,28 @@ describe("atomFamily", () => {
         expect(userAtomFamily(1)).toEqual(userAtomFamily(1))
     })
 
+    test("family membership is an immutable snapshot with hidden metadata", () => {
+        const store1 = store()
+        const family = atomFamily<number, [string]>(0)
+        const a = family("a")
+        const b = family("b")
+
+        store1.set(a, 1)
+        store1.set(b, 2)
+        const members = store1.get(family)
+
+        expect(Object.isFrozen(members)).toBe(true)
+        expect(Object.keys(members)).toStrictEqual(["0", "1"])
+        expect(
+            Object.prototype.propertyIsEnumerable.call(members, "__index"),
+        ).toBe(false)
+        expect(() => (members as any).pop()).toThrow(TypeError)
+
+        // The cached fast path still returns the same intact snapshot.
+        expect(store1.get(family)).toBe(members)
+        expect(store1.get(family)).toStrictEqual([a, b])
+    })
+
     test("deleting from one store preserves identity retained by another store", async () => {
         const family = atomFamily((id: string) => `default:${id}`)
         const store1 = store()

--- a/packages/valdres/src/indexConstructor.ts
+++ b/packages/valdres/src/indexConstructor.ts
@@ -63,10 +63,7 @@ export const index = <
         const filteredSelector = selector<AtomFamilyAtom<Value, FamilyArgs>[]>(
             get => {
                 const res: AtomFamilyAtom<Value, FamilyArgs>[] = []
-                const members = get(family) as AtomFamilyAtom<
-                    Value,
-                    FamilyArgs
-                >[]
+                const members = get(family)
                 for (const atom of members) {
                     if (get(predicateFor(atom))) res.push(atom)
                 }

--- a/packages/valdres/src/lib/atomFamilyIndex.ts
+++ b/packages/valdres/src/lib/atomFamilyIndex.ts
@@ -35,17 +35,24 @@ const getSortedKeysByValues = <K, V extends number | string>(
     // res.__in
 }
 
-export const renderAtomFamilyIndex = (index: AtomFamilyIndex) => {
+type RenderedAtomFamilyIndex = readonly AtomFamilyAtom<any, any>[] & {
+    readonly __index: AtomFamilyIndex
+}
+
+export const renderAtomFamilyIndex = (
+    index: AtomFamilyIndex,
+): RenderedAtomFamilyIndex => {
     if (index.renderedArray) {
         return index.renderedArray
     }
     const renderedMap = getAtomFamilyRenderedMap(index)
-    const array = getSortedKeysByValues(renderedMap)
-    // @ts-ignore
-    array.__index = index
-    // @ts-ignore
-    index.renderedArray = array
-    return array
+    const snapshot = getSortedKeysByValues(renderedMap)
+    Object.defineProperty(snapshot, "__index", { value: index })
+    Object.freeze(snapshot)
+    // Object.defineProperty does not refine the array's static type.
+    const renderedSnapshot = snapshot as unknown as RenderedAtomFamilyIndex
+    index.renderedArray = renderedSnapshot
+    return renderedSnapshot
 }
 
 /** Whether this index itself owns a live member. Parent membership is
@@ -61,9 +68,7 @@ export type AtomFamilyIndex = {
     created: Map<AtomFamilyAtom<any, any>, number>
     deleted: Map<AtomFamilyAtom<any, any>, number>
     rendered: Map<AtomFamilyAtom<any, any>, number> | null
-    renderedArray:
-        | (AtomFamilyAtom<any, any>[] & { __index: AtomFamilyIndex })
-        | null
+    renderedArray: RenderedAtomFamilyIndex | null
     parentIndex?: AtomFamilyIndex
 }
 

--- a/packages/valdres/src/lib/atomFamilySnapshot.types.test.ts
+++ b/packages/valdres/src/lib/atomFamilySnapshot.types.test.ts
@@ -1,0 +1,24 @@
+import { test } from "bun:test"
+import { atomFamily } from "../atomFamily"
+import { store } from "../store"
+import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+
+type Expect<T extends true> = T
+type Equal<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+        ? true
+        : false
+
+test("family membership snapshots are readonly", () => {
+    const family = atomFamily<number, [string]>(0)
+    const members = store().get(family)
+
+    type _ = Expect<
+        Equal<typeof members, readonly AtomFamilyAtom<number, [string]>[]>
+    >
+
+    if (false) {
+        // @ts-expect-error family membership snapshots cannot be mutated
+        members.push(family("a"))
+    }
+})

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -142,7 +142,7 @@ export function getState<
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     circularDependencySet?: WeakSet<Selector>,
-): AtomFamilyAtom<Value, Args>[]
+): readonly AtomFamilyAtom<Value, Args>[]
 
 export function getState<
     Value extends any,

--- a/packages/valdres/src/types/GetValue.ts
+++ b/packages/valdres/src/types/GetValue.ts
@@ -10,5 +10,5 @@ export type GetValue = {
     ): Value
     <Value extends any, Args extends [any, ...any[]]>(
         family: AtomFamily<Value, Args>,
-    ): AtomFamilyAtom<Value, Args>[]
+    ): readonly AtomFamilyAtom<Value, Args>[]
 }


### PR DESCRIPTION
## Summary

- render each atom-family membership revision into one cached, frozen snapshot while keeping internal `__index` metadata non-enumerable
- expose `get(family)` as `readonly AtomFamilyAtom[]` and remove the downstream mutable cast
- add red-first runtime and compile-time regressions plus a patch changeset

## Staff engineering review

- **Correctness:** callers can no longer mutate the cached array and corrupt later reads; old snapshots remain stable across subsequent membership revisions
- **Internal safety:** rendered-index consumers only read `__index`; transaction staging uses a separate mutable carrier, so freezing rendered snapshots does not block writes
- **API:** the readonly return type matches the runtime contract for both store and transaction `get` paths
- **Performance:** freezing happens only when membership is rendered; cache hits still return the identical array with no copy or per-read allocation
- **Coverage:** verifies frozen state, hidden metadata, mutation failure, cache identity, intact later reads, and compile-time rejection of mutation

## Validation

- `bun test --reporter=dots` in `packages/valdres` — 853 passed, 1 existing todo, 0 failed
- `bun run typecheck:types`
- package and monorepo `bun run build:types`
- atom-family 5,000-member transaction benchmark — 1.09 ms locally
- focused Prettier check and `git diff --check`