### PR TITLE
ci: stabilize Bencher alerts on main

### DIFF
--- a/.changeset/stabilize-bencher-main-alerts.md
+++ b/.changeset/stabilize-bencher-main-alerts.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only benchmark tracking changes; no published package behavior changes.

--- a/.github/workflows/bencher-base.yml
+++ b/.github/workflows/bencher-base.yml
@@ -1,6 +1,6 @@
 # Bencher base lane — the benchmark CI for this repo. On pushes to main it
-# records the baseline latency series for each runtime and creates/updates the
-# regression Threshold that PRs are gated against.
+# records raw latency and tracks a runner-normalized latency measure over time.
+# PRs use a separate same-runner relative gate in bencher-pr.yml.
 #
 # Project slug is `valdres` (BENCHER_PROJECT below); the project is public, so
 # its perf page and plots are viewable at bencher.dev/perf/valdres.
@@ -12,6 +12,7 @@ on:
 
 permissions:
     checks: write
+    contents: read
 
 concurrency:
     group: bencher-base-${{ github.ref }}
@@ -42,41 +43,52 @@ jobs:
             - name: Install
               run: bun install --frozen-lockfile
 
-            # Measurement layer writes per-implementation latency NDJSON
-            # (bench-utils.ts: measureOne / compare) which we convert to BMF.
-            - name: Run benchmarks (Bun)
+            # Run each runtime three times and take the per-benchmark median in
+            # bench-to-bmf. This rejects one GC/scheduler or JIT-tier outlier
+            # before the cross-run statistical Threshold sees the result.
+            - name: Run benchmarks (Bun + Node, 3×)
               working-directory: packages/valdres
-              run: bun run test:bench
-            - name: Run benchmarks (Node)
-              working-directory: packages/valdres
-              run: bun run test:bench:node
+              run: |
+                  rm -f /tmp/main_bun.ndjson /tmp/main_node.ndjson
+                  for i in 1 2 3; do
+                    bun run test:bench
+                    cat test/performance/bench-results.ndjson >> /tmp/main_bun.ndjson
+                    bun run test:bench:node
+                    cat test/performance/bench-results-node.ndjson >> /tmp/main_node.ndjson
+                  done
 
+            # Raw latency remains in Bencher for plots. The additional
+            # runner-normalized measure divides each gateable Valdres median by
+            # a fixed geometric-mean index of pinned-Jotai controls from the
+            # same run. Shared runner slowdown cancels; Valdres-only slowdown
+            # remains. Reference and sub-noise-floor benchmarks do not receive
+            # the normalized measure and therefore cannot alert on main.
             - name: Convert NDJSON -> Bencher Metric Format
+              env:
+                  BENCH_NDJSON_BUN: /tmp/main_bun.ndjson
+                  BENCH_NDJSON_NODE: /tmp/main_node.ndjson
+                  BENCH_NORMALIZE: "1"
               run: bun run scripts/bench-to-bmf.ts
 
-            # Gate the built-in `latency` measure with a t-test against main's
-            # history (auto-scales tolerance to each benchmark's own variance).
-            # Tuned for noisy shared runners: min-sample-size 6 means a benchmark
-            # isn't gated until it has enough history (kills early-life false
-            # alerts on a thin baseline), and a wide 0.9999 upper boundary
-            # tolerates the ~1.5x wobble heavy/allocation benches show on a loaded
-            # runner while still catching genuine large regressions. NOTE:
-            # thresholds are per-measure, so the jotai/map reference benches are
-            # gated too — stable enough to self-pass; move them to their own
-            # measure if that ever flakes.
+            # Positive ratios are multiplicative, so a log-normal model is a
+            # better fit than the old absolute-latency t-test. 0.9999 keeps the
+            # per-report false-positive budget low across dozens of benchmarks;
+            # min 6 lets the new measure establish history before alerting.
+            # `--thresholds-reset` also removes the obsolete raw-latency model.
             - name: Track Bun baseline
               run: |
                   bencher run \
                     --branch main \
                     --testbed ubuntu-2204-bun \
-                    --threshold-measure latency \
-                    --threshold-test t_test \
+                    --threshold-measure runner-normalized-latency-v1 \
+                    --threshold-test log_normal \
                     --threshold-min-sample-size 6 \
                     --threshold-max-sample-size 64 \
                     --threshold-upper-boundary 0.9999 \
                     --thresholds-reset \
                     --adapter json \
                     --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+                    --ci-id main-bun-normalized \
                     --file packages/valdres/bun_results.json
 
             - name: Track Node baseline
