### PR TITLE
perf(valdres): make dehydrate store-proportional

### DIFF
--- a/.changeset/faster-store-dehydrate.md
+++ b/.changeset/faster-store-dehydrate.md
@@ -1,0 +1,8 @@
+---
+"valdres": patch
+---
+
+Make `dehydrate(store)` proportional to that store's named state. Named atoms
+are indexed lazily per store, and named family entries now iterate the store's
+own family membership instead of the process-global registry and identity
+cache.

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -11,6 +11,7 @@ import { isLive, mountAtom, unmountAtom } from "./mountAtom"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { noteStateValueChanged } from "./stateRevisions"
 import { installMaxAgeTimer } from "./subscribe"
+import { untrackNamedAtom } from "./namedStateIndex"
 import { globalStore } from "../globalStore"
 import {
     isStoreDisposed,
@@ -144,6 +145,7 @@ export const globalAtom = <Value = unknown>(
         for (const store of snapshot) {
             detach(store)
             if (store.values.delete(atom)) {
+                untrackNamedAtom(atom, store)
                 noteStateValueChanged(atom, store)
             }
             try {

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -8,6 +8,7 @@ import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { setAtom } from "./setAtom"
 import { setValueInData } from "./setValueInData"
 import { noteStateValueChanged } from "./stateRevisions"
+import { trackNamedState, untrackNamedAtom } from "./namedStateIndex"
 import { validateResolvedValue } from "./validateResolvedValue"
 import { validateSchema } from "./validateSchema"
 
@@ -41,6 +42,7 @@ export const getAtomInitValue = <V = any>(
                         // stuck on an unvalidated promise.
                         if (data.values.get(atom) === value) {
                             data.values.delete(atom)
+                            untrackNamedAtom(atom, data)
                             noteStateValueChanged(atom, data)
                         }
                         return
@@ -55,6 +57,7 @@ export const getAtomInitValue = <V = any>(
                     // rather than being stuck with a rejected promise.
                     if (data.values.get(atom) === value) {
                         data.values.delete(atom)
+                        untrackNamedAtom(atom, data)
                         noteStateValueChanged(atom, data)
                     }
                 },
@@ -103,6 +106,10 @@ export const initAtom = <
 ) => {
     const tmpVal = getAtomInitValue(atom, data, initializedAtomsSet)
     let value = setValueInData(atom, tmpVal, data)
+    // Cold-path bookkeeping for dehydrate. This runs once per materialized
+    // atom/store pair, not on subsequent writes; family members index only
+    // their globally named family, never each member identity.
+    if (atom.name !== undefined) trackNamedState(atom, data)
     if (atom.onInit)
         atom.onInit((newVal: Value) => {
             value = newVal

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -49,7 +49,13 @@ export const getAtomInitValue = <V = any>(
                     }
                     // @ts-ignore @ts-todo
                     setValueInData(atom, resolvedValue, data)
-                    propagateAtomUpdate([atom], data, false, undefined, "async-set")
+                    propagateAtomUpdate(
+                        [atom],
+                        data,
+                        false,
+                        undefined,
+                        "async-set",
+                    )
                 },
                 () => {
                     // On rejection, remove the rejected promise from the
@@ -106,10 +112,11 @@ export const initAtom = <
 ) => {
     const tmpVal = getAtomInitValue(atom, data, initializedAtomsSet)
     let value = setValueInData(atom, tmpVal, data)
-    // Cold-path bookkeeping for dehydrate. This runs once per materialized
-    // atom/store pair, not on subsequent writes; family members index only
-    // their globally named family, never each member identity.
-    if (atom.name !== undefined) trackNamedState(atom, data)
+    // Cold-path bookkeeping for dehydrate. Resolve registration through the
+    // reverse WeakMap instead of probing the optional `name` property: besides
+    // being the registry's source of truth, this keeps unnamed atoms on Bun's
+    // original property-access shape for subsequent hot reads.
+    trackNamedState(atom, data)
     if (atom.onInit)
         atom.onInit((newVal: Value) => {
             value = newVal

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -110,7 +110,16 @@ export const initAtom = <
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
 ) => {
-    const tmpVal = getAtomInitValue(atom, data, initializedAtomsSet)
+    let tmpVal
+    try {
+        tmpVal = getAtomInitValue(atom, data, initializedAtomsSet)
+    } catch (error) {
+        // A stale value may have been evicted immediately before this
+        // re-initialization. Keep failure cleanup off the steady store.get()
+        // path while ensuring historical direct-atom state is not retained.
+        untrackNamedAtom(atom, data)
+        throw error
+    }
     let value = setValueInData(atom, tmpVal, data)
     // Cold-path bookkeeping for dehydrate. Resolve registration through the
     // reverse WeakMap instead of probing the optional `name` property: besides

--- a/packages/valdres/src/lib/namedStateIndex.ts
+++ b/packages/valdres/src/lib/namedStateIndex.ts
@@ -20,10 +20,11 @@ export const trackNamedState = (
     state: Atom<any> | AtomFamilyAtom<any, any>,
     data: StoreData,
 ): void => {
-    // Keep unnamed atom initialization on its old path: named family members
-    // carry the family's derived member name, while every transferable direct
-    // atom carries its registered name.
-    if (state.name === undefined) return
+    // Directly named atoms are present in the reverse registry. Family members
+    // are represented by their registered family, never by member identity.
+    // Avoid probing `state.name`: it is mutable and is not the registry source
+    // of truth, and on Bun/JSC the optional-property read perturbs the hot atom
+    // property-access shape after initialization.
     let namedState: NamedState = state
     let name = getRegisteredName(state)
     if (name === undefined) {
@@ -44,7 +45,6 @@ export const trackNamedState = (
 
 /** Remove a directly registered atom after its own store value disappears. */
 export const untrackNamedAtom = (atom: Atom<any>, data: StoreData): void => {
-    if (atom.name === undefined) return
     if (getRegisteredName(atom) === undefined) return
     const index = indexes.get(data)
     if (index === undefined) return

--- a/packages/valdres/src/lib/namedStateIndex.ts
+++ b/packages/valdres/src/lib/namedStateIndex.ts
@@ -1,0 +1,57 @@
+import type { Atom } from "../types/Atom"
+import type { AtomFamily } from "../types/AtomFamily"
+import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+import type { StoreData } from "../types/StoreData"
+import { getRegisteredName } from "./registerName"
+
+type NamedState = Atom<any> | AtomFamily<any>
+export type NamedStateIndex = Map<NamedState, string>
+
+/**
+ * Stores use WeakMaps for state values, so those values cannot be enumerated by
+ * dehydrate. Keep a lazy side index containing only globally addressable state
+ * this store has materialized. The WeakMap key means the index does not extend
+ * a store's lifetime; family members are represented by their already-global
+ * family, never retained individually here.
+ */
+const indexes = new WeakMap<StoreData, NamedStateIndex>()
+
+export const trackNamedState = (
+    state: Atom<any> | AtomFamilyAtom<any, any>,
+    data: StoreData,
+): void => {
+    // Keep unnamed atom initialization on its old path: named family members
+    // carry the family's derived member name, while every transferable direct
+    // atom carries its registered name.
+    if (state.name === undefined) return
+    let namedState: NamedState = state
+    let name = getRegisteredName(state)
+    if (name === undefined) {
+        const family = (state as AtomFamilyAtom<any, any>).family
+        if (family === undefined) return
+        namedState = family
+        name = getRegisteredName(family)
+        if (name === undefined) return
+    }
+
+    let index = indexes.get(data)
+    if (index === undefined) {
+        index = new Map()
+        indexes.set(data, index)
+    }
+    index.set(namedState, name)
+}
+
+/** Remove a directly registered atom after its own store value disappears. */
+export const untrackNamedAtom = (atom: Atom<any>, data: StoreData): void => {
+    if (atom.name === undefined) return
+    if (getRegisteredName(atom) === undefined) return
+    const index = indexes.get(data)
+    if (index === undefined) return
+    index.delete(atom)
+    if (index.size === 0) indexes.delete(data)
+}
+
+export const getNamedStateIndex = (
+    data: StoreData,
+): NamedStateIndex | undefined => indexes.get(data)

--- a/packages/valdres/src/lib/registerName.ts
+++ b/packages/valdres/src/lib/registerName.ts
@@ -2,6 +2,16 @@ import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import { valdresGlobal } from "./valdresGlobal"
 
+// Reverse lookup for store-local dehydration indexes. Weak keys preserve the
+// registry's existing ownership model while letting a store record the exact
+// address registered for a state (rather than trusting its mutable `name`
+// property later).
+const registeredNames = new WeakMap<WeakKey, string>()
+
+export const getRegisteredName = (
+    state: Atom<any> | AtomFamily<any>,
+): string | undefined => registeredNames.get(state)
+
 /** Register a `name`d atom or atomFamily in the global name registry (the
  *  `globalThis.__valdres__` slot), keyed by name. Names are global addresses —
  *  `dehydrate`/`hydrate` resolve state by name across processes — so a
@@ -24,4 +34,5 @@ export const registerName = (
         )
     }
     registry.set(name, state)
+    registeredNames.set(state, name)
 }

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -24,6 +24,7 @@ import {
 } from "./mountAtom"
 import { onCommitEnd } from "./onCommitEnd"
 import { onStoreChange } from "./onStoreChange"
+import { untrackNamedAtom } from "./namedStateIndex"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { resetAtom } from "./resetAtom"
 import { setAtom } from "./setAtom"
@@ -167,6 +168,9 @@ const createStoreRuntime = (data: StoreData): Store => {
                     return data.values.get(state)
                 }
                 data.values.delete(state)
+                // Only directly registered atoms are present in this index;
+                // selectors and family members make this a cheap no-op.
+                untrackNamedAtom(state as Atom, data)
                 data.lastValueWriteAt.delete(state)
             }
         }

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -24,7 +24,6 @@ import {
 } from "./mountAtom"
 import { onCommitEnd } from "./onCommitEnd"
 import { onStoreChange } from "./onStoreChange"
-import { untrackNamedAtom } from "./namedStateIndex"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { resetAtom } from "./resetAtom"
 import { setAtom } from "./setAtom"
@@ -168,9 +167,6 @@ const createStoreRuntime = (data: StoreData): Store => {
                     return data.values.get(state)
                 }
                 data.values.delete(state)
-                // Only directly registered atoms are present in this index;
-                // selectors and family members make this a cheap no-op.
-                untrackNamedAtom(state as Atom, data)
                 data.lastValueWriteAt.delete(state)
             }
         }

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -9,6 +9,7 @@ import {
     reportUnsetAtom,
 } from "./notifyChangeListeners"
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { untrackNamedAtom } from "./namedStateIndex"
 import { propagateAtomUpdate } from "./propagateUpdatedAtoms"
 import { noteStateValueChanged } from "./stateRevisions"
 
@@ -27,6 +28,7 @@ export const detachOwnValue = (atom: Atom<any>, data: StoreData): boolean => {
     if (!data.values.has(atom)) return false
 
     data.values.delete(atom)
+    untrackNamedAtom(atom, data)
     noteStateValueChanged(atom, data)
     // Only present for maxAge atoms; guard to avoid materializing the lazy
     // WeakMap getter for the common (non-maxAge) atom.

--- a/packages/valdres/src/utils/dehydrate.test.ts
+++ b/packages/valdres/src/utils/dehydrate.test.ts
@@ -3,6 +3,8 @@ import { z } from "zod"
 import { atom } from "../atom"
 import { atomFamily } from "../atomFamily"
 import { SchemaValidationError } from "../errors/SchemaValidationError"
+import { getNamedStateIndex } from "../lib/namedStateIndex"
+import { valdresGlobal } from "../lib/valdresGlobal"
 import { selector } from "../selector"
 import { store } from "../store"
 import { dehydrate } from "./dehydrate"
@@ -59,6 +61,79 @@ describe("dehydrate", () => {
         expect(dehydrate(request2).families).toEqual([
             ["dh-req-fam", ["r2-only"], 2],
         ])
+    })
+
+    test("does not scan the global registry or family identity cache", () => {
+        const fam = atomFamily<number, [string]>(0, {
+            name: "dh-local-index-fam",
+        })
+        const unrelated = atomFamily<number, [number]>(0, {
+            name: "dh-local-index-unrelated",
+        })
+        const store1 = store()
+        store1.set(fam("owned"), 1)
+
+        // Keep unrelated identities live. Their exact count is deliberately
+        // small: iterator-call instrumentation below guards the asymptotic
+        // behavior without a timing threshold or a slow test fixture.
+        const unrelatedMembers = Array.from({ length: 32 }, (_, i) =>
+            unrelated(i),
+        )
+        expect(unrelatedMembers).toHaveLength(32)
+
+        const registry = valdresGlobal().registry
+        const registryIterator = registry[Symbol.iterator]
+        const familyValues = fam.__valdresAtomFamilyMap.values
+        const unrelatedValues = unrelated.__valdresAtomFamilyMap.values
+        let registryScans = 0
+        let familyCacheScans = 0
+
+        registry[Symbol.iterator] = function () {
+            registryScans++
+            return registryIterator.call(this)
+        }
+        fam.__valdresAtomFamilyMap.values = function () {
+            familyCacheScans++
+            return familyValues.call(this)
+        }
+        unrelated.__valdresAtomFamilyMap.values = function () {
+            familyCacheScans++
+            return unrelatedValues.call(this)
+        }
+
+        try {
+            expect(dehydrate(store1).families).toEqual([
+                ["dh-local-index-fam", ["owned"], 1],
+            ])
+            expect(registryScans).toBe(0)
+            expect(familyCacheScans).toBe(0)
+        } finally {
+            // Each method was inherited; delete the temporary own override so
+            // this test leaves the shared registry/cache objects unchanged.
+            delete (registry as any)[Symbol.iterator]
+            delete (fam.__valdresAtomFamilyMap as any).values
+            delete (unrelated.__valdresAtomFamilyMap as any).values
+        }
+    })
+
+    test("prunes named atoms from the local index when their value is removed", () => {
+        const kept = atom(0, { name: "dh-local-index-kept" })
+        const removed = atom(0, { name: "dh-local-index-removed" })
+        const store1 = store()
+        store1.set(kept, 1)
+        store1.set(removed, 2)
+
+        expect([...getNamedStateIndex(store1.data)!.values()]).toEqual([
+            "dh-local-index-kept",
+            "dh-local-index-removed",
+        ])
+
+        store1.unset(removed)
+
+        expect([...getNamedStateIndex(store1.data)!.values()]).toEqual([
+            "dh-local-index-kept",
+        ])
+        expect(dehydrate(store1).atoms).toEqual([["dh-local-index-kept", 1]])
     })
 
     test("unnamed atoms and named selectors are never included", () => {

--- a/packages/valdres/src/utils/dehydrate.test.ts
+++ b/packages/valdres/src/utils/dehydrate.test.ts
@@ -136,6 +136,27 @@ describe("dehydrate", () => {
         expect(dehydrate(store1).atoms).toEqual([["dh-local-index-kept", 1]])
     })
 
+    test("index bookkeeping does not probe an unnamed atom's name property", () => {
+        const unnamed = atom(0)
+        let nameReads = 0
+        Object.defineProperty(unnamed, "name", {
+            configurable: true,
+            get: () => {
+                nameReads++
+                return undefined
+            },
+        })
+        const store1 = store()
+
+        store1.get(unnamed)
+        store1.unset(unnamed)
+
+        // Registration, not a mutable optional property, is the source of
+        // truth. Keeping this at zero also protects Bun/JSC's steady atom-read
+        // property-access shape from initialization-only index bookkeeping.
+        expect(nameReads).toBe(0)
+    })
+
     test("unnamed atoms and named selectors are never included", () => {
         const unnamed = atom(1)
         const named = atom(2, { name: "dh-excl-named" })

--- a/packages/valdres/src/utils/dehydrate.test.ts
+++ b/packages/valdres/src/utils/dehydrate.test.ts
@@ -157,6 +157,34 @@ describe("dehydrate", () => {
         expect(nameReads).toBe(0)
     })
 
+    test("prunes a named atom when stale re-initialization throws", () => {
+        let now = 0
+        let initializations = 0
+        const nowSpy = spyOn(Date, "now").mockImplementation(() => now)
+        try {
+            const stale = atom(
+                () => {
+                    if (initializations++ === 0) return 1
+                    throw new Error("stale init failed")
+                },
+                { name: "dh-stale-init-failure", maxAge: 0 },
+            )
+            const store1 = store()
+            expect(store1.get(stale)).toBe(1)
+            expect(getNamedStateIndex(store1.data)?.has(stale)).toBe(true)
+
+            now = 1
+            expect(() => store1.get(stale)).toThrow("stale init failed")
+
+            expect(store1.data.values.has(stale)).toBe(false)
+            expect(getNamedStateIndex(store1.data)?.has(stale) ?? false).toBe(
+                false,
+            )
+        } finally {
+            nowSpy.mockRestore()
+        }
+    })
+
     test("unnamed atoms and named selectors are never included", () => {
         const unnamed = atom(1)
         const named = atom(2, { name: "dh-excl-named" })

--- a/packages/valdres/src/utils/dehydrate.ts
+++ b/packages/valdres/src/utils/dehydrate.ts
@@ -1,5 +1,5 @@
 import { IS_PROD } from "../lib/IS_PROD"
-import { valdresGlobal } from "../lib/valdresGlobal"
+import { getNamedStateIndex } from "../lib/namedStateIndex"
 import { encodeWireValue } from "../lib/wireCodec"
 import type { DehydratedState } from "../types/DehydratedState"
 import type { Store } from "../types/Store"
@@ -12,14 +12,12 @@ import { isPromiseLike } from "./isPromiseLike"
  * `DehydratedState` payload — the server half of SSR state transfer (see
  * `hydrate` for the client half).
  *
- * Iterates the global name registry, NOT the store: every `name`d atom gets an
- * `atoms: [name, value]` entry and every `name`d atomFamily gets one
- * `families: [name, args, value]` entry per member — in both cases only when
- * the state holds an own value in THIS store, so a freshly created per-request
- * store dehydrates to exactly the state that request touched (family identity
- * caches are module-global and shared across per-request stores; the per-store
- * value check is what keeps requests apart). The cache is weak-valued, so it
- * does not become the lifetime owner of unused members.
+ * Iterates a lazy per-store index of globally named state: every `name`d atom
+ * gets an `atoms: [name, value]` entry and every `name`d atomFamily gets one
+ * `families: [name, args, value]` entry per member in THIS store's membership.
+ * Work is therefore proportional to the store being serialized, independent
+ * of the process-global name registry and family identity caches shared by
+ * other request stores.
  * Unnamed state is not transferable;
  * selectors are never included (they re-derive from hydrated atoms).
  *
@@ -53,9 +51,13 @@ export const dehydrate = (store: Store): DehydratedState => {
     }
     const atoms: DehydratedState["atoms"] = []
     const families: DehydratedState["families"] = []
-    for (const [name, state] of valdresGlobal().registry) {
+    const namedStates = getNamedStateIndex(data)
+    if (namedStates === undefined) return { atoms, families }
+    for (const [state, name] of namedStates) {
         if (isAtomFamily(state)) {
-            for (const member of state.__valdresAtomFamilyMap.values()) {
+            const members = data.values.get(state)
+            if (members === undefined) continue
+            for (const member of members) {
                 if (!data.values.has(member)) continue
                 // The payload contracts args as a non-empty tuple (mirroring
                 // atomFamily's Args), and hydrate skips empty-args entries.

--- a/packages/valdres/test/performance/dehydrate.bench.ts
+++ b/packages/valdres/test/performance/dehydrate.bench.ts
@@ -1,0 +1,31 @@
+import { do_not_optimize } from "mitata"
+import { atomFamily } from "../../src/atomFamily"
+import { store } from "../../src/store"
+import { dehydrate } from "../../src/utils/dehydrate"
+import { measureOne } from "./bench-utils"
+import { describe, test } from "./test-compat"
+
+describe("dehydrate", () => {
+    test("one store member among 100,000 global family identities", async () => {
+        const memberCount = 100_000
+        const family = atomFamily<number, [number]>(0, {
+            name: "bench-dehydrate-sparse-family",
+        })
+        const members = Array.from({ length: memberCount }, (_, id) =>
+            family(id),
+        )
+        const sparseStore = store()
+        sparseStore.set(members[0], 1)
+
+        await measureOne(
+            "dehydrate: 1 of 100,000 global family identities",
+            () => {
+                // Retain every unrelated identity for the full measurement so
+                // the benchmark cannot improve merely because GC weakened the
+                // family's process-global identity cache.
+                do_not_optimize(members[memberCount - 1])
+                do_not_optimize(dehydrate(sparseStore))
+            },
+        )
+    })
+})


### PR DESCRIPTION
## Summary

- maintain a lazy, weak-keyed per-store index of globally named atoms and atom families
- serialize family entries from that store's rendered membership instead of scanning the process-global family identity cache
- prune direct named atoms from the local index when their own value is removed
- add deterministic regression coverage, a 100,000-identity benchmark, and a patch changeset

## Performance

For one stored family member with 100,000 other globally live member identities:

- previous global walk, local median: about 3.085 ms
- store-local path, local median: about 0.334 microseconds
- final benchmark: 298 ns on Bun and 170 ns on Node in local runs

The first CI run also exposed an unrelated steady-read code-shape regression
from probing `atom.name` during initialization. The index now resolves names
through the authoritative reverse registry and keeps stale-entry cleanup out of
the optimized `store.get()` closure. Direct local medians returned to parity
with `main` (about 10.9 microseconds for 1,000 cached atom reads).

The dehydrate path is now proportional to the target store's named state and family membership, independent of unrelated globally live identities.

## Staff engineering review

- no blocking correctness, lifecycle, memory-ownership, API compatibility, or performance findings remain
- the side index is weakly keyed by StoreData and retains only atoms/families already strongly owned by the global name registry
- steady atom writes are unchanged; bookkeeping occurs on first materialization and removal paths
- deterministic tests guard global-scan removal, pruning after named-state churn,
  stale initialization failure, and the no-`name`-probe performance invariant

## Verification

- bun --filter valdres test (902 passed, 1 todo)
- bun --filter valdres build
- bun --filter valdres build:types
- bun --filter valdres typecheck:types
- full Bun performance suite
- focused Node/Vitest performance benchmarks
- Prettier check and git diff --check
