### PR TITLE
Resolve the selector-family contract

### DIFF
--- a/.changeset/resolve-selector-family-contract.md
+++ b/.changeset/resolve-selector-family-contract.md
@@ -1,0 +1,12 @@
+---
+"valdres": patch
+---
+
+Make selector-family objects identity-cached factories rather than readable or
+subscribable store state. Remove the untyped O(K) family-key enumeration path,
+narrow family subscriptions to `atomFamily`, and reject invalid runtime
+subscriptions consistently.
+
+Align async construction with `selector()`: selector-family member getters must
+be synchronous functions, but may return Promises. Cache hits remain unchanged;
+the native-async guard runs only when a new member is created.

--- a/docs/content/guides/vs-jotai.mdx
+++ b/docs/content/guides/vs-jotai.mdx
@@ -34,7 +34,7 @@ Jotai has a single concept for both state and derived state. Valdres separates s
 
 ### atomFamily / selectorFamily
 
-In Jotai, `atomFamily` is a simple utility. In Valdres, `atomFamily` and `selectorFamily` are first-class citizens with a Recoil-like API. You can subscribe to an entire family and get all keys as an array.
+In Jotai, `atomFamily` is a simple utility. In Valdres, `atomFamily` also has store-local membership: you can subscribe to the family and read its active members as an array. A `selectorFamily` is an identity-cached selector factory; read and subscribe to its individual members.
 
 ### Transactions
 

--- a/docs/src/layout/LandingPage.tsx
+++ b/docs/src/layout/LandingPage.tsx
@@ -390,7 +390,7 @@ export function LandingPage({ bench }: { bench?: BenchProps }) {
                             />
                             <FeatureCard
                                 title="First-class families"
-                                description="atomFamily and selectorFamily are first-class citizens, not just utilities. Subscribe to entire families."
+                                description="Create identity-cached atom and selector families, with store-local membership subscriptions for atom families."
                                 icon={
                                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect width="8" height="8" x="2" y="2" rx="2"/><rect width="8" height="8" x="14" y="2" rx="2"/><rect width="8" height="8" x="2" y="14" rx="2"/><rect width="8" height="8" x="14" y="14" rx="2"/></svg>
                                 }
@@ -743,4 +743,3 @@ function highlightAngular() {
         `${plain("}")}`,
     ].join("\n")
 }
-

--- a/packages/valdres/src/lib/atomFamilyIndex.ts
+++ b/packages/valdres/src/lib/atomFamilyIndex.ts
@@ -1,5 +1,5 @@
+import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
-import type { Family } from "../types/Family"
 import type { StoreData } from "../types/StoreData"
 import { noteStateValueChanged } from "./stateRevisions"
 import { trackScopeValue } from "./trackScopeValue"