@@ -84,12 +96,13 @@ jobs:
                   bencher run \
                     --branch main \
                     --testbed ubuntu-2204-node \
-                    --threshold-measure latency \
-                    --threshold-test t_test \
+                    --threshold-measure runner-normalized-latency-v1 \
+                    --threshold-test log_normal \
                     --threshold-min-sample-size 6 \
                     --threshold-max-sample-size 64 \
                     --threshold-upper-boundary 0.9999 \
                     --thresholds-reset \
                     --adapter json \
                     --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+                    --ci-id main-node-normalized \
                     --file packages/valdres/node_results.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,5 +52,5 @@ Changesets. Any PR touching a publishable package needs `bunx changeset` committ
 
 ## Benchmarks
 
-- Benchmarks live in `packages/valdres/test/performance/*.bench.ts` (mitata via the `compare` / `measureOne` helpers in `bench-utils.ts`) and report to [Bencher](https://bencher.dev/perf/valdres) through `.github/workflows/bencher-{base,pr}.yml`. Bencher gates PRs on per-benchmark `latency` regressions vs `main`; the hosted perf page is the source of truth. The README's `BENCH` table and `docs/content/bench-summary.json` are committed snapshots auto-refreshed from Bencher — don't hand-edit.
+- Benchmarks live in `packages/valdres/test/performance/*.bench.ts` (mitata via the `compare` / `measureOne` helpers in `bench-utils.ts`) and report to [Bencher](https://bencher.dev/perf/valdres) through `.github/workflows/bencher-{base,pr}.yml`. PRs use a same-runner relative `latency` gate; `main` tracks median-of-three raw latency plus a pinned-Jotai runner-normalized measure for cumulative regressions. The hosted perf page is the source of truth. The README's `BENCH` table and `docs/content/bench-summary.json` are committed snapshots auto-refreshed from Bencher — don't hand-edit.
 - New perf work needs head-to-head comparisons against the relevant competitor (Jotai for core, Recoil/MiniSearch/etc. where applicable), not isolated numbers.

--- a/packages/valdres/test/performance/atomFamily.bench.ts
+++ b/packages/valdres/test/performance/atomFamily.bench.ts
@@ -10,9 +10,7 @@ import { do_not_optimize } from "mitata"
 
 describe("atomFamily", () => {
     test("create atoms from family", async () => {
-        const vFamily = valdresAtomFamily<string, [number]>(
-            id => `user-${id}`,
-        )
+        const vFamily = valdresAtomFamily<string, [number]>(id => `user-${id}`)
         const jFamily = jotaiAtomFamily((id: number) => jotaiAtom(`user-${id}`))
 
         let vCounter = 0
@@ -27,9 +25,7 @@ describe("atomFamily", () => {
 
 describe("atomFamily cache hit", () => {
     test("atomFamily cache hit", async () => {
-        const vFamily = valdresAtomFamily<string, [number]>(
-            id => `user-${id}`,
-        )
+        const vFamily = valdresAtomFamily<string, [number]>(id => `user-${id}`)
         const jFamily = jotaiAtomFamily((id: number) => jotaiAtom(`user-${id}`))
 
         // Prime the cache
@@ -38,8 +34,8 @@ describe("atomFamily cache hit", () => {
 
         // valdres's atomFamily cache hit is ~2x slower than jotai's on quiet
         // hardware (a known optimization target). It sits near the timer-
-        // resolution floor (~16ns), so its absolute latency is noisy; Bencher's
-        // t-test widens the band accordingly — tracked, not tightly gated.
+        // resolution floor (~16ns), so its absolute latency is noisy. It stays
+        // in the raw history and plots but is excluded from both CI gates.
         await compare(
             "atomFamily(id) cache hit",
             () => do_not_optimize(vFamily(1)),
@@ -112,7 +108,7 @@ describe("selectorFamily", () => {
         const jAtom = jotaiAtom(0)
 
         const vFamily = valdresSelectorFamily<number, [number]>(
-            (id) => (get) => get(vAtom) + id,
+            id => get => get(vAtom) + id,
         )
         const jFamily = jotaiAtomFamily((id: number) =>
             jotaiAtom(get => get(jAtom) + id),

--- a/packages/valdres/test/performance/bench-utils.ts
+++ b/packages/valdres/test/performance/bench-utils.ts
@@ -27,8 +27,8 @@ const MEASURE_ONE_OPTS = {
 }
 
 // Record one absolute latency (ns) for a benchmark. mitata's measure() already
-// returns a robust, tail-trimmed p50; Bencher's t-test owns cross-run noise, so
-// we report p50 directly with no extra outlier filtering.
+// returns a robust, tail-trimmed p50. The CI workflows repeat the suite and
+// bench-to-bmf takes the cross-run median before Bencher evaluates it.
 export async function measureOne(name: string, fn: () => void) {
     const stats = await measure(fn, MEASURE_ONE_OPTS)
     console.log(`  ${name}: ${fmtNs(stats.p50)}`)
@@ -40,9 +40,9 @@ export async function measureOne(name: string, fn: () => void) {
 
 // Measure valdres and a reference implementation for the same operation as two
 // separate `latency` benchmarks — "<op> / valdres" and "<op> / <ref>". The
-// comparison is read off an overlaid Bencher plot; each series is gated against
-// its own history. The two sides are measured in independent windows on purpose
-// (no in-process ratio) — Bencher is the gate.
+// comparison is read off an overlaid Bencher plot. Main also uses a fixed set of
+// pinned-Jotai series to normalize runner-wide slowdown; PRs gate Valdres only.
+// The two sides use independent measurement windows so each retains a robust p50.
 export async function compare(
     op: string,
     valdresFn: () => void,

--- a/packages/valdres/test/performance/scope.bench.ts
+++ b/packages/valdres/test/performance/scope.bench.ts
@@ -7,8 +7,8 @@ import { store as valdresCreateStore } from "../../src/store"
 
 // Valdres-only scope-propagation scaling (jotai has no scopes, so there is no
 // competitor here). Recorded as `latency` benchmarks via measureOne so Bencher
-// tracks and t-test-gates them like the rest of the suite, rather than only
-// printing to the console.
+// tracks them, gates PRs against the same-runner base, and includes them in the
+// runner-normalized main history rather than only printing to the console.
 describe("scope propagation", () => {
     test("acquire and detach another handle for an existing scope", async () => {
         const root = valdresCreateStore()

--- a/scripts/bench-to-bmf.test.ts
+++ b/scripts/bench-to-bmf.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import {
+    NORMALIZED_LATENCY_MEASURE,
+    RUNNER_CONTROL_BENCHMARKS,
+    toBmf,
+} from "./bench-to-bmf"
+import type { BenchResult } from "./lib/read-bench-results"
+
+const latency = (name: string, ns: number): BenchResult => ({
+    kind: "latency",
+    name,
+    ns,
+})
+
+const controls = (ns: number): BenchResult[] =>
+    RUNNER_CONTROL_BENCHMARKS.map(name => latency(name, ns))
+
+describe("bench-to-bmf", () => {
+    test("normalizes gateable Valdres benchmarks with the fixed control index", () => {
+        const bmf = toBmf(
+            [
+                ...controls(10),
+                latency("get 1000 atoms / valdres", 100),
+                latency("get 1000 atoms / valdres", 300),
+                latency("get 1000 atoms / valdres", 200),
+                latency("scope: set atom, 5 scopes (realistic)", 60),
+                latency("store.get(atom) / valdres", 20),
+                latency("new comparison / jotai", 1_000_000),
+            ],
+            { normalize: true },
+        )
+
+        expect(bmf["get 1000 atoms / valdres"].latency.value).toBe(200)
+        expect(
+            bmf["get 1000 atoms / valdres"][NORMALIZED_LATENCY_MEASURE].value,
+        ).toBeCloseTo(20)
+        expect(
+            bmf["scope: set atom, 5 scopes (realistic)"][
+                NORMALIZED_LATENCY_MEASURE
+            ].value,
+        ).toBeCloseTo(6)
+        expect(bmf["store.get(atom) / valdres"]).toEqual({
+            latency: { value: 20 },
+        })
+        expect(bmf["new comparison / jotai"]).toEqual({
+            latency: { value: 1_000_000 },
+        })
+    })
+
+    test("cancels a runner-wide multiplicative slowdown", () => {
+        const normal = toBmf(
+            [...controls(10), latency("set 1000 atoms / valdres", 250)],
+            { normalize: true },
+        )
+        const slowRunner = toBmf(
+            [...controls(20), latency("set 1000 atoms / valdres", 500)],
+            { normalize: true },
+        )
+
+        expect(
+            normal["set 1000 atoms / valdres"][NORMALIZED_LATENCY_MEASURE]
+                .value,
+        ).toBeCloseTo(
+            slowRunner["set 1000 atoms / valdres"][NORMALIZED_LATENCY_MEASURE]
+                .value,
+        )
+    })
+
+    test("uses a geometric mean for differently scaled controls", () => {
+        const mixedControls = RUNNER_CONTROL_BENCHMARKS.map((name, index) =>
+            latency(name, index % 2 === 0 ? 1 : 100),
+        )
+        const bmf = toBmf(
+            [...mixedControls, latency("set 1000 atoms / valdres", 200)],
+            { normalize: true },
+        )
+
+        // Four controls at 1 and four at 100 have a geometric mean of 10.
+        expect(
+            bmf["set 1000 atoms / valdres"][NORMALIZED_LATENCY_MEASURE].value,
+        ).toBeCloseTo(20)
+    })
+
+    test("fails closed when a fixed runner control is missing", () => {
+        expect(() =>
+            toBmf(
+                [
+                    ...controls(10).slice(1),
+                    latency("set 1000 atoms / valdres", 250),
+                ],
+                { normalize: true },
+            ),
+        ).toThrow(`Missing runner controls: ${RUNNER_CONTROL_BENCHMARKS[0]}`)
+    })
+
+    test("preserves PR filtering without requiring normalization", () => {
+        const bmf = toBmf(
+            [
+                latency("get 1000 atoms / valdres", 100),
+                latency("get 1000 atoms / jotai", 200),
+                latency("store.get(atom) / valdres", 20),
+            ],
+            { excludeRefs: true, excludeTiny: true },
+        )
+
+        expect(bmf).toEqual({
+            "get 1000 atoms / valdres": { latency: { value: 100 } },
+        })
+    })
+})

--- a/scripts/bench-to-bmf.ts
+++ b/scripts/bench-to-bmf.ts
@@ -1,15 +1,19 @@
 /**
  * Converts the benchmark NDJSON (from bench-utils.ts) into Bencher Metric
- * Format (BMF), one file per runtime/testbed. A SINGLE measure: the built-in
- * `latency` (nanoseconds — units are set automatically by Bencher).
+ * Format (BMF), one file per runtime/testbed. Every benchmark gets the built-in
+ * `latency` measure (nanoseconds — units are set automatically by Bencher).
+ * When BENCH_NORMALIZE is set, gateable Valdres benchmarks also get the custom
+ * `runner-normalized-latency-v1` measure. It divides latency by a fixed
+ * geometric-mean index of pinned-Jotai controls from the same run, cancelling
+ * runner-wide slowdown while preserving Valdres-specific regressions.
  *
  * Each benchmark is one implementation of an operation, named "<op> / <impl>"
  * (e.g. "store.get(atom) / valdres", "store.get(atom) / jotai",
  * "store.get(atom) / map"). The competitor / native-floor comparison is read
- * off a Bencher plot by overlaying the sibling benchmarks; regression gating is
- * per-benchmark against the base branch. Names are deduped — an implementation
- * can be measured in more than one comparison (e.g. valdres.get appears in both
- * the vs-jotai and vs-map comparisons).
+ * off a Bencher plot by overlaying the sibling benchmarks. PRs gate Valdres
+ * latency against a same-runner base; main gates only the normalized measure.
+ * Names are deduped — an implementation can be measured in more than one
+ * comparison (e.g. valdres.get appears in both the vs-jotai and vs-map plots).
  *
  *   bench-results.ndjson       -> packages/valdres/bun_results.json   (testbed ubuntu-2204-bun)
  *   bench-results-node.ndjson  -> packages/valdres/node_results.json  (testbed ubuntu-2204-node)
@@ -20,7 +24,13 @@ import { type BenchResult, readBenchResults } from "./lib/read-bench-results"
 import { median } from "./lib/median"
 
 type Metric = { value: number; lower_value?: number; upper_value?: number }
-type Bmf = Record<string, Record<string, Metric>>
+export type Bmf = Record<string, Record<string, Metric>>
+
+export interface BmfOptions {
+    excludeRefs?: boolean
+    excludeTiny?: boolean
+    normalize?: boolean
+}
 
 const ROOT = join(import.meta.dir, "..")
 const PERF_DIR = join(ROOT, "packages/valdres/test/performance")
@@ -46,38 +56,106 @@ const UNGATEABLE_OPS = new Set([
     "atom(1)", // ~2ns
     "selector(fn)", // ~5ns
     "atomFamily(id) cache hit", // ~10ns
+    "atomFamily(string) cache hit", // ~25ns
+    "selectorFamily(string) cache hit", // ~60ns
     // The single-call p50 flips between JIT tiers on the same runner (roughly
     // 15-40ns). The identical hot path remains gated by "get 1000 atoms",
     // whose aggregated window is stable enough for a percentage boundary.
     "store.get(atom)",
 ])
 
-function toBmf(results: BenchResult[]): Bmf {
+// Versioned because changing the control set changes the scale of every metric.
+// If a control ever needs replacing, create a v2 measure instead of silently
+// splicing a different scale into v1's history. Jotai is exactly pinned in the
+// package manifest, and these controls span the suite from microseconds to tens
+// of milliseconds so one workload or transient cannot dominate the index.
+export const NORMALIZED_LATENCY_MEASURE = "runner-normalized-latency-v1"
+export const RUNNER_CONTROL_BENCHMARKS = [
+    "set(atom) with 10 subs / jotai",
+    "atom lifecycle (create+100get+100set) / jotai",
+    "sub + unsub / jotai",
+    "set(atom, curr => curr+1) / jotai",
+    "get 1000 atoms / jotai",
+    "txn: cross-atom 1000 selectors, with subs / jotai",
+    "txn: asymmetric DAG shared sink / jotai",
+    "txn: large asymmetric DAG (1000 leaves × 50 chain) / jotai",
+] as const
+
+function geometricMean(values: number[]): number {
+    if (
+        values.length === 0 ||
+        values.some(value => !Number.isFinite(value) || value <= 0)
+    ) {
+        throw new Error(
+            "Runner controls must contain finite, positive latencies",
+        )
+    }
+    return Math.exp(
+        values.reduce((sum, value) => sum + Math.log(value), 0) / values.length,
+    )
+}
+
+export function toBmf(results: BenchResult[], options: BmfOptions = {}): Bmf {
     // The relative-CB gate runs the suite multiple times and concatenates the
     // NDJSON, so a benchmark name legitimately appears once per repeat. Keep the
     // MEDIAN latency across repeats: with three runs it rejects either one slow
     // GC/scheduler sample or one anomalously fast JIT sample. Min-of-three only
     // rejected slow outliers and could turn one lucky base result into a false
-    // regression. A single run (the base lane) yields median-of-one.
+    // regression. A single local run still yields median-of-one.
     //
     // BENCH_EXCLUDE_REFS drops the competitor/native-floor sides. The PR gate
     // sets it because those benches can't regress from a valdres change (jotai
     // is pinned, map is native) — gating them only adds noise. They're still
     // measured and plotted via the base lane (bencher-base.yml) for the
     // head-to-head perf page.
-    const excludeRefs = !!process.env.BENCH_EXCLUDE_REFS
-    const excludeTiny = !!process.env.BENCH_EXCLUDE_TINY
+    const {
+        excludeRefs = false,
+        excludeTiny = false,
+        normalize = false,
+    } = options
     const samples: Record<string, number[]> = {}
     for (const r of results) {
-        if (excludeRefs && isReference(r.name)) continue
-        if (excludeTiny && UNGATEABLE_OPS.has(opName(r.name))) continue
         samples[r.name] ??= []
         samples[r.name].push(r.ns)
     }
 
+    const latencies = new Map(
+        Object.entries(samples).map(([name, values]) => [name, median(values)]),
+    )
+    let runnerControlIndex: number | undefined
+    if (normalize) {
+        const missingControls = RUNNER_CONTROL_BENCHMARKS.filter(
+            name => !latencies.has(name),
+        )
+        if (missingControls.length > 0) {
+            throw new Error(
+                `Missing runner controls: ${missingControls.join(", ")}`,
+            )
+        }
+        runnerControlIndex = geometricMean(
+            RUNNER_CONTROL_BENCHMARKS.map(name => latencies.get(name)!),
+        )
+    }
+
     const bmf: Bmf = {}
-    for (const [name, values] of Object.entries(samples)) {
-        bmf[name] = { latency: { value: median(values) } }
+    for (const [name, latency] of latencies) {
+        if (excludeRefs && isReference(name)) continue
+        if (excludeTiny && UNGATEABLE_OPS.has(opName(name))) continue
+
+        const measures: Record<string, Metric> = { latency: { value: latency } }
+        // Raw latency remains available for every benchmark and for the public
+        // comparison plots. Only Valdres-owned, sufficiently large benchmarks
+        // get the normalized measure that main's Threshold evaluates.
+        if (
+            runnerControlIndex !== undefined &&
+            !isReference(name) &&
+            !UNGATEABLE_OPS.has(opName(name))
+        ) {
+            measures[NORMALIZED_LATENCY_MEASURE] = {
+                value: latency / runnerControlIndex,
+            }
+        }
+        bmf[name] = measures
     }
     return bmf
 }
@@ -87,8 +165,12 @@ function toBmf(results: BenchResult[]): Bmf {
 // the base SHA ships an older bench-to-bmf that would reject the repeated names.
 const lanes = [
     {
-        ndjson: process.env.BENCH_NDJSON_BUN ?? join(PERF_DIR, "bench-results.ndjson"),
-        out: process.env.BENCH_OUT_BUN ?? join(ROOT, "packages/valdres/bun_results.json"),
+        ndjson:
+            process.env.BENCH_NDJSON_BUN ??
+            join(PERF_DIR, "bench-results.ndjson"),
+        out:
+            process.env.BENCH_OUT_BUN ??
+            join(ROOT, "packages/valdres/bun_results.json"),
     },
     {
         ndjson:
@@ -100,13 +182,25 @@ const lanes = [
     },
 ]
 
-for (const lane of lanes) {
-    const results = readBenchResults(lane.ndjson)
-    if (results.length === 0) {
-        console.warn(`No results in ${lane.ndjson} — skipping ${lane.out}`)
-        continue
+if (import.meta.main) {
+    const options: BmfOptions = {
+        excludeRefs: !!process.env.BENCH_EXCLUDE_REFS,
+        excludeTiny: !!process.env.BENCH_EXCLUDE_TINY,
+        normalize: !!process.env.BENCH_NORMALIZE,
     }
-    const bmf = toBmf(results)
-    writeFileSync(lane.out, JSON.stringify(bmf, null, 2))
-    console.log(`Wrote ${Object.keys(bmf).length} benchmarks -> ${lane.out}`)
+    for (const lane of lanes) {
+        const results = readBenchResults(lane.ndjson)
+        if (results.length === 0) {
+            console.warn(`No results in ${lane.ndjson} — skipping ${lane.out}`)
+            continue
+        }
+        const bmf = toBmf(results, options)
+        writeFileSync(lane.out, JSON.stringify(bmf, null, 2))
+        const normalized = options.normalize
+            ? ` with ${NORMALIZED_LATENCY_MEASURE}`
+            : ""
+        console.log(
+            `Wrote ${Object.keys(bmf).length} benchmarks${normalized} -> ${lane.out}`,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- run the Bun and Node base benchmarks three times and report the per-benchmark median
- add a versioned `runner-normalized-latency-v1` measure based on the geometric mean of eight fixed, pinned-Jotai controls while preserving every raw latency series
- gate stable Valdres metrics on a conservative log-normal threshold and remove the noisy historical raw-latency model
- exclude reference and sub-noise-floor metrics from main alerts, and add focused converter tests and benchmark documentation

## Why

Hosted-runner speed changes were producing false main-branch alerts, including on reference benchmarks. Normalizing against controls measured on the same runner cancels broad runner slowdown while retaining longitudinal detection of Valdres-specific regressions. The same-runner relative PR gate remains in place.

## Validation

- `bun test ./scripts/bench-to-bmf.test.ts` — 5 passed
- Bun benchmark suite — 48 passed
- Node benchmark suite — 48 passed
- normalized BMF conversion — 87 raw and 45 protected metrics per runtime
- `bun run typecheck:types`
- Prettier and `git diff --check`
- `actionlint` on the changed base workflow
- Bencher v0.6.6 dry-run with the custom measure and threshold payload

## Rollout note

The new measure needs six main samples before its boundary becomes active. The first main run resets the obsolete raw-latency threshold; existing historical alert records still require a one-time dismissal in Bencher.