### PR TITLE
perf(valdres): index affected scope branches

### DIFF
--- a/.changeset/index-affected-scope-branches.md
+++ b/.changeset/index-affected-scope-branches.md
@@ -1,0 +1,12 @@
+---
+"valdres": patch
+---
+
+Index active inherited dependencies by immediate scope branch so parent atom
+updates traverse only subtrees with affected selectors. The index follows
+dynamic dependency churn, nested atom shadows, `unset`, unsubscribe cleanup, and
+scope detach; atom-family membership inheritance remains branch-aware.
+
+Root atom-set latency with 10,000 idle scopes is now effectively flat against
+the no-scope path (~90ns in the Bun benchmark), instead of scaling into hundreds
+of microseconds by visiting every scope.

--- a/packages/valdres/src/lib/asyncDependencyTracking.ts
+++ b/packages/valdres/src/lib/asyncDependencyTracking.ts
@@ -3,6 +3,7 @@ import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import { getState } from "./getState"
+import { addStateDependent } from "./inheritedDependencyBranches"
 import {
     activateSelectorGraph,
     isLive,
@@ -29,17 +30,6 @@ export const isSuspendError = (
     return e instanceof SuspendAndWaitForResolveError
 }
 
-export const getOrInitDependentsSet = (
-    state: State,
-    data: StoreData,
-): Set<State<any>> => {
-    const set = data.stateDependents.get(state)
-    if (set) return set
-    const newSet = new Set<State>()
-    data.stateDependents.set(state, newSet)
-    return newSet
-}
-
 /**
  * Handle a deferred `get` call — one that runs after the synchronous
  * evaluation of the selector has already completed (e.g. inside a
@@ -62,8 +52,7 @@ export const lateGet = (
         deps.add(state)
         if (data.selectorGraphActive.has(selector)) {
             noteDependencyGraphChanged(selector, data)
-            const dependents = getOrInitDependentsSet(state, data)
-            dependents.add(selector)
+            addStateDependent(state, selector, data)
             // New edge: keep the mount-closure marker's no-false-negative invariant.
             noteDependencyAdded(selector, state, data)
         } else {

--- a/packages/valdres/src/lib/cleanupOrphanedDeps.ts
+++ b/packages/valdres/src/lib/cleanupOrphanedDeps.ts
@@ -1,6 +1,7 @@
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Selector } from "../types/Selector"
+import { removeStateDependent } from "./inheritedDependencyBranches"
 import { isLive } from "./mountAtom"
 import { noteStateValueChanged } from "./stateRevisions"
 
@@ -49,7 +50,7 @@ export const cleanupOrphanedDeps = (state: State, data: StoreData) => {
             data.latestEvalContext.delete(selector)
 
             for (const dep of deps) {
-                data.stateDependents.get(dep)?.delete(current)
+                removeStateDependent(dep, current, data)
             }
             data.stateDependencies.delete(current)
             // The active marker is weak and can remain through teardown. A

--- a/packages/valdres/src/lib/createStoreData.ts
+++ b/packages/valdres/src/lib/createStoreData.ts
@@ -26,6 +26,7 @@ Object.defineProperties(lazyProto, {
     subscriptionsRequireEqualCheck: makeLazyGetter("subscriptionsRequireEqualCheck"),
     stateDependents: makeLazyGetter("stateDependents"),
     stateDependencies: makeLazyGetter("stateDependencies"),
+    inheritedDependencyBranches: makeLazyGetter("inheritedDependencyBranches"),
     selectorGraphActive: makeLazyGetter(
         "selectorGraphActive",
         () => new WeakSet(),
@@ -116,6 +117,7 @@ export function createStoreData(
         data.parent = parent
         data.scopeConsumers = new Set()
         data.scopeIndexKeys = new Set()
+        data.inheritedDependencyKeys = undefined
     }
     return data
 }

--- a/packages/valdres/src/lib/disposeStoreData.ts
+++ b/packages/valdres/src/lib/disposeStoreData.ts
@@ -1,5 +1,6 @@
 import type { GlobalAtom } from "../types/GlobalAtom"
 import type { StoreData } from "../types/StoreData"
+import { detachInheritedDependencyBranches } from "./inheritedDependencyBranches"
 import { deleteMaxAgeCleanup, getMaxAgeCleanup } from "./maxAgeCleanups"
 import { unmountAtom } from "./mountAtom"
 import { getTouchedGlobals, markStoreDisposed } from "./storeLifecycle"
@@ -30,6 +31,7 @@ export const disposeStoreData = (data: StoreData): void => {
         // also what the ref-counted ScopedStore.detach() path needs to release.
         const parent = current.parent
         if (parent) {
+            detachInheritedDependencyBranches(current, current === data)
             if (parent.scopes.get(current.id) === current) {
                 parent.scopes.delete(current.id)
             }

--- a/packages/valdres/src/lib/inheritedDependencyBranches.ts
+++ b/packages/valdres/src/lib/inheritedDependencyBranches.ts
@@ -1,0 +1,129 @@
+import type { State } from "../types/State"
+import type { StoreData } from "../types/StoreData"
+import { isAtom } from "../utils/isAtom"
+import { isAtomFamily } from "../utils/isAtomFamily"
+
+/** Only atoms and atom families read through a scope boundary. Selectors are
+ * evaluated per store, so their reverse edges never belong in the branch index. */
+const isInheritedState = (state: State) => isAtom(state) || isAtomFamily(state)
+
+/** Recompute whether `data` should be present in its parent's branch set for
+ * `state`, then carry an actual membership transition toward the root.
+ *
+ * A branch is relevant when this store has a local active dependent or a
+ * relevant child branch. An atom shadow stops that relevance from escaping to
+ * the parent; atom-family indexes are overlays and always inherit membership. */
+export const refreshInheritedDependencyBranch = (
+    state: State,
+    start: StoreData,
+) => {
+    if (!isInheritedState(state)) return
+
+    let data = start
+    while (data.parent) {
+        const registeredKeys = data.inheritedDependencyKeys
+        const isRegistered = registeredKeys?.has(state) ?? false
+        const hasDependent =
+            !!data.stateDependents.get(state)?.size ||
+            !!data.inheritedDependencyBranches.get(state)?.size
+        const inherits = isAtomFamily(state) || !data.values.has(state)
+        const shouldRegister = hasDependent && inherits
+
+        // The parent's view of this whole subtree did not change, so no higher
+        // ancestor can change either.
+        if (isRegistered === shouldRegister) return
+
+        const parent = data.parent
+        if (shouldRegister) {
+            let branches = parent.inheritedDependencyBranches.get(state)
+            if (!branches) {
+                branches = new Set()
+                parent.inheritedDependencyBranches.set(state, branches)
+            }
+            branches.add(data)
+            ;(data.inheritedDependencyKeys ??= new Set()).add(state)
+        } else {
+            const branches = parent.inheritedDependencyBranches.get(state)
+            if (branches) {
+                branches.delete(data)
+                if (branches.size === 0) {
+                    parent.inheritedDependencyBranches.delete(state)
+                }
+            }
+            registeredKeys?.delete(state)
+        }
+
+        data = parent
+    }
+}
+
+/** Add one committed reverse dependency edge and publish the branch only on
+ * the zero-to-one transition for this state in this store. */
+export const addStateDependent = (
+    state: State,
+    dependent: State,
+    data: StoreData,
+) => {
+    let dependents = data.stateDependents.get(state) as Set<State> | undefined
+    if (!dependents) {
+        dependents = new Set()
+        data.stateDependents.set(state, dependents)
+    }
+    const wasEmpty = dependents.size === 0
+    dependents.add(dependent)
+    if (wasEmpty && dependents.size !== 0 && data.parent) {
+        refreshInheritedDependencyBranch(state, data)
+    }
+    return dependents
+}
+
+/** Remove one committed reverse dependency edge and retract the branch only on
+ * the one-to-zero transition for this state in this store. */
+export const removeStateDependent = (
+    state: State,
+    dependent: State,
+    data: StoreData,
+) => {
+    const dependents = data.stateDependents.get(state) as Set<State> | undefined
+    if (!dependents || !dependents.delete(dependent)) return false
+    if (dependents.size === 0 && data.parent) {
+        refreshInheritedDependencyBranch(state, data)
+    }
+    return true
+}
+
+/** True when at least one input has an affected immediate child branch. */
+export const hasInheritedDependencyBranches = (
+    states: Iterable<State>,
+    data: StoreData,
+) => {
+    if (data.scopes.size === 0) return false
+    for (const state of states) {
+        if (data.inheritedDependencyBranches.get(state)?.size) return true
+    }
+    return false
+}
+
+/** Remove a scope's registrations from its parent. `propagate` is disabled for
+ * descendants while disposing a whole subtree: their parent is being disposed
+ * too, and refreshing it could re-register the already-detached subtree root. */
+export const detachInheritedDependencyBranches = (
+    data: StoreData,
+    propagate = true,
+) => {
+    const parent = data.parent
+    const keys = data.inheritedDependencyKeys
+    if (!parent || !keys || keys.size === 0) return
+
+    for (const state of [...keys] as State[]) {
+        const branches = parent.inheritedDependencyBranches.get(state)
+        if (branches) {
+            branches.delete(data)
+            if (branches.size === 0) {
+                parent.inheritedDependencyBranches.delete(state)
+            }
+        }
+        keys.delete(state)
+        if (propagate) refreshInheritedDependencyBranch(state, parent)
+    }
+}

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -14,10 +14,13 @@ import { isSelector } from "../utils/isSelector"
 import {
     SuspendAndWaitForResolveError,
     cleanUpRejectedPromise,
-    getOrInitDependentsSet,
     lateGet,
 } from "./asyncDependencyTracking"
 import { getState } from "./getState"
+import {
+    addStateDependent,
+    removeStateDependent,
+} from "./inheritedDependencyBranches"
 import {
     activateSelectorGraph,
     isLive,
@@ -342,16 +345,14 @@ const evaluateLiveOnlySelector = <V>(
             const prev = currentDependencies ?? new Set<State<any>>()
             for (const state of updatedDependencies) {
                 if (!prev.has(state)) {
-                    const set = getOrInitDependentsSet(state, data)
-                    set.add(selector)
+                    addStateDependent(state, selector, data)
                     noteDependencyAdded(selector, state, data)
                 }
             }
             if (!isAsyncResult) {
                 for (const state of prev) {
                     if (!updatedDependencies.has(state)) {
-                        const set = getOrInitDependentsSet(state, data)
-                        set.delete(selector)
+                        removeStateDependent(state, selector, data)
                         if (
                             data.livenessPassActive &&
                             isSelector(state)
@@ -639,8 +640,7 @@ export const evaluateSelector = <V>(
             for (const state of updatedDependencies) {
                 if (!prev.has(state)) {
                     if (tracksReverseEdges) {
-                        const set = getOrInitDependentsSet(state, data)
-                        set.add(selector)
+                        addStateDependent(state, selector, data)
                         // New edge: propagate the mount-closure marker up so the
                         // mount/unmount walk-skip stays free of false negatives.
                         noteDependencyAdded(selector, state, data)
@@ -665,8 +665,7 @@ export const evaluateSelector = <V>(
                 for (const state of prev) {
                     if (!updatedDependencies.has(state)) {
                         if (tracksReverseEdges) {
-                            const set = getOrInitDependentsSet(state, data)
-                            set.delete(selector)
+                            removeStateDependent(state, selector, data)
                             if (depsChangeOut) {
                                 if (!depsChangeOut.removed)
                                     depsChangeOut.removed = new Set<State>()
@@ -869,8 +868,7 @@ export const handleSelectorResult = <Value>(
                             }
                             currentDeps.delete(dep)
                             if (tracksReverseEdges) {
-                                const dependents = data.stateDependents.get(dep)
-                                if (dependents) dependents.delete(selector)
+                                removeStateDependent(dep, selector, data)
                                 if (selectorIsLive) {
                                     onLiveDependencyRemoved(dep, data)
                                 }

--- a/packages/valdres/src/lib/mountAtom.ts
+++ b/packages/valdres/src/lib/mountAtom.ts
@@ -1,6 +1,7 @@
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import { isSelector } from "../utils/isSelector"
+import { addStateDependent } from "./inheritedDependencyBranches"
 import { noteDependencyGraphChanged } from "./noteDependencyGraphChanged"
 import { storeFromStoreData } from "./storeFromStoreData"
 
@@ -142,12 +143,7 @@ export const activateSelectorGraph = (root: State, data: StoreData) => {
         if (!dependencies) continue
         noteDependencyGraphChanged(selector, data)
         for (const dependency of dependencies) {
-            let dependents = data.stateDependents.get(dependency)
-            if (!dependents) {
-                dependents = new Set<State>()
-                data.stateDependents.set(dependency, dependents)
-            }
-            dependents.add(selector)
+            addStateDependent(dependency, selector, data)
             noteDependencyAdded(selector, dependency, data)
             if (isSelector(dependency)) stack.push(dependency)
         }

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.test.ts
@@ -191,6 +191,126 @@ test("propagateUpdatedAtoms", () => {
 })
 
 describe("scopeValueIndex", () => {
+    test("root writes do not scan idle scope branches", () => {
+        const rootStore = store()
+        const source = atom(0)
+        rootStore.get(source)
+
+        // Keep one genuinely affected branch among a wider set of scopes. The
+        // selector proves propagation still reaches that branch; the counting
+        // map makes a full `data.scopes` scan observable without a timing-based
+        // assertion.
+        const affected = rootStore.scope("affected")
+        const derived = selector(get => get(source) + 1)
+        const callback = mock(() => {})
+        affected.sub(derived, callback)
+        for (let i = 0; i < 100; i++) rootStore.scope(`idle-${i}`)
+
+        expect(rootStore.data.inheritedDependencyBranches.get(source)).toEqual(
+            new Set([affected.data]),
+        )
+
+        const scopes = new Map(rootStore.data.scopes)
+        const entries = [...scopes.entries()]
+        let visited = 0
+        function* countScopes() {
+            for (const entry of entries) {
+                visited++
+                yield entry
+            }
+        }
+        scopes[Symbol.iterator] = countScopes
+        rootStore.data.scopes = scopes
+
+        rootStore.set(source, 1)
+
+        expect(callback).toHaveBeenCalledTimes(1)
+        expect(affected.get(derived)).toBe(2)
+        expect(visited).toBe(0)
+    })
+
+    test("nested branch registration stops at shadows and resumes after unset", () => {
+        const rootStore = store()
+        const middle = rootStore.scope("middle")
+        const leaf = middle.scope("leaf")
+        const source = atom(0)
+        const derived = selector(get => get(source) + 1)
+        const callback = mock(() => {})
+        leaf.sub(derived, callback)
+
+        expect(rootStore.data.inheritedDependencyBranches.get(source)).toEqual(
+            new Set([middle.data]),
+        )
+        expect(middle.data.inheritedDependencyBranches.get(source)).toEqual(
+            new Set([leaf.data]),
+        )
+
+        middle.set(source, 10)
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(source),
+        ).toBeUndefined()
+        expect(middle.data.inheritedDependencyBranches.get(source)).toEqual(
+            new Set([leaf.data]),
+        )
+
+        middle.unset(source)
+        expect(rootStore.data.inheritedDependencyBranches.get(source)).toEqual(
+            new Set([middle.data]),
+        )
+
+        leaf.detach()
+        expect(
+            middle.data.inheritedDependencyBranches.get(source),
+        ).toBeUndefined()
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(source),
+        ).toBeUndefined()
+    })
+
+    test("dynamic dependencies and unsubscribe update the branch index", async () => {
+        const rootStore = store()
+        const scoped = rootStore.scope("dynamic")
+        const chooseLeft = atom(true)
+        const left = atom(1)
+        const right = atom(2)
+        let evaluations = 0
+        const dynamic = selector(get => {
+            evaluations++
+            return get(chooseLeft) ? get(left) : get(right)
+        })
+        const unsubscribe = scoped.sub(dynamic, () => {})
+
+        expect(rootStore.data.inheritedDependencyBranches.get(left)).toEqual(
+            new Set([scoped.data]),
+        )
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(right),
+        ).toBeUndefined()
+
+        rootStore.set(chooseLeft, false)
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(left),
+        ).toBeUndefined()
+        expect(rootStore.data.inheritedDependencyBranches.get(right)).toEqual(
+            new Set([scoped.data]),
+        )
+
+        const afterSwitch = evaluations
+        rootStore.set(left, 10)
+        expect(evaluations).toBe(afterSwitch)
+        rootStore.set(right, 20)
+        expect(evaluations).toBe(afterSwitch + 1)
+
+        unsubscribe()
+        await new Promise<void>(resolve => queueMicrotask(resolve))
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(chooseLeft),
+        ).toBeUndefined()
+        expect(
+            rootStore.data.inheritedDependencyBranches.get(right),
+        ).toBeUndefined()
+    })
+
     test("3-level deep family deletion: root → A → B with cloned family", () => {
         const rootStore = store()
         const family = atomFamily<string>(undefined, { name: "deepFamily" })

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -471,10 +471,12 @@ export const propagateAtomUpdate = (
     if (commitEndRegistry.count !== 0) commitRoot = beginCommit(data)
     let completed = false
     try {
-        const hasScopeCascadeForInputs = hasInheritedDependencyBranches(
-            atoms,
-            data,
-        )
+        // Keep the no-scope gate at this call site even though the helper also
+        // checks it. Avoiding that call keeps large scope-free transactions on
+        // V8's optimized path (Node 22 otherwise falls off a severe perf cliff).
+        const hasScopeCascadeForInputs =
+            data.scopes.size !== 0 &&
+            hasInheritedDependencyBranches(atoms, data)
         // Fast path: single non-family atom with no dependent selectors and no
         // affected scope branch can skip the full graph walk entirely and just
         // notify subscribers. Merely having idle scopes no longer defeats it.

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -41,6 +41,7 @@ import {
     type ChangeSink,
 } from "./notifyChangeListeners"
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { hasInheritedDependencyBranches } from "./inheritedDependencyBranches"
 import { setValueInData } from "./setValueInData"
 import { noteStateValueChanged } from "./stateRevisions"
 
@@ -319,18 +320,9 @@ export const propagateDeletedAtoms = (
     if (commitEndRegistry.count !== 0) commitRoot = beginCommit(data)
     let completed = false
     try {
-        const hasScopeCascade = !!data.scopes && data.scopes.size > 0
-        // An immediate store-tree propagation still needs a deferred notify
-        // phase: every descendant selector must settle before the first root
-        // callback can observe (or interrupt) the tree. Keep the allocation off
-        // the single-store hot path, and let callers that already own a deferred
-        // commit keep owning its notification phase.
-        const localNotify: NotifyTarget | undefined =
-            notify === undefined && hasScopeCascade ? new Map() : undefined
-        const effectiveNotify = notify ?? localNotify
         // Reuse an entry from an earlier pass. The first pass stays local until
         // it actually finds a subscriber, avoiding empty per-scope entries.
-        const notifyEntry = effectiveNotify?.get(data)
+        const notifyEntry = notify?.get(data)
         if (notifyEntry) {
             subscriptions = notifyEntry.subscriptions
         }
@@ -357,6 +349,21 @@ export const propagateDeletedAtoms = (
                 deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
             }
         }
+        // A deleted member changes both its own value and family membership.
+        // Include family objects before deciding whether any scope branch is
+        // affected; a scope selector may observe only get(family), not member.
+        const scopeAtoms: AtomInput[] = atoms.slice()
+        for (const family of deletedFamilyAtoms.keys()) {
+            if (!scopeAtoms.includes(family)) scopeAtoms.push(family)
+        }
+        const hasScopeCascade = hasInheritedDependencyBranches(scopeAtoms, data)
+        // An immediate store-tree propagation still needs a deferred notify
+        // phase: every affected descendant selector must settle before the
+        // first root callback can observe (or interrupt) the tree. Keep the
+        // allocation off both the single-store and idle-scope paths.
+        const localNotify: NotifyTarget | undefined =
+            notify === undefined && hasScopeCascade ? new Map() : undefined
+        const effectiveNotify = notify ?? localNotify
         // `selectorCount` is the cheap global short-circuit; `hasSelectorChangeListener`
         // then confirms a selector listener actually exists on THIS store's ancestor
         // chain, so an unrelated root store with a selector listener doesn't make this
@@ -411,10 +418,6 @@ export const propagateDeletedAtoms = (
         // selector reads the family list (get(family)). Members skip scopes that
         // shadow them (visible value unchanged); families always propagate.
         if (hasScopeCascade) {
-            const scopeAtoms: AtomInput[] = atoms.slice()
-            for (const family of deletedFamilyAtoms.keys()) {
-                scopeAtoms.push(family)
-            }
             propagateToScopes(scopeAtoms, data, false, effectiveNotify, effectiveReport)
         }
 
@@ -468,16 +471,20 @@ export const propagateAtomUpdate = (
     if (commitEndRegistry.count !== 0) commitRoot = beginCommit(data)
     let completed = false
     try {
-        const hasScopes = !!data.scopes && data.scopes.size > 0
+        const hasScopeCascadeForInputs = hasInheritedDependencyBranches(
+            atoms,
+            data,
+        )
         // Fast path: single non-family atom with no dependent selectors and no
-        // scopes can skip the full graph walk entirely and just notify subscribers.
+        // affected scope branch can skip the full graph walk entirely and just
+        // notify subscribers. Merely having idle scopes no longer defeats it.
         if (atoms.length === 1) {
             const atom = atoms[0]
             if (!isFamilyAtom(atom) && !isAtomFamily(atom)) {
                 const dependents = data.stateDependents.get(atom)
                 if (
                     (!dependents || dependents.size === 0) &&
-                    !hasScopes
+                    !hasScopeCascadeForInputs
                 ) {
                     const subs = data.subscriptions.get(atom)
                     if (subs && subs.size > 0) {
@@ -507,13 +514,7 @@ export const propagateAtomUpdate = (
             }
         }
 
-        // Scope cascades must finish before any subscriber can observe the tree
-        // (or throw and interrupt it). Allocate a local target only for that
-        // store-tree path; externally deferred commits keep their existing target.
-        const localNotify: NotifyTarget | undefined =
-            notify === undefined && hasScopes ? new Map() : undefined
-        const effectiveNotify = notify ?? localNotify
-        const notifyEntry = effectiveNotify?.get(data)
+        const notifyEntry = notify?.get(data)
         const subscriptions = notifyEntry
             ? notifyEntry.subscriptions
             : new Set<Subscription>()
@@ -565,6 +566,28 @@ export const propagateAtomUpdate = (
             }
         }
 
+        // A family object is scope-relevant only when membership changed. A
+        // value-only member update stays on the member's branch index.
+        let scopeAtoms: AtomInput[] = atoms
+        if (membershipChanged) {
+            scopeAtoms = atoms.slice()
+            for (const family of membershipChanged) {
+                if (!scopeAtoms.includes(family)) scopeAtoms.push(family)
+            }
+        }
+        const hasScopeCascade =
+            membershipChanged === undefined
+                ? hasScopeCascadeForInputs
+                : hasInheritedDependencyBranches(scopeAtoms, data)
+
+        // Scope cascades must finish before any subscriber can observe the tree
+        // (or throw and interrupt it). Allocate a local target only when the
+        // branch index found affected descendants; externally deferred commits
+        // keep their existing target.
+        const localNotify: NotifyTarget | undefined =
+            notify === undefined && hasScopeCascade ? new Map() : undefined
+        const effectiveNotify = notify ?? localNotify
+
         // A family OBJECT in `atoms` means the committed family index may be a
         // freshly cloned transaction index. Re-link shadowing child scopes so
         // their dependent selectors read that new index before evaluation.
@@ -611,7 +634,7 @@ export const propagateAtomUpdate = (
         let localSink: ChangeSink | undefined
         let effectiveReport: ChangeReport | undefined = report
         if (
-            hasScopes &&
+            hasScopeCascade &&
             typeof report === "string" &&
             changeListenerRegistry.selectorCount !== 0
         ) {
@@ -637,7 +660,7 @@ export const propagateAtomUpdate = (
             }
         }
         if (watching && reportIsSink) emitOrigin(effectiveReport as ChangeReport)
-        if (hasScopes) {
+        if (hasScopeCascade) {
             // A scope selector that reads get(family) depends on the FAMILY object,
             // not the individual member atoms. When the parent's MEMBERSHIP changes (a
             // member added/removed), propagating only the changed members into scopes
@@ -649,13 +672,6 @@ export const propagateAtomUpdate = (
             // deliberately NOT included — its scope-side effect reaches selectors via
             // the member atom already in `atoms`, so it keeps the single-atom scope
             // fast path. That gate is `membershipChanged`.
-            let scopeAtoms: AtomInput[] = atoms
-            if (membershipChanged) {
-                scopeAtoms = atoms.slice()
-                for (const family of membershipChanged) {
-                    if (!scopeAtoms.includes(family)) scopeAtoms.push(family)
-                }
-            }
             propagateToScopes(scopeAtoms, data, isInitOnly, effectiveNotify, effectiveReport)
         }
         if (localNotify) notifyDeferred(localNotify)
@@ -723,60 +739,35 @@ const propagateToScopes = (
     report?: ChangeReport,
 ) => {
     if (atoms.length === 1) {
-        // Fast path for single-atom updates (most common case)
+        // Fast path for single-atom updates (most common case): the index is
+        // already pruned at atom shadows and contains only affected branches.
         const atom = atoms[0]
-        const shadowingScopes = isAtomFamily(atom)
-            ? undefined
-            : data.scopeValueIndex.get(atom)
-        for (const [, scope] of data.scopes) {
-            if (!shadowingScopes || !shadowingScopes.has(scope)) {
-                propagateInScope(atoms, scope, isInitOnly, notify, report)
-            }
-        }
-        return
-    }
-
-    // Multi-atom path: precompute shadow sets once
-    let anyShadowed = false
-    let atomShadows: Map<any, Set<any>> | undefined
-    for (const atom of atoms) {
-        if (!isAtomFamily(atom)) {
-            const s = data.scopeValueIndex.get(atom)
-            if (s && s.size > 0) {
-                if (!atomShadows) atomShadows = new Map()
-                atomShadows.set(atom, s)
-                anyShadowed = true
-            }
-        }
-    }
-
-    if (!anyShadowed) {
-        for (const [, scope] of data.scopes) {
+        const branches = data.inheritedDependencyBranches.get(atom)
+        if (!branches) return
+        for (const scope of branches) {
             propagateInScope(atoms, scope, isInitOnly, notify, report)
         }
         return
     }
 
-    // Some atoms are shadowed, filter per scope
-    for (const [, scope] of data.scopes) {
-        const atomsToUpdateInScope: AtomInput[] = []
-        for (const atom of atoms) {
-            if (isAtomFamily(atom)) {
-                // The scope has its own family index, but the parent
-                // index may have changed (e.g. a member was deleted
-                // from root). Re-evaluate dependent selectors in the
-                // scope so subscribers get notified.
-                atomsToUpdateInScope.push(atom)
+    // Multi-atom path: invert the per-state branch sets into one pass per
+    // affected child. Idle siblings never enter this map, and each child sees
+    // only the atoms whose inherited value can affect its subtree.
+    const atomsByScope = new Map<StoreData, AtomInput[]>()
+    for (const atom of atoms) {
+        const branches = data.inheritedDependencyBranches.get(atom)
+        if (!branches) continue
+        for (const scope of branches) {
+            const scopeAtoms = atomsByScope.get(scope)
+            if (scopeAtoms) {
+                scopeAtoms.push(atom)
             } else {
-                const s = atomShadows!.get(atom)
-                if (!s || !s.has(scope)) {
-                    atomsToUpdateInScope.push(atom)
-                }
+                atomsByScope.set(scope, [atom])
             }
         }
-        if (atomsToUpdateInScope.length > 0) {
-            propagateInScope(atomsToUpdateInScope, scope, isInitOnly, notify, report)
-        }
+    }
+    for (const [scope, scopeAtoms] of atomsByScope) {
+        propagateInScope(scopeAtoms, scope, isInitOnly, notify, report)
     }
 }
 

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -4,6 +4,7 @@ import type { StoreData } from "../types/StoreData"
 import { deepFreeze } from "../utils/deepFreeze"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { ensureFamilyAncestorChain } from "./atomFamilyIndex"
+import { refreshInheritedDependencyBranch } from "./inheritedDependencyBranches"
 import { IS_PROD } from "./IS_PROD"
 import { trackScopeValue } from "./trackScopeValue"
 
@@ -60,6 +61,9 @@ export const setValueInData = <Value extends unknown>(
     }
     if (isNewAtomInScope) {
         trackScopeValue(atom, data)
+        // The new shadow cuts this store's dependent subtree off from ancestor
+        // writes. Keep the complementary inherited-dependency index in sync.
+        refreshInheritedDependencyBranch(atom, data)
         // This scope now shadows `atom`, so any subscription here that was
         // delegating to an ancestor must stop delegating now — otherwise an
         // ancestor write in the same transaction commit would notify it in

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -2,6 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { StoreData } from "../types/StoreData"
 import { isAtom } from "../utils/isAtom"
 import { getState } from "./getState"
+import { refreshInheritedDependencyBranch } from "./inheritedDependencyBranches"
 import {
     createChangeSink,
     flushChangeSink,
@@ -40,6 +41,9 @@ export const detachOwnValue = (atom: Atom<any>, data: StoreData): boolean => {
             if (scopes.size === 0) parent.scopeValueIndex.delete(atom)
         }
         data.scopeIndexKeys!.delete(atom)
+        // Dropping the shadow may expose this store's local/descendant
+        // dependents to ancestor writes again.
+        refreshInheritedDependencyBranch(atom, data)
     }
     return true
 }

--- a/packages/valdres/src/types/StoreData.ts
+++ b/packages/valdres/src/types/StoreData.ts
@@ -192,6 +192,10 @@ export type StoreData = {
     batchUpdates?: boolean
     schemaValidation?: boolean
     scopeValueIndex: WeakMap<WeakKey, Set<StoreData>>
+    /** Per inherited atom/family, the immediate child branches that contain at
+     *  least one active dependent before any intervening atom shadow. Parent
+     *  propagation uses this to enter only affected scope subtrees. */
+    inheritedDependencyBranches: WeakMap<WeakKey, Set<StoreData>>
     /** Present iff this is a scoped store. Root stores have `parent: undefined`. */
     parent?: StoreData
     /** Present iff this is a scoped store. Tracks active scope consumers
@@ -200,6 +204,9 @@ export type StoreData = {
     /** Present iff this is a scoped store. Records keys this scope registered
      *  in its parent's `scopeValueIndex`, used for cleanup on detach. */
     scopeIndexKeys?: Set<WeakKey>
+    /** Present iff this is a scoped store. Records inherited dependency keys
+     *  for which this scope is registered as a branch in its parent's index. */
+    inheritedDependencyKeys?: Set<WeakKey>
     /** Store-wide change listeners registered via `store.onChange`, each mapped
      *  to the kinds of change it opted into: `atoms` (default true) and
      *  `selectors` (default false). Absent (undefined) until the first listener

--- a/packages/valdres/test/performance/scope.bench.ts
+++ b/packages/valdres/test/performance/scope.bench.ts
@@ -40,6 +40,21 @@ describe("scope propagation", () => {
         })
     })
 
+    test("set atom in root with 10,000 idle child scopes", async () => {
+        const root = valdresCreateStore()
+        const a = valdresAtom(0)
+        root.get(a)
+
+        // These branches deliberately never read or subscribe to `a`. Root
+        // writes should remain on the atom fast path regardless of scope count.
+        Array.from({ length: 10_000 }, (_, i) => root.scope(`idle-scope-${i}`))
+
+        let counter = 0
+        await measureOne("scope: set atom, 10,000 idle scopes", () => {
+            root.set(a, ++counter)
+        })
+    })
+
     test("set atom in root with 100 child scopes (50 shadowing)", async () => {
         const root = valdresCreateStore()
         const a = valdresAtom(0)


### PR DESCRIPTION
## Summary

- maintain a lazy per-store index of immediate scope branches with active inherited atom/family dependencies
- use that index to propagate single- and multi-atom updates only through affected subtrees
- keep branch membership synchronized with dynamic dependency changes, shadow/unset transitions, unsubscribe cleanup, and scope detach
- add deterministic regression coverage, a 10,000-idle-scope benchmark, and a patch changeset

## Performance

The regression test was red before the fix: a root write iterated all 101 child scopes despite only one affected branch. It now visits zero entries in the root scope map while still updating the affected selector.

On this machine, the production benchmark for a root atom write with 10,000 idle child scopes measures **89 ns**, down from the hundreds-of-microseconds scaling behavior this change targets.

## Verification

- `bun --filter valdres test` — 895 passed, 1 todo, 0 failed
- `bun --filter valdres typecheck:types`
- `bunx tsc -p packages/valdres/tsconfig.json --noEmit`
- focused scope/propagation regression tests — 169 passed, 0 failed
- production 10,000-idle-scope benchmark — 89 ns