@@ -98,7 +98,7 @@ export const createAtomFamilyIndex = (
 }
 
 export const deleteFamilyAtomsFromSet = (
-    family: Family<any>,
+    family: AtomFamily<any, any>,
     familyAtoms: Set<AtomFamilyAtom<any>>,
     data: StoreData,
     timestamp: number,
@@ -120,7 +120,10 @@ export const deleteFamilyAtomsFromSet = (
 // recursivelyUpdateIndexes relies on this: it only recurses into child scopes
 // that appear in scopeValueIndex, trusting that intermediate scopes without
 // the family have no descendants with it either.
-export const initFamilyIndex = (family: Family<any>, data: StoreData) => {
+export const initFamilyIndex = (
+    family: AtomFamily<any, any>,
+    data: StoreData,
+) => {
     if (data.values.has(family)) return data.values.get(family).__index
     let parentIndex
     if (data.parent) {
@@ -136,7 +139,7 @@ export const initFamilyIndex = (family: Family<any>, data: StoreData) => {
     return index
 }
 
-const findFamilyIndex = (family: Family<any>, data: StoreData) => {
+const findFamilyIndex = (family: AtomFamily<any, any>, data: StoreData) => {
     if (!data.values.has(family)) {
         initFamilyIndex(family, data)
     }
@@ -150,7 +153,7 @@ const findFamilyIndex = (family: Family<any>, data: StoreData) => {
 
 export const recursivelyUpdateIndexes = (
     data: StoreData,
-    family: Family<any>,
+    family: AtomFamily<any, any>,
 ) => {
     const childScopesWithFamily = data.scopeValueIndex.get(family)
     if (!childScopesWithFamily || childScopesWithFamily.size === 0) return
@@ -187,7 +190,7 @@ export const recursivelyUpdateIndexes = (
 // level. Idempotent: a no-op once the chain already links up (the common
 // direct-child-of-root case never relinks).
 export const ensureFamilyAncestorChain = (
-    family: Family<any>,
+    family: AtomFamily<any, any>,
     data: StoreData,
 ) => {
     if (!data.parent) return
@@ -213,7 +216,7 @@ export const ensureFamilyAncestorChain = (
 // "changed" (an inherited-but-not-locally-created member), which is safe — it
 // never suppresses a needed propagation.
 export const addFamilyAtomsToSet = (
-    family: Family<any>,
+    family: AtomFamily<any, any>,
     familyAtoms: Set<AtomFamilyAtom<any>>,
     data: StoreData,
     timestamp: number,

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -1,7 +1,6 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
-import type { Family } from "../types/Family"
 import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type { ColdSelectorCache, StoreData } from "../types/StoreData"
@@ -10,8 +9,6 @@ import { isAtomFamily } from "../utils/isAtomFamily"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isSelector } from "../utils/isSelector"
-import { isSelectorFamily } from "../utils/isSelectorFamily"
-import { equal } from "./equal"
 import { initAtom } from "./initAtom"
 import { initSelector } from "./initSelector"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
@@ -148,7 +145,7 @@ export function getState<
     Value extends any,
     Args extends [any, ...any[]] = [any, ...any[]],
 >(
-    state: Atom<Value> | Selector<Value> | Family<Value, Args>,
+    state: State<Value, Args>,
     data: StoreData,
     initializedAtomsSet: Set<Atom<any>>,
     circularDependencySet?: WeakSet<Selector>,
@@ -281,15 +278,6 @@ export function getState<
         noteStateValueChanged(state, data)
         initializedAtomsSet.add(state)
         return data.values.get(state)
-    }
-    if (isSelectorFamily<Value, Args>(state)) {
-        // TODO: Impement more efficient way to solve this
-        const array = Array.from(state.__valdresSelectorFamilyMap.keys())
-        // @ts-ignore
-        if (equal(array, state._keyArray)) return state._keyArray
-        // @ts-ignore
-        state._keyArray = array
-        return array
     }
     throw new Error("Invalid object passed to get")
 }

--- a/packages/valdres/src/lib/nativeAsyncSelectorError.ts
+++ b/packages/valdres/src/lib/nativeAsyncSelectorError.ts
@@ -1,0 +1,8 @@
+export const nativeAsyncSelectorError = (
+    api: "selector()" | "selectorFamily()",
+) =>
+    new Error(
+        api +
+            " does not accept async functions. " +
+            "Use a sync function that returns a Promise instead.",
+    )

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -1,7 +1,6 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
-import type { Family } from "../types/Family"
 import type { Selector } from "../types/Selector"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
@@ -273,7 +272,7 @@ const addSetToSet = (fromSet: Set<any> | undefined, toSet: Set<any>) => {
 }
 
 const findClosestStoreWithAtomInitialized = (
-    atom: State | Family<any>,
+    atom: State,
     data: StoreData,
 ) => {
     if (!data.parent) return data
@@ -282,7 +281,7 @@ const findClosestStoreWithAtomInitialized = (
 }
 
 const findInClosestStore = (
-    state: State<any> | Family<any>,
+    state: State<any>,
     data: StoreData,
 ) => {
     const store = findClosestStoreWithAtomInitialized(state, data)

--- a/packages/valdres/src/lib/selectorFamilyContract.types.test.ts
+++ b/packages/valdres/src/lib/selectorFamilyContract.types.test.ts
@@ -1,0 +1,15 @@
+import { test } from "bun:test"
+import { selectorFamily } from "../selectorFamily"
+import { store } from "../store"
+
+test("selector-family objects are factories, not readable or subscribable state", () => {
+    const family = selectorFamily((id: string) => () => id)
+    const rootStore = store()
+
+    if (false) {
+        // @ts-expect-error selector-family objects cannot be read as state
+        rootStore.get(family)
+        // @ts-expect-error subscribe to a selector-family member instead
+        rootStore.sub(family, () => {})
+    }
+})

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -1,6 +1,5 @@
 import type { Atom } from "../types/Atom"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
-import type { Family } from "../types/Family"
 import type { GetValue } from "../types/GetValue"
 import type { SetAtom } from "../types/SetAtom"
 import type { State } from "../types/State"
@@ -288,7 +287,7 @@ const createStoreRuntime = (data: StoreData): Store => {
     }
 
     const sub = <V>(
-        state: State<V> | Family<V, any>,
+        state: State<V>,
         callback: () => void,
         deepEqualCheckBeforeCallback: boolean = true,
     ) => {

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -288,7 +288,7 @@ const createStoreRuntime = (data: StoreData): Store => {
 
     const sub = <V>(
         state: State<V>,
-        callback: () => void,
+        callback: (...args: any[]) => void,
         deepEqualCheckBeforeCallback: boolean = true,
     ) => {
         if (data.pendingOrphanCleanup) flushPendingOrphanCleanup(data)

--- a/packages/valdres/src/lib/subscribe.test.ts
+++ b/packages/valdres/src/lib/subscribe.test.ts
@@ -381,6 +381,18 @@ describe("subscribe", () => {
         expect(level2callback.mock.calls[0]).toStrictEqual(["Foo"])
     })
 
+    test("scoped family callbacks preserve every family argument", () => {
+        const rootStore = store()
+        const scopedStore = rootStore.scope("child")
+        const family = atomFamily<string, [string, number]>("default")
+        const callback = mock((_key: string, _revision: number) => {})
+
+        scopedStore.sub(family, callback)
+        scopedStore.set(family("document", 2), "updated")
+
+        expect(callback.mock.calls).toStrictEqual([["document", 2]])
+    })
+
     test("nested selectors should only re-calculate when needed", () => {
         const rootStore = store()
         const atom1 = atom(1, { name: "sub-nested-atom" })

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -1,16 +1,13 @@
 import type { Atom } from "../types/Atom"
-import type { Family } from "../types/Family"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Subscription } from "../types/Subscription"
 import { isAtom } from "../utils/isAtom"
 import { isAtomFamily } from "../utils/isAtomFamily"
-import { isFamily } from "../utils/isFamily"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { isSelector } from "../utils/isSelector"
-import { isSelectorFamily } from "../utils/isSelectorFamily"
 import { isReactive, resolveReactive } from "../utils/resolveReactive"
 import type { CacheMeta } from "../types/Atom"
 import { equal } from "./equal"
@@ -24,7 +21,7 @@ import { mountTransitiveDeps, onFirstDirectSubscriber } from "./mountAtom"
 import { unsubscribe } from "./unsubscribe"
 import { validateResolvedValue } from "./validateResolvedValue"
 
-const initSubscribers = <V>(state: State<V> | Family<V>, data: StoreData) => {
+const initSubscribers = <V>(state: State<V>, data: StoreData) => {
     const set = new Set<Subscription>()
     data.subscriptions.set(state, set)
     return set
@@ -327,15 +324,25 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
 }
 
 export const subscribe = <V>(
-    state: State<V> | Family<V>,
+    state: State<V>,
     callback: (arg?: any) => void,
     requireDeepEqualCheckBeforeCallback: boolean,
     data: StoreData,
 ) => {
+    // Classify once. Besides rejecting selector-family factory objects at the
+    // runtime boundary, this avoids repeating Object.hasOwn checks throughout
+    // the subscription setup hot path.
+    const atomState = isAtom(state)
+    const atomFamilyState = !atomState && isAtomFamily(state)
+    const selectorState =
+        !atomState && !atomFamilyState && isSelector(state)
+    if (!atomState && !atomFamilyState && !selectorState) {
+        throw new Error("Invalid object passed to sub")
+    }
     let parentUnsubscribe: undefined | (() => void)
     let dropDelegate: undefined | (() => void)
     let reDelegate: undefined | (() => void)
-    if (data.parent && (isAtom(state) || isAtomFamily(state))) {
+    if (data.parent && (atomState || atomFamilyState)) {
         /**
          * Getting here means that we are within a scope subscribing to an atom
          * (or a family, which always reads through). While the scope does not
@@ -354,7 +361,7 @@ export const subscribe = <V>(
             )
         // A family always reads through (no own value); an atom delegates only
         // while this scope does not shadow it.
-        if (isAtomFamily(state) || !data.values.has(state)) {
+        if (atomFamilyState || !data.values.has(state)) {
             parentUnsubscribe = delegateToParent()
         }
         // Idempotent: once the scope re-roots the subscription, the parent-side
@@ -381,7 +388,7 @@ export const subscribe = <V>(
             dropDelegate!()
             originalCallback(arg)
         }
-    } else if (!data.values.has(state) && isAtom(state)) {
+    } else if (!data.values.has(state) && atomState) {
         const initializedAtomsSet = new Set<Atom>()
         initAtom(state, data, initializedAtomsSet)
         if (initializedAtomsSet.size) {
@@ -394,7 +401,7 @@ export const subscribe = <V>(
     // A selector may have a revision-validated cold cache. Read through
     // getState even on a cache hit so a stale dynamic dependency set is rebuilt
     // before the first subscriber promotes it into the live reverse graph.
-    if (isSelector(state)) {
+    if (selectorState) {
         const selectorHasValue = data.values.has(state)
         // With no value or dependency set there is nothing cold to validate.
         // Check this dominant fresh-subscription shape before touching the
@@ -416,12 +423,7 @@ export const subscribe = <V>(
         data.subscriptions.get(state) || initSubscribers(state, data)
 
     let subscription
-    if (isFamily(state)) {
-        if (isSelectorFamily(state)) {
-            throw new Error(
-                "Subscribe to selectorFammily is currently not supported",
-            )
-        }
+    if (atomFamilyState) {
         subscription = {
             callback,
             state,
@@ -459,12 +461,12 @@ export const subscribe = <V>(
             // overwrite the shadow on the next tick and double the work for
             // non-global maxAge atoms (which lack the refCount sharing that
             // installMaxAgeTimer uses for global atoms).
-            if (isAtom(state) && state.maxAge !== undefined && !data.parent) {
+            if (atomState && state.maxAge !== undefined && !data.parent) {
                 installMaxAgeTimer(state, data)
             }
             // First direct subscriber: bump liveness through the dep graph.
             // Selectors track this via stateDependencies; families have none.
-            if (!isFamily(state)) {
+            if (!atomFamilyState) {
                 // First direct subscriber is an ADDITIVE liveness change — the
                 // incremental walk is correct here, including through cycles (each
                 // live dependent is counted once; the prev===0 guard visits each

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -325,7 +325,7 @@ export const installMaxAgeTimer = (state: Atom<any>, data: StoreData) => {
 
 export const subscribe = <V>(
     state: State<V>,
-    callback: (arg?: any) => void,
+    callback: (...args: any[]) => void,
     requireDeepEqualCheckBeforeCallback: boolean,
     data: StoreData,
 ) => {
@@ -384,10 +384,15 @@ export const subscribe = <V>(
                 parentUnsubscribe = delegateToParent()
             }
         }
-        callback = arg => {
-            dropDelegate!()
-            originalCallback(arg)
-        }
+        callback = atomFamilyState
+            ? (...args) => {
+                  dropDelegate!()
+                  originalCallback(...args)
+              }
+            : () => {
+                  dropDelegate!()
+                  originalCallback()
+              }
     } else if (!data.values.has(state) && atomState) {
         const initializedAtomsSet = new Set<Atom>()
         initAtom(state, data, initializedAtomsSet)

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -1,4 +1,3 @@
-import type { Family } from "../types/Family"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
 import type { Subscription } from "../types/Subscription"
@@ -14,7 +13,7 @@ import {
 import { queueOrphanCleanup } from "./queueOrphanCleanup"
 
 export const unsubscribe = <V>(
-    state: State<V> | Family<V>,
+    state: State<V>,
     subscription: Subscription,
     data: StoreData,
 ) => {

--- a/packages/valdres/src/selector.ts
+++ b/packages/valdres/src/selector.ts
@@ -1,4 +1,5 @@
 import { equal } from "./lib/equal"
+import { nativeAsyncSelectorError } from "./lib/nativeAsyncSelectorError"
 import type { GetValue } from "./types/GetValue"
 import type { Selector, SelectorGetOptions } from "./types/Selector"
 import type { SelectorOptions } from "./types/SelectorOptions"
@@ -11,10 +12,7 @@ export const selector = <
     options?: SelectorOptions<Value>,
 ): Selector<Value, FamilyArgs> => {
     if (get.constructor?.name === "AsyncFunction") {
-        throw new Error(
-            "selector() does not accept async functions. " +
-                "Use a sync function that returns a Promise instead.",
-        )
+        throw nativeAsyncSelectorError("selector()")
     }
     if (!options) return { equal, get }
     return { equal, ...options, get }

--- a/packages/valdres/src/selectorFamily.mdx
+++ b/packages/valdres/src/selectorFamily.mdx
@@ -16,6 +16,11 @@ description: Create a collection of selectors keyed by a parameter
 
 Creates a family of selectors keyed by a parameter. Each selector derives its value from atoms or other selectors based on the key.
 
+The family object is a factory, not readable or subscribable state. Read or
+subscribe to a member such as `userDisplayNameSelector("user-1")`. Unlike an
+`atomFamily`, creating a selector-family member does not add store-local state
+or membership to enumerate.
+
 Selector options apply to every family member. In particular, use
 `{ mutable: true }` when results contain mutable built-ins or host objects; see
 the selector [immutability contract](/valdres/selector#parameters).
@@ -54,11 +59,15 @@ const userRevision = selectorFamily(
 ## With async computation
 
 ```ts
-const userPostsSelector = selectorFamily(userId => async get => {
-    const res = await fetch(`/api/users/${userId}/posts`)
-    return res.json()
-})
+const userPostsSelector = selectorFamily(userId => get =>
+    fetch(`/api/users/${userId}/posts`).then(res => res.json()),
+)
 ```
+
+As with `selector()`, the member getter itself must be synchronous. It may
+return a Promise, but a native `async` function is rejected because Valdres
+unwraps settled selector values and therefore cannot preserve an async
+function's always-Promise return contract.
 
 ## In React
 

--- a/packages/valdres/src/selectorFamily.test.ts
+++ b/packages/valdres/src/selectorFamily.test.ts
@@ -6,7 +6,28 @@ import { wait } from "../test/utils/wait"
 import { selector } from "./selector"
 
 describe("selectorFamily", () => {
-    test("the same atom is returned when calling atomFamily", () => {
+    test("the family object is a factory, not enumerable state", () => {
+        const family = selectorFamily((id: string) => () => id)
+        family("one")
+        const rootStore = store()
+
+        expect(() => rootStore.get(family as any)).toThrow(
+            "Invalid object passed to get",
+        )
+        expect(() => rootStore.sub(family as any, () => {})).toThrow(
+            "Invalid object passed to sub",
+        )
+    })
+
+    test("throws if a member factory returns an async function", () => {
+        const family = selectorFamily((id: number) => async () => id)
+
+        expect(() => family(1)).toThrow(
+            "selectorFamily() does not accept async functions",
+        )
+    })
+
+    test("the same selector is returned for the same family arguments", () => {
         const nameSelectorFamily2 = selectorFamily(() => () => null)
         nameSelectorFamily2(1)
 
@@ -63,7 +84,7 @@ describe("selectorFamily", () => {
     test("get returns a promise", async () => {
         const store1 = store()
         const nameSelectorFamily = selectorFamily<string>(
-            (key: number) => async () => wait(1).then(() => "done"),
+            (key: number) => () => wait(1).then(() => "done"),
         )
 
         const res = store1.get(nameSelectorFamily(1))

--- a/packages/valdres/src/selectorFamily.ts
+++ b/packages/valdres/src/selectorFamily.ts
@@ -1,5 +1,6 @@
 import { equal } from "./lib/equal"
 import { familyKey, type FamilyKey } from "./lib/familyKey"
+import { nativeAsyncSelectorError } from "./lib/nativeAsyncSelectorError"
 import type { GetValue } from "./types/GetValue"
 import type { Selector } from "./types/Selector"
 import type { SelectorFamily } from "./types/SelectorFamily"
@@ -50,10 +51,16 @@ export const selectorFamily = <
             keyArgs.length === 1 && typeof keyArgs[0] === "string"
                 ? keyArgs[0]
                 : key
+        const get = callback(...args)
+        // Keep native-async behavior aligned with selector(). Detection stays
+        // on the cache-miss path so family cache hits pay no extra work.
+        if (get.constructor?.name === "AsyncFunction") {
+            throw nativeAsyncSelectorError("selectorFamily()")
+        }
         const newSelector = {
             equal,
             ...selectorOptions,
-            get: callback(...args),
+            get,
             family: selectorFamily,
             familyArgs: args,
             familyArgsStringified: key,

--- a/packages/valdres/src/types/SelectorFamily.ts
+++ b/packages/valdres/src/types/SelectorFamily.ts
@@ -4,6 +4,9 @@ import type { Selector } from "./Selector"
 
 export type SelectorFamily<Value extends any, Args extends [any, ...any[]]> = {
     (...args: Args): Selector<Value, Args>
+    /** Explicitly evict a cached selector identity. Selector-family objects are
+     * factories, not store-local membership state; this strong cache is not an
+     * enumerable family snapshot. */
     release: (...args: Args) => boolean
     name?: string
     /** The schema members validate against, readable from the family itself —
@@ -11,5 +14,6 @@ export type SelectorFamily<Value extends any, Args extends [any, ...any[]]> = {
     schema?: Schema<Value>
     /** Per-family `schemaValidation` override, mirrored from the options. */
     schemaValidation?: boolean
+    /** Internal strong identity cache, evicted through `release`. */
     __valdresSelectorFamilyMap: Map<FamilyKey, Selector<Value, Args>>
 }

--- a/packages/valdres/src/types/SubscribeFn.ts
+++ b/packages/valdres/src/types/SubscribeFn.ts
@@ -2,17 +2,17 @@ import type { Atom } from "./Atom"
 import type { AtomFamily } from "./AtomFamily"
 import type { Selector } from "./Selector"
 
-type UnsuscribeFn = () => void
+type UnsubscribeFn = () => void
 
 export type SubscribeFn = {
     <Value extends any, Args extends [any, ...any[]] = [any, ...any[]]>(
         state: AtomFamily<Value, Args>,
         callback: (...args: Args) => void,
         requireDeepEqualCheckBeforeCallback?: boolean,
-    ): UnsuscribeFn
+    ): UnsubscribeFn
     <Value extends any>(
         state: Atom<Value> | Selector<Value>,
         callback: () => void,
         requireDeepEqualCheckBeforeCallback?: boolean,
-    ): UnsuscribeFn
+    ): UnsubscribeFn
 }

--- a/packages/valdres/src/types/SubscribeFn.ts
+++ b/packages/valdres/src/types/SubscribeFn.ts
@@ -1,12 +1,12 @@
 import type { Atom } from "./Atom"
-import type { Family } from "./Family"
+import type { AtomFamily } from "./AtomFamily"
 import type { Selector } from "./Selector"
 
 type UnsuscribeFn = () => void
 
 export type SubscribeFn = {
     <Value extends any, Args extends [any, ...any[]] = [any, ...any[]]>(
-        state: Family<Value, Args>,
+        state: AtomFamily<Value, Args>,
         callback: (...args: Args) => void,
         requireDeepEqualCheckBeforeCallback?: boolean,
     ): UnsuscribeFn


### PR DESCRIPTION
## Summary

- define selector-family objects as factory-only: remove untyped enumeration and exclude them from subscriptions
- retain strong identity caches with explicit release semantics, while rejecting invalid runtime reads/subscriptions
- align native `async` member behavior with `selector()` while preserving synchronous Promise-returning getters
- update public types, documentation, regression coverage, and the package changeset

## Staff engineering review

- no blocking findings across API compatibility, cache lifecycle, subscription behavior, or documentation
- selector-family cache-hit behavior is unchanged; native-async validation runs only on cache misses
- subscription state classification is consolidated so the hot path avoids repeated object-shape checks

## Validation

- `bun test` — 895 pass, 1 existing todo
- `bun run typecheck:types`
- `bun run build:types`
- `bun run build`
- `bun run docs:build` — 194 pages
- focused performance sanity checks: selector-family hit 26 ns, creation 166 ns, subscribe/unsubscribe 208 ns
