### PR TITLE
fix(valdres): align store API contracts

### DIFF
--- a/.changeset/align-store-contracts.md
+++ b/.changeset/align-store-contracts.md
@@ -4,5 +4,5 @@
 
 Align the `Store` type contract with runtime behavior: `store.set()` now types
 its existing return value, while callback-form `scope()` exposes a borrowed
-store without a `detach()` lease. Correct subscription and transaction examples
-across the documentation.
+store without `dispose()` or `detach()` lifecycle ownership. Correct
+subscription and transaction examples across the documentation.

--- a/.changeset/align-store-contracts.md
+++ b/.changeset/align-store-contracts.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Align the `Store` type contract with runtime behavior: `store.set()` now types
+its existing return value, while callback-form `scope()` exposes a borrowed
+store without a `detach()` lease. Correct subscription and transaction examples
+across the documentation.

--- a/docs/content/guides/core-concepts.mdx
+++ b/docs/content/guides/core-concepts.mdx
@@ -62,8 +62,8 @@ myStore.set(countAtom, 42)
 console.log(myStore.get(countAtom)) // 42
 
 // Subscribe to changes
-myStore.sub(countAtom, value => {
-    console.log("count changed:", value)
+myStore.sub(countAtom, () => {
+    console.log("count changed:", myStore.get(countAtom))
 })
 ```
 

--- a/docs/content/guides/example-dashboard.mdx
+++ b/docs/content/guides/example-dashboard.mdx
@@ -49,7 +49,7 @@ export const userStatsSelector = selector(get => {
 // Actions
 export function addUser(store, name) {
     const id = crypto.randomUUID()
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(userAtom(id), { id, name, status: "online", lastSeen: Date.now() })
         set(userIdsAtom, ids => [...ids, id])
     })
@@ -64,7 +64,7 @@ export function setStatus(store, id, status) {
 }
 
 export function removeUser(store, id) {
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(userIdsAtom, ids => ids.filter(i => i !== id))
     })
 }

--- a/docs/content/guides/example-todo.mdx
+++ b/docs/content/guides/example-todo.mdx
@@ -24,7 +24,7 @@ export const remainingCountSelector = selector(get => {
 
 export function addTodo(store, title) {
     const id = crypto.randomUUID()
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(todoAtom(id), { id, title, done: false })
         set(todoIdsAtom, ids => [...ids, id])
     })
@@ -36,7 +36,7 @@ export function toggleTodo(store, id) {
 }
 
 export function removeTodo(store, id) {
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(todoIdsAtom, ids => ids.filter(i => i !== id))
     })
 }

--- a/docs/content/guides/outside-react.mdx
+++ b/docs/content/guides/outside-react.mdx
@@ -25,8 +25,8 @@ myStore.set(countAtom, 5)
 myStore.get(doubleSelector)  // 10
 
 // Subscribe to changes
-const unsub = myStore.sub(countAtom, value => {
-    console.log("count changed:", value)
+const unsub = myStore.sub(countAtom, () => {
+    console.log("count changed:", myStore.get(countAtom))
 })
 
 myStore.set(countAtom, 10)
@@ -115,7 +115,7 @@ test("transactions are atomic", () => {
     const b = atom(100)
     const total = selector(get => get(a) + get(b))
 
-    testStore.txn(set => {
+    testStore.txn(({ set }) => {
         set(a, 50)
         set(b, 150)
     })

--- a/docs/content/guides/patterns.mdx
+++ b/docs/content/guides/patterns.mdx
@@ -20,7 +20,7 @@ const todoIdsAtom = atom([])
 // Add a todo
 function addTodo(store, title) {
     const id = crypto.randomUUID()
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(todoAtom(id), { id, title, done: false })
         set(todoIdsAtom, ids => [...ids, id])
     })
@@ -125,7 +125,7 @@ myStore.set(balanceA, prev => prev - 50)
 myStore.set(balanceB, prev => prev + 50) // brief moment where $50 is "missing"
 
 // With transaction: atomic update
-myStore.txn(set => {
+myStore.txn(({ set }) => {
     set(balanceA, prev => prev - 50)
     set(balanceB, prev => prev + 50)
     // Subscribers fire once, after both updates
@@ -176,16 +176,16 @@ import { atomFamily, store } from "valdres"
 const userAtom = atomFamily()
 const myStore = store()
 
-// Subscribe to the family — callback receives array of all active keys
-myStore.sub(userAtom, keys => {
-    console.log("Active user IDs:", keys)
+// Family callbacks receive the arguments of the member that changed
+myStore.sub(userAtom, id => {
+    console.log("Changed user ID:", id)
 })
 
 myStore.set(userAtom("user-1"), { name: "Alice" })
-// logs: Active user IDs: ["user-1"]
+// logs: Changed user ID: user-1
 
 myStore.set(userAtom("user-2"), { name: "Bob" })
-// logs: Active user IDs: ["user-1", "user-2"]
+// logs: Changed user ID: user-2
 ```
 
 ## State outside of components

--- a/docs/content/guides/scoped-stores.mdx
+++ b/docs/content/guides/scoped-stores.mdx
@@ -107,8 +107,8 @@ const root = store()
 const child = root.scope("child")
 const countAtom = atom(0)
 
-child.sub(countAtom, value => {
-    console.log("child sees:", value)
+child.sub(countAtom, () => {
+    console.log("child sees:", child.get(countAtom))
 })
 
 root.set(countAtom, 1)
@@ -126,7 +126,7 @@ root.set(countAtom, 2)
 Transactions work the same way inside scopes:
 
 ```ts
-child.txn(set => {
+child.txn(({ set }) => {
     set(nameAtom, "New name")
     set(ageAtom, 25)
     // Both updates are atomic within the scope

--- a/packages/valdres-react/src/useStore.mdx
+++ b/packages/valdres-react/src/useStore.mdx
@@ -43,7 +43,7 @@ function BatchUpdate() {
     const store = useStore()
 
     const handleReset = () => {
-        store.txn(set => {
+        store.txn(({ set }) => {
             set(nameAtom, "")
             set(emailAtom, "")
             set(ageAtom, 0)

--- a/packages/valdres-react/test/performance/compareInitialization.tsx
+++ b/packages/valdres-react/test/performance/compareInitialization.tsx
@@ -17,7 +17,7 @@ const testValdres = async users => {
         const store = valdres.useStore()
         useEffect(() => {
             users.map(user => store.set(userAtomFamily(user.id), user))
-            // store.txn(set =>
+            // store.txn(({ set }) =>
             // )
             store.set(isInitializedAtom, true)
             // console.log(store.get(userAtomFamily(users[0].id)))

--- a/packages/valdres-vue/src/useStore.mdx
+++ b/packages/valdres-vue/src/useStore.mdx
@@ -45,7 +45,7 @@ import { useStore } from "valdres-vue"
 const store = useStore()
 
 function resetAll() {
-    store.txn(set => {
+    store.txn(({ set }) => {
         set(nameAtom, "")
         set(emailAtom, "")
         set(ageAtom, 0)

--- a/packages/valdres/src/atom.mdx
+++ b/packages/valdres/src/atom.mdx
@@ -247,9 +247,12 @@ const meta = store.get(cacheMeta(dataAtom))
 `cacheMeta()` returns a selector, so you can subscribe to it reactively:
 
 ```ts
-store.sub(cacheMeta(dataAtom), meta => {
-    console.log(meta.isRevalidating) // true when re-fetching
-    console.log(meta.lastSuccessAt)  // timestamp of last success
+const dataMeta = cacheMeta(dataAtom)
+
+store.sub(dataMeta, () => {
+    const meta = store.get(dataMeta)
+    console.log(meta?.isRevalidating) // true when re-fetching
+    console.log(meta?.lastSuccessAt)  // timestamp of last success
 })
 ```
 

--- a/packages/valdres/src/atomFamily.mdx
+++ b/packages/valdres/src/atomFamily.mdx
@@ -71,16 +71,16 @@ members leave the weak identity cache automatically once no caller or store can
 reach them. Manual eviction could otherwise create two live member objects for
 the same arguments and split their values across stores.
 
-## Subscribing to all keys
+## Subscribing to a family
 
 <div className="callout callout-tip">
   <div className="callout-title">Tip</div>
-  Unlike Jotai, you can subscribe to an entire family and get all active keys as an array. This is a first-class feature, not a workaround.
+  Subscribe to an entire family to be notified when any member changes. The callback receives that member's family arguments.
 </div>
 
 ```ts
-store.sub(todoAtom, keys => {
-    console.log("Active todo keys:", keys)
+store.sub(todoAtom, id => {
+    console.log("Changed todo ID:", id)
 })
 ```
 

--- a/packages/valdres/src/lib/store.types.test.ts
+++ b/packages/valdres/src/lib/store.types.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { store } from "../store"
+import type { SetAtom, Store } from "../index"
+
+type Expect<T extends true> = T
+type Equal<X, Y> =
+    (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+        ? true
+        : false
+
+test("store set returns the written value", () => {
+    const root = store()
+    const count = atom(0)
+    const items = atomFamily<string, [string]>("")
+
+    const countResult = root.set(count, current => current + 1)
+    const itemResult = root.set(items("first"), "value")
+
+    expect(countResult).toBe(1)
+    expect(itemResult).toBe("value")
+
+    type _CountResult = Expect<Equal<typeof countResult, number>>
+    type _ItemResult = Expect<Equal<typeof itemResult, string>>
+    type _PublicSetContract = Expect<Equal<Store["set"], SetAtom>>
+})
+
+test("batched store set returns the staged value", () => {
+    const batched = store({ batchUpdates: true })
+    const count = atom(0)
+
+    const result = batched.set(count, current => current + 1)
+
+    expect(result).toBe(1)
+    type _Result = Expect<Equal<typeof result, number>>
+
+    batched.dispose()
+})
+
+test("callback scopes expose a borrowed store, not a detachable lease", () => {
+    const root = store()
+    const lease = root.scope("child")
+
+    root.scope("child", borrowed => {
+        expect("detach" in borrowed).toBe(false)
+        if (false) {
+            // @ts-expect-error callback scopes do not own a detach lease
+            borrowed.detach()
+        }
+    })
+
+    lease.detach()
+    expect(root.data.scopes.has("child")).toBe(false)
+})

--- a/packages/valdres/src/lib/store.types.test.ts
+++ b/packages/valdres/src/lib/store.types.test.ts
@@ -38,7 +38,7 @@ test("batched store set returns the staged value", () => {
     batched.dispose()
 })
 
-test("callback scopes expose a borrowed store, not a detachable lease", () => {
+test("callback scopes expose a borrowed store without lifecycle ownership", () => {
     const root = store()
     const lease = root.scope("child")
 
@@ -47,6 +47,8 @@ test("callback scopes expose a borrowed store, not a detachable lease", () => {
         if (false) {
             // @ts-expect-error callback scopes do not own a detach lease
             borrowed.detach()
+            // @ts-expect-error callback scopes do not own store disposal
+            borrowed.dispose()
         }
     })
 

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -319,17 +319,17 @@ const createStoreRuntime = (data: StoreData): Store => {
 
     const dispose = () => disposeStoreData(data)
 
-    const scope: ScopeFn = ((scopeId: string, callback?: any) => {
+    const scope: ScopeFn = ((
+        scopeId: string,
+        callback?: (store: Store) => unknown,
+    ) => {
         if (callback) {
             if (!data.scopes.has(scopeId)) {
                 throw new Error(`Scope ${scopeId} does not exist`)
             }
             const scopedStoreData = data.scopes.get(scopeId)!
-            const scopedStore = storeFromStoreData(
-                scopedStoreData,
-            ) as ScopedStore
-            const res = callback(scopedStore)
-            return res
+            const scopedStore = storeFromStoreData(scopedStoreData)
+            return callback(scopedStore)
         } else {
             let scopedStoreData
             if (data.scopes.has(scopeId)) {

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -321,7 +321,7 @@ const createStoreRuntime = (data: StoreData): Store => {
 
     const scope: ScopeFn = ((
         scopeId: string,
-        callback?: (store: Store) => unknown,
+        callback?: (store: Omit<Store, "dispose">) => unknown,
     ) => {
         if (callback) {
             if (!data.scopes.has(scopeId)) {

--- a/packages/valdres/src/store.mdx
+++ b/packages/valdres/src/store.mdx
@@ -56,9 +56,12 @@ myStore.set(countAtom, prev => prev + 1)
 
 ## Subscribing to changes
 
+Subscription callbacks are notifications. Read the current value from the
+store when the callback runs:
+
 ```ts
-const unsub = myStore.sub(countAtom, value => {
-    console.log("count changed:", value)
+const unsub = myStore.sub(countAtom, () => {
+    console.log("count changed:", myStore.get(countAtom))
 })
 
 // Later: stop listening

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -6,17 +6,9 @@ import type { SnapshotEntry } from "./SnapshotEntry"
 import type { AtomChange, SelectorChange, StoreChange } from "./StoreChange"
 import type { StoreChangeMeta } from "./StoreChangeMeta"
 import type { StoreData } from "./StoreData"
-import type { SetAtomValue } from "./SetAtomValue"
+import type { SetAtom } from "./SetAtom"
 import type { SubscribeFn } from "./SubscribeFn"
 import type { TransactionFn } from "./TransactionFn"
-
-type SetAtom = {
-    <Value extends any, Args extends [any, ...any[]] = [any, ...any[]]>(
-        atom: AtomFamilyAtom<Value, Args>,
-        value: SetAtomValue<Value>,
-    ): void
-    <Value extends any>(atom: Atom<Value>, value: SetAtomValue<Value>): void
-}
 
 type DeleteAtom = <
     Value extends any,
@@ -36,11 +28,11 @@ type DeleteAtom = <
 type UnsetAtom = <Value extends any>(atom: Atom<Value>) => void
 
 export type ScopeFn = {
-    <ReturnType extends any>(scopeId: string): ScopedStore
-    <ReturnType extends any>(
-        scopeId: string,
-        callback: (store: ScopedStore) => ReturnType,
-    ): ReturnType
+    /** Acquire a scope lease. The caller owns the returned `detach`. */
+    (scopeId: string): ScopedStore
+    /** Borrow an existing scope for the duration of `callback`. A borrowed
+     * store has no `detach` lease to release. */
+    <Result>(scopeId: string, callback: (store: Store) => Result): Result
 }
 
 export type Store<T = StoreData> = {

--- a/packages/valdres/src/types/Store.ts
+++ b/packages/valdres/src/types/Store.ts
@@ -31,8 +31,11 @@ export type ScopeFn = {
     /** Acquire a scope lease. The caller owns the returned `detach`. */
     (scopeId: string): ScopedStore
     /** Borrow an existing scope for the duration of `callback`. A borrowed
-     * store has no `detach` lease to release. */
-    <Result>(scopeId: string, callback: (store: Store) => Result): Result
+     * store has no lifecycle ownership, so it cannot be disposed or detached. */
+    <Result>(
+        scopeId: string,
+        callback: (store: Omit<Store, "dispose">) => Result,
+    ): Result
 }
 
 export type Store<T = StoreData> = {


### PR DESCRIPTION
## Summary

- align `Store.set` with exported `SetAtom` so callers receive inferred return values
- type callback-form `scope()` as a borrowed capability view without `dispose()` or `detach()` lifecycle ownership
- correct subscription, family subscription, and transaction examples across core and framework docs

## Performance

- add no work to either `set` hot path
- keep callback scopes on the shared runtime without allocating a lifecycle facade or detach lease

## Tests

- `bun run typecheck:types`
- `bun test --reporter=dots` (895 pass, 1 todo)
- `bun run build`
- `bun run build:types`
- `bun run docs:build` (194 pages)
- contract scans for stale subscription and transaction examples