### PR TITLE
fix(valdres): keep root unset observationally neutral

### DIFF
--- a/.changeset/lazy-root-unset.md
+++ b/.changeset/lazy-root-unset.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+"@valdres/redux-devtools": patch
+---
+
+Keep root `unset()` lazy when `store.onChange` is active. Reporting an unset no
+longer evaluates a function or async default just to populate the event; a root
+unset omits `value` unless propagation already rematerialized it. Redux DevTools
+now removes cold root entries when that optional value is absent.

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.test.ts
@@ -251,6 +251,28 @@ describe("connectReduxDevtools", () => {
         scoped.detach()
     })
 
+    test("a root unset removes a cold lazy value without evaluating its default", () => {
+        const fake = makeFakeExtension()
+        install(fake.ext)
+        const s = store()
+        let initCount = 0
+        const a = atom(() => ++initCount, { name: "un_lazy_root" })
+        const handle = connectReduxDevtools(s)
+
+        expect(s.get(a)).toBe(1)
+        s.set(a, 9)
+        expect(fake.sent.at(-1)!.state.un_lazy_root).toBe(9)
+
+        s.unset(a)
+
+        const last = fake.sent.at(-1)!
+        expect(last.action.source).toBe("unset")
+        expect("un_lazy_root" in last.state).toBe(false)
+        expect(initCount).toBe(1)
+        expect(s.get(a)).toBe(2)
+        handle.disconnect()
+    })
+
     test("unset inside a transaction still drops the scope override", () => {
         const fake = makeFakeExtension()
         install(fake.ext)

--- a/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
+++ b/packages/@valdres/redux-devtools/src/connectReduxDevtools.ts
@@ -199,11 +199,13 @@ export const connectReduxDevtools = (
             //  - unset + scope → the override is gone and the scope re-inherits,
             //                    so drop it from `@scopes` rather than showing
             //                    the inherited value as if it were an override.
-            //  - unset + root  → reverted to default; that IS the root's value.
+            //  - unset + root  → apply the default only if a live consumer
+            //                    rematerialized it; otherwise drop the cold entry.
             //  - set           → the new value.
             if (
                 change.kind === "delete" ||
-                (change.kind === "unset" && scopeKey !== null)
+                (change.kind === "unset" &&
+                    (scopeKey !== null || !("value" in change)))
             ) {
                 delete bucket[atomName]
             } else {

--- a/packages/valdres/src/lib/notifyChangeListeners.ts
+++ b/packages/valdres/src/lib/notifyChangeListeners.ts
@@ -1,7 +1,7 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { Selector } from "../types/Selector"
-import type { StoreChange } from "../types/StoreChange"
+import type { AtomChange, StoreChange } from "../types/StoreChange"
 import type { StoreChangeMeta } from "../types/StoreChangeMeta"
 import type { StoreChangeSource } from "../types/StoreChangeSource"
 import type { StoreData } from "../types/StoreData"
@@ -28,6 +28,14 @@ export type ChangeSink = {
     source: StoreChangeSource
     name: string | undefined
     groups: ChangeGroup[]
+    /** Root unset changes whose optional value is finalized immediately before
+     *  dispatch. Allocated only for a watched root unset that is still lazy when
+     *  first buffered; propagation may rematerialize it before the sink flushes. */
+    pendingRootUnsets?: [
+        change: Extract<AtomChange, { kind: "unset" }>,
+        atom: Atom<any>,
+        data: StoreData,
+    ][]
 }
 
 /** Where a propagation's change reports go: a bare `source` tag means emit
@@ -280,15 +288,18 @@ export const reportAtomChanges = (
 }
 
 /** Report that `data`'s own value for `atom` was unset (called from unsetValue,
- *  after the value and its bookkeeping have been removed). The store now reads
- *  `revertedValue` — the inherited parent value on a scope, or the default on a
- *  root — carried as the change's `value`. The change is a `kind: "unset"`, NOT
- *  a `"set"` (so a consumer can drop the override rather than treat the reverted
- *  value as a new write) and NOT a `"delete"` (the atom still exists, only this
- *  store's own value is gone). The batch's `meta.source` is "unset" for a
- *  standalone unset, or "transaction" when buffered into a txn — but the
- *  per-change kind stays "unset" either way, so it's distinguishable even inside
- *  a mixed transaction. */
+ *  after the value and its bookkeeping have been removed). A scope carries its
+ *  inherited `revertedValue`. A root carries `value` only when the atom is
+ *  already materialized; otherwise the property stays absent and a buffered
+ *  report checks once more immediately before dispatch, after propagation had a
+ *  chance to rematerialize it. Reporting never evaluates a lazy default.
+ *
+ *  The change is a `kind: "unset"`, NOT a `"set"` (so a consumer can drop the
+ *  override rather than treat the reverted value as a new write) and NOT a
+ *  `"delete"` (the atom still exists, only this store's own value is gone). The
+ *  batch's `meta.source` is "unset" for a standalone unset, or "transaction"
+ *  when buffered into a txn — but the per-change kind stays "unset" either way,
+ *  so it's distinguishable even inside a mixed transaction. */
 export const reportUnsetAtom = (
     atom: Atom<any>,
     data: StoreData,
@@ -296,17 +307,23 @@ export const reportUnsetAtom = (
     report: ChangeReport,
 ) => {
     if (!hasChangeListener(data)) return
+    const change: Extract<AtomChange, { kind: "unset" }> = {
+        type: "atom",
+        kind: "unset",
+        state: atom,
+        scope: scopePath(data),
+    }
+    if (data.parent) {
+        change.value = revertedValue
+    } else if (data.values.has(atom)) {
+        change.value = data.values.get(atom)
+    } else if (typeof report !== "string") {
+        const pendingRootUnsets = (report.pendingRootUnsets ??= [])
+        pendingRootUnsets.push([change, atom, data])
+    }
     const group: ChangeGroup = {
         data,
-        changes: [
-            {
-                type: "atom",
-                kind: "unset",
-                state: atom,
-                value: revertedValue,
-                scope: scopePath(data),
-            },
-        ],
+        changes: [change],
     }
     emitGroup(group, report)
 }
@@ -355,6 +372,12 @@ export const createChangeSink = (
 
 /** Flush a sink's accumulated changes as a single callback. */
 export const flushChangeSink = (sink: ChangeSink) => {
+    const pendingRootUnsets = sink.pendingRootUnsets
+    if (pendingRootUnsets) {
+        for (const [change, atom, data] of pendingRootUnsets) {
+            if (data.values.has(atom)) change.value = data.values.get(atom)
+        }
+    }
     if (sink.groups.length > 0) {
         notifyChangeListeners(sink.groups, { source: sink.source, name: sink.name })
     }

--- a/packages/valdres/src/lib/unsetValue.test.ts
+++ b/packages/valdres/src/lib/unsetValue.test.ts
@@ -254,13 +254,59 @@ describe("unset — root store", () => {
         expect(root.data.values.has(a)).toBe(false)
     })
 
-    test("a subscriber fires on unset and onChange reports the default with source 'unset'", () => {
+    test("onChange does not evaluate a lazy default solely to report a root unset", () => {
+        const root = store()
+        let initCount = 0
+        const a = atom(() => ++initCount)
+        expect(root.get(a)).toBe(1)
+
+        let received: readonly StoreChange[] = []
+        root.onChange(changes => (received = changes))
+
+        root.unset(a)
+
+        expect(initCount).toBe(1)
+        expect(root.data.values.has(a)).toBe(false)
+        expect(received).toEqual([
+            { type: "atom", kind: "unset", state: a, scope: [] },
+        ])
+        expect(root.get(a)).toBe(2)
+        expect(initCount).toBe(2)
+    })
+
+    test("onChange does not start an async default solely to report a root unset", () => {
+        const root = store()
+        let initCount = 0
+        const a = atom(() => {
+            initCount++
+            return new Promise<number>(() => {})
+        })
+        const first = root.get(a)
+
+        let received: readonly StoreChange[] = []
+        root.onChange(changes => (received = changes))
+
+        root.unset(a)
+
+        expect(initCount).toBe(1)
+        expect(root.data.values.has(a)).toBe(false)
+        expect(received).toEqual([
+            { type: "atom", kind: "unset", state: a, scope: [] },
+        ])
+        const second = root.get(a)
+        expect(initCount).toBe(2)
+        expect(second).not.toBe(first)
+    })
+
+    test("a consumer can rematerialize the default before onChange reports a root unset", () => {
         const root = store()
         const a = atom(1)
+        const doubled = selector(get => get(a) * 2)
         root.set(a, 5)
 
         const sub = mock(() => {})
-        root.sub(a, sub)
+        root.sub(doubled, sub)
+        expect(root.get(doubled)).toBe(10)
         const calls: { changes: readonly StoreChange[]; meta: any }[] = []
         root.onChange((changes, meta) => calls.push({ changes, meta }))
 
@@ -273,6 +319,7 @@ describe("unset — root store", () => {
             { type: "atom", kind: "unset", state: a, value: 1, scope: [] },
         ])
         expect(root.get(a)).toBe(1)
+        expect(root.get(doubled)).toBe(2)
     })
 
     test("a dependent selector re-evaluates after a root atom is unset", () => {
@@ -299,6 +346,26 @@ describe("unset — root store", () => {
         // De-materialized first (a read would re-initialize it), then reverts.
         expect(root.data.values.has(a)).toBe(false)
         expect(root.get(a)).toBe(1)
+    })
+
+    test("transaction onChange does not evaluate a lazy default solely to report a root unset", () => {
+        const root = store()
+        let initCount = 0
+        const a = atom(() => ++initCount)
+        expect(root.get(a)).toBe(1)
+
+        let received: readonly StoreChange[] = []
+        root.onChange(changes => (received = changes))
+
+        root.txn(t => t.unset(a))
+
+        expect(initCount).toBe(1)
+        expect(root.data.values.has(a)).toBe(false)
+        expect(received).toEqual([
+            { type: "atom", kind: "unset", state: a, scope: [] },
+        ])
+        expect(root.get(a)).toBe(2)
+        expect(initCount).toBe(2)
     })
 
     test("reading a root atom mid-transaction after unset returns the default", () => {

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -65,11 +65,12 @@ export const reDelegateScopeSubscriptions = (
  *  - **scoped store** → the inherited parent value (already materialized, since
  *    shadowing an atom always initializes the parent first), so this is a cheap
  *    read-through.
- *  - **root store** → `undefined`; `reportUnsetAtom` reads `data.values` itself
- *    if a live consumer already rematerialized the atom. Reporting must never
- *    evaluate a lazy function/async default: root unset stays observationally
- *    neutral and the next read initializes it exactly as it would without an
- *    `onChange` listener. */
+ *  - **root store** → `undefined`; `reportUnsetAtom` carries an already-
+ *    materialized value when buffering, otherwise omits it and lets the change
+ *    sink recheck `data.values` after propagation. Reporting must never evaluate
+ *    a lazy function/async default: root unset stays observationally neutral and
+ *    the next read initializes it exactly as it would without an `onChange`
+ *    listener. */
 export const effectiveValueAfterUnset = (
     atom: Atom<any>,
     data: StoreData,

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -2,7 +2,6 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isAtom } from "../utils/isAtom"
 import { getState } from "./getState"
-import { getAtomInitValue } from "./initAtom"
 import {
     createChangeSink,
     flushChangeSink,
@@ -60,32 +59,27 @@ export const reDelegateScopeSubscriptions = (
     }
 }
 
-/** The value the store reads for `atom` after its own value was removed, used to
- *  populate the `onChange` report:
+/** The already-available value the store reads for `atom` after its own value
+ *  was removed, used to populate the `onChange` report:
  *
  *  - **scoped store** → the inherited parent value (already materialized, since
  *    shadowing an atom always initializes the parent first), so this is a cheap
  *    read-through.
- *  - **root store** → the atom's default. We deliberately do NOT re-materialize
- *    (write) it: unset's purpose on a root is to drop the stored value and let
- *    the next read re-initialize lazily. If a live consumer re-read the atom
- *    during propagation it is already back in `data.values`, so we report that;
- *    otherwise we compute the default with `getAtomInitValue` (which does not
- *    write). For an atom whose default is a function/async, computing it here
- *    runs the same initializer the next read would run. */
+ *  - **root store** → `undefined`; `reportUnsetAtom` reads `data.values` itself
+ *    if a live consumer already rematerialized the atom. Reporting must never
+ *    evaluate a lazy function/async default: root unset stays observationally
+ *    neutral and the next read initializes it exactly as it would without an
+ *    `onChange` listener. */
 export const effectiveValueAfterUnset = (
     atom: Atom<any>,
     data: StoreData,
 ): unknown => {
     const parent = data.parent
-    if (parent) {
-        const initSet = new Set<Atom>()
-        const value = getState(atom, parent, initSet)
-        if (initSet.size > 0) propagateAtomUpdate([...initSet], parent, true)
-        return value
-    }
-    if (data.values.has(atom)) return data.values.get(atom)
-    return getAtomInitValue(atom, data, new Set())
+    if (!parent) return undefined
+    const initSet = new Set<Atom>()
+    const value = getState(atom, parent, initSet)
+    if (initSet.size > 0) propagateAtomUpdate([...initSet], parent, true)
+    return value
 }
 
 /** Public `store.unset(atom)`: drop the store's own value for `atom` so it
@@ -103,8 +97,10 @@ export const effectiveValueAfterUnset = (
  *  store has no own value for `atom`. Otherwise removes the value + bookkeeping,
  *  notifies subscribers, dependent selectors, and nested scopes of the reverted
  *  value, re-delegates scope subscriptions so future parent changes are observed
- *  again, and reports the change on `store.onChange` as a `kind: "unset"` (carrying
- *  the reverted value) with `meta.source === "unset"`. */
+ *  again, and reports the change on `store.onChange` as a `kind: "unset"` with
+ *  `meta.source === "unset"`. A scope change carries its inherited value. A root
+ *  change carries a value only if propagation rematerialized the atom; otherwise
+ *  the value is omitted to preserve lazy-default semantics. */
 export const unsetValue = <V>(atom: Atom<V>, data: StoreData): void => {
     if (!isAtom(atom)) throw new Error(InvalidStateError)
 

--- a/packages/valdres/src/types/StoreChange.ts
+++ b/packages/valdres/src/types/StoreChange.ts
@@ -9,11 +9,14 @@ import type { Selector } from "./Selector"
  *                 atom resolving, a cache revalidation, …; the originating
  *                 operation is on `StoreChangeMeta.source`).
  *  - `"unset"`  — the store dropped its own value for the atom (`store.unset` /
- *                 `txn.unset`); it now reverts to what it otherwise reads, carried
- *                 as `value` (the inherited parent value on a scope, the default
- *                 on a root). The atom still exists — NOT a `"delete"`. A flat
- *                 value-mirror can read `value`; an inheritance-aware consumer
- *                 switches on the kind to drop the override. `"unset"` is also on
+ *                 `txn.unset`); it now reverts to what it otherwise reads. `value`
+ *                 carries the inherited parent value on a scope. On a root it is
+ *                 present only when a live consumer rematerialized the default
+ *                 during propagation; otherwise it is omitted so reporting the
+ *                 change does not evaluate a lazy default. The atom still exists
+ *                 — NOT a `"delete"`. An inheritance-aware consumer switches on
+ *                 the kind to drop the override; a flat mirror should also drop a
+ *                 root entry when `value` is absent. `"unset"` is also on
  *                 `StoreChangeMeta.source` for a standalone unset, but inside a
  *                 transaction the source is `"transaction"`, so this per-change
  *                 kind is the only signal distinguishing it from a set.
@@ -36,7 +39,7 @@ export type AtomChange =
           type: "atom"
           kind: "unset"
           state: Atom<any> | AtomFamilyAtom<any, any>
-          value: unknown
+          value?: unknown
           scope: string[]
       }
     | {

--- a/packages/valdres/src/types/StoreChangeSource.ts
+++ b/packages/valdres/src/types/StoreChangeSource.ts
@@ -7,13 +7,15 @@
  *  - `"unset"`       — `store.unset`: a store dropped its own value for an atom,
  *                      which now reverts to what it otherwise reads (a scope
  *                      re-inherits the parent; a root reverts to the default).
- *                      The reported change is a `kind: "unset"` carrying that
- *                      reverted value (NOT a `"delete"` — the atom still exists,
- *                      only the store's own value is gone). A consumer keying off
- *                      either `source === "unset"` or the per-change `kind` knows
- *                      to drop the override from a per-store view. Note `txn.unset`
- *                      reports `source === "transaction"`, so inside a txn the
- *                      per-change `kind: "unset"` is the signal that survives.
+ *                      The reported change is a `kind: "unset"` (NOT a
+ *                      `"delete"` — the atom still exists, only the store's own
+ *                      value is gone). A scope carries its inherited value; a
+ *                      root carries a value only when a live consumer already
+ *                      rematerialized it. A consumer keying off either `source
+ *                      === "unset"` or the per-change `kind` knows to drop the
+ *                      override from a per-store view. Note `txn.unset` reports
+ *                      `source === "transaction"`, so inside a txn the per-change
+ *                      `kind: "unset"` is the signal that survives.
  *  - `"transaction"` — `store.txn` (and the implicit commit in `batchUpdates` mode)
  *  - `"revalidate"`  — a maxAge / stale-while-revalidate cache refresh
  *  - `"async-set"`   — a previously-pending async value resolved (an async `set`


### PR DESCRIPTION
## Summary

- keep root `store.unset()` lazy when `store.onChange` is active, so reporting cannot evaluate a function or async default
- omit `AtomChange.value` for a cold root unset, but populate it when propagation already rematerialized the atom; scoped unsets continue carrying their inherited value
- preserve atom-before-selector ordering and transaction/error-path batching by finalizing pending root values immediately before sink dispatch
- make Redux DevTools remove cold root entries when the optional value is absent

## Staff engineering review

- listener-free execution remains on the existing branch with no new work or allocation
- pending bookkeeping is allocated only for a watched root unset that is still unmaterialized
- scoped inheritance, live-selector rematerialization, standalone/transaction ordering, and flush-on-error semantics remain intact
- regression coverage was added red-first for sync defaults, async defaults, transactions, live consumers, and the Redux DevTools mirror

## Performance

Five-round alternating median against `origin/main` (negative is faster):

| Scenario | Base | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Root unset cycle, no listener, function default | 190 ns | 188 ns | -0.8% |
| Root unset cycle, listener, literal default | 512 ns | 511 ns | -0.1% |
| Root unset cycle, listener, function default | 541 ns | 518 ns | -4.2% |
| Root unset cycle, listener + live selector | 1770 ns | 1725 ns | -2.5% |

The standard atom/transaction performance smoke suite also passes all 14 benchmarks.

## Verification

- `valdres`: 856 passed, 1 todo, 0 failed
- `@valdres/redux-devtools`: 34 passed, 0 failed
- public typecheck and both type builds pass
- changeset validation and `git diff --check` pass
