### PR TITLE
fix(jotai): sync compatibility with 2.20.2

### DIFF
--- a/.changeset/fresh-jotai-tests.md
+++ b/.changeset/fresh-jotai-tests.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+"@valdres-react/jotai": patch
+---
+
+Update Jotai compatibility coverage to Jotai 2.20.2. Preserve dependency read
+order when mounting sibling atoms, and surface original atom-read errors from
+the Jotai adapter instead of Valdres diagnostic wrappers. Support Jotai's
+per-store `INTERNAL_onInit` hook for primitive atoms.

--- a/bun.lock
+++ b/bun.lock
@@ -485,7 +485,7 @@
       "version": "1.0.0-beta.8",
       "devDependencies": {
         "@testing-library/react": "16.3.0",
-        "jotai": "2.19.0",
+        "jotai": "2.20.2",
         "mitata": "^1.0.34",
         "react": "19.1.1",
         "react-dom": "19.1.1",
@@ -1599,7 +1599,7 @@
 
     "jiti": ["jiti@1.21.6", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w=="],
 
-    "jotai": ["jotai@2.19.0", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-r2wwxEXP1F2JteDLZEOPoIpAHhV89paKsN5GWVYndPNMMP/uVZDcC+fNj0A8NjKgaPWzdyO8Vp8YcYKe0uCEqQ=="],
+    "jotai": ["jotai@2.20.2", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w=="],
 
     "js-beautify": ["js-beautify@1.15.4", "", { "dependencies": { "config-chain": "^1.1.13", "editorconfig": "^1.0.4", "glob": "^10.4.2", "js-cookie": "^3.0.5", "nopt": "^7.2.1" }, "bin": { "css-beautify": "js/bin/css-beautify.js", "html-beautify": "js/bin/html-beautify.js", "js-beautify": "js/bin/js-beautify.js" } }, "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA=="],
 

--- a/packages/@valdres-react/jotai/COMPAT_TODO.md
+++ b/packages/@valdres-react/jotai/COMPAT_TODO.md
@@ -1,6 +1,6 @@
 # Jotai Compatibility - Todo Tests
 
-## Currently Failing (10 tests)
+## Resolved compatibility gaps
 
 ### onMount/onUnmount not called on error (2)
 When `onMount`/`onUnmount` throws, valdres skips remaining lifecycle hooks:
@@ -16,7 +16,7 @@ Valdres notifies listeners at different points in the write cycle:
 
 ### Deep recursion / stack overflow (1)
 Deeply nested or circular selector graphs blow the stack:
-- [ ] `processes deep atom a graph beyond maxDepth` — skipped; valdres now matches jotai's behavior here (plain recursion, JS stack ceiling applies). Removing the iterative trampoline eliminated a 26x perf cliff at depth >100.
+- [x] `surfaces a stack overflow for a graph too deep to read synchronously` — valdres matches jotai's behavior here (plain recursion, JS stack ceiling applies) and recovers after callers warm the graph bottom-up.
 - [x] `should not inf on subscribe or unsubscribe`
 
 ### Error resilience in listeners (1)
@@ -29,24 +29,20 @@ Related to how pending state is handled during unsubscribe:
 
 ---
 
-## Safe to Ignore (5 tests)
-
-### Jotai Internals (3)
-Not part of the public API (`INTERNAL_onInit`, `createDevStore`, `deriveStore`):
-- [ ] `should call onInit only once per atom`
-- [ ] `should call onInit only once per store`
-- [ ] `should pass store and atomState to the atom initializer`
+## Safe to Ignore (1 test)
 
 ### DEV-ONLY (1)
 Debug/development warning, not functional behavior:
 - [ ] `[DEV-ONLY] should warn store mutation during read`
 
-### Memory Leak — upstream todo (1)
-- [ ] `memory leaks (get & set only) > should not hold onto dependent atoms that are not mounted` (todo in upstream jotai)
-
 ---
 
-## Should Support (50 tests)
+## Supported compatibility coverage
+
+### Jotai initialization hook — now passing (3)
+- [x] `should call onInit only once per atom`
+- [x] `should call onInit only once per store`
+- [x] `should pass store and atomState to the atom initializer`
 
 ### Async Atoms — HIGH priority (16)
 Core jotai feature, most common migration blocker:
@@ -107,18 +103,19 @@ React rendering patterns with atoms:
 - [x] `uses a writable atom without read function`
 - [x] `write self atom (undocumented usage)`
 
-### Memory Leak Detection — now passing (6)
+### Memory Leak Detection — now passing (10)
 Using Bun-native LeakDetector (`Bun.gc` + `FinalizationRegistry`) instead of `jest-leak-detector`:
 - [x] `memory leaks (get & set only) > one atom`
 - [x] `memory leaks (get & set only) > two atoms`
+- [x] `memory leaks (get & set only) > should not hold onto dependent atoms that are not mounted` (still todo in upstream jotai; passing in valdres)
 - [x] `memory leaks (get & set only) > with a long-lived base atom`
 - [x] `memory leaks (with subscribe) > one atom`
 - [x] `memory leaks (with subscribe) > two atoms`
 - [x] `memory leaks (with subscribe) > with a long-lived base atom`
-- [ ] `memory leaks (with dependencies) > sync dependency` (valdres retains cached dependency values after re-eval)
-- [ ] `memory leaks (with dependencies) > async dependency` (same)
-- [ ] `memory leaks (with dependencies) > async await dependency` (same)
+- [x] `memory leaks (with dependencies) > sync dependency`
+- [x] `memory leaks (with dependencies) > async dependency`
+- [x] `memory leaks (with dependencies) > async await dependency`
 
 ### Dev Store / Mounted Atoms — LOW priority (2)
-- [ ] `should unmount with store.get`
-- [ ] `should unmount dependencies with store.get`
+- [x] `should unmount with store.get`
+- [x] `should unmount dependencies with store.get`

--- a/packages/@valdres-react/jotai/jotai-tests/UPSTREAM.md
+++ b/packages/@valdres-react/jotai/jotai-tests/UPSTREAM.md
@@ -1,0 +1,12 @@
+# Upstream Jotai test snapshot
+
+The compatibility tests in this directory were last compared with Jotai
+`v2.20.2` at commit `5c4ca26b0db5571114be58393e17854a771f7790`.
+
+The suite adapts upstream tests to Bun and imports the local compatibility
+implementation instead of Jotai. It covers the adapter's exported core, React,
+`atomFamily`, and `atomWithLazy` APIs. Tests for Jotai APIs that this package
+does not export are intentionally not copied.
+
+Local adaptations, skipped internal-only cases, and known gaps are tracked in
+[`../COMPAT_TODO.md`](../COMPAT_TODO.md).

--- a/packages/@valdres-react/jotai/jotai-tests/vanilla/memoryleaks.test.ts
+++ b/packages/@valdres-react/jotai/jotai-tests/vanilla/memoryleaks.test.ts
@@ -33,8 +33,8 @@ describe("memory leaks (get & set only)", () => {
         expect(await detector2.isLeaking()).toBe(false)
     })
 
-    // Also todo in upstream jotai
-    test.todo(
+    // Still todo upstream, but Valdres keeps cold dependency metadata weak.
+    leakTest(
         "should not hold onto dependent atoms that are not mounted",
         async () => {
             const store = createStore()
@@ -113,9 +113,8 @@ describe("memory leaks (with subscribe)", () => {
 
 describe("memory leaks (with dependencies)", () => {
     // These tests verify that atoms dropped as dependencies (via conditional
-    // short-circuit) can be GC'd. Valdres still retains the old dependency's
-    // cached value after re-evaluation, preventing collection.
-    test.todo("sync dependency", async () => {
+    // short-circuit) can be GC'd.
+    leakTest("sync dependency", async () => {
         const store = createStore()
         let objAtom: Atom<object> | undefined = atom({})
         const detector = new LeakDetector(store.get(objAtom))
@@ -130,7 +129,7 @@ describe("memory leaks (with dependencies)", () => {
         expect(await detector.isLeaking()).toBe(false)
     })
 
-    test.todo("async dependency", async () => {
+    leakTest("async dependency", async () => {
         const store = createStore()
         let objAtom: Atom<object> | undefined = atom({})
         const detector = new LeakDetector(store.get(objAtom))
@@ -145,7 +144,7 @@ describe("memory leaks (with dependencies)", () => {
         expect(await detector.isLeaking()).toBe(false)
     })
 
-    test.todo("async await dependency", async () => {
+    leakTest("async await dependency", async () => {
         const store = createStore()
         let objAtom: Atom<object> | undefined = atom({})
         const detector = new LeakDetector(store.get(objAtom))

--- a/packages/@valdres-react/jotai/jotai-tests/vanilla/store.test.ts
+++ b/packages/@valdres-react/jotai/jotai-tests/vanilla/store.test.ts
@@ -36,29 +36,31 @@ test("should not fire subscription if derived atom value is the same", () => {
     expect(callback).toHaveBeenCalledTimes(calledTimes)
 })
 
-// Requires createDevStore + get_mounted_atoms (jotai internals)
-test.todo("should unmount with store.get", () => {
-    const store = createStore() // jotai uses createDevStore()
+test("should unmount with store.get", () => {
+    const store = createStore()
     const countAtom = atom(0)
+    const cleanup = mock(() => {})
+    countAtom.onMount = () => cleanup
     const callback = mock(() => {})
     const unsub = store.sub(countAtom, callback)
 
     store.get(countAtom)
     unsub()
-    // jotai asserts: Array.from(store.get_mounted_atoms()) === []
+    expect(cleanup).toHaveBeenCalledTimes(1)
 })
 
-// Requires createDevStore + get_mounted_atoms (jotai internals)
-test.todo("should unmount dependencies with store.get", () => {
-    const store = createStore() // jotai uses createDevStore()
+test("should unmount dependencies with store.get", () => {
+    const store = createStore()
     const countAtom = atom(0)
+    const cleanup = mock(() => {})
+    countAtom.onMount = () => cleanup
     const derivedAtom = atom((get) => get(countAtom) * 2)
     const callback = mock(() => {})
     const unsub = store.sub(derivedAtom, callback)
 
     store.get(derivedAtom)
     unsub()
-    // jotai asserts: Array.from(store.get_mounted_atoms()) === []
+    expect(cleanup).toHaveBeenCalledTimes(1)
 })
 
 test("should update async atom with delay (#1813)", async () => {
@@ -397,6 +399,27 @@ test("should mount once with atom creator atom (#2314)", () => {
     const store = createStore()
     store.sub(atomCreatorAtom, () => {})
     expect(countAtom.onMount).toHaveBeenCalledTimes(1)
+})
+
+test("should mount sibling dependencies in read order", () => {
+    const store = createStore()
+    const mounted: string[] = []
+    const firstAtom = atom(0)
+    firstAtom.onMount = () => {
+        mounted.push("first")
+    }
+    const secondAtom = atom(0)
+    secondAtom.onMount = () => {
+        mounted.push("second")
+    }
+    const derivedAtom = atom((get) => {
+        get(firstAtom)
+        get(secondAtom)
+    })
+
+    const unsub = store.sub(derivedAtom, () => {})
+    expect(mounted).toEqual(["first", "second"])
+    unsub()
 })
 
 // Requires async atoms
@@ -988,13 +1011,7 @@ test("should call subscribers after setAtom updates atom value on mount but not 
     expect(listener).toHaveBeenCalledTimes(0)
 })
 
-// Valdres previously used an iterative trampoline to handle arbitrarily
-// deep selector chains, which let it pass this test where jotai itself
-// throws. The trampoline was removed in favor of plain recursion (matching
-// jotai's strategy and removing a 26x perf cliff at depth >100); the
-// failure mode at extreme depths is now the JS engine's stack limit, the
-// same as jotai.
-test.skip("processes deep atom a graph beyond maxDepth", () => {
+test("surfaces a stack overflow for a graph too deep to read synchronously", () => {
     function getMaxDepth() {
         let depth = 0
         function d(): number {
@@ -1007,7 +1024,7 @@ test.skip("processes deep atom a graph beyond maxDepth", () => {
         }
         return d()
     }
-    const maxDepth = Math.min(getMaxDepth(), 5000)
+    const maxDepth = getMaxDepth()
     const store = createStore()
     const baseAtom = atom(0)
     const atoms: any[] = [baseAtom]
@@ -1017,8 +1034,11 @@ test.skip("processes deep atom a graph beyond maxDepth", () => {
         atoms.push(a)
     })
     const lastAtom = atoms[maxDepth]!
-    expect(() => store.sub(lastAtom, () => {})).not.toThrow()
+    expect(() => store.get(lastAtom)).toThrow(/call stack|recursion/i)
+    expect(() => store.sub(lastAtom, () => {})).toThrow(/call stack|recursion/i)
     expect(() => store.set(baseAtom, 1)).not.toThrow()
+    atoms.forEach((a) => store.get(a))
+    expect(store.get(lastAtom)).toBe(1)
 }, 10_000)
 
 test("mounted atom should be recomputed eagerly", () => {
@@ -1082,8 +1102,7 @@ test("should process all atom listeners even if some of them throw errors", () =
     expect(listenerC).toHaveBeenCalledTimes(1)
 })
 
-// Requires INTERNAL_onInit (jotai internal)
-test.todo("should call onInit only once per atom", () => {
+test("should call onInit only once per atom", () => {
     const store = createStore()
     const a = atom(0)
     const onInit = mock(() => {})
@@ -1106,8 +1125,7 @@ test.todo("should call onInit only once per atom", () => {
     expect(onInit).not.toHaveBeenCalled()
 })
 
-// Requires INTERNAL_onInit + deriveStore (jotai internals)
-test.todo("should call onInit only once per store", () => {
+test("should call onInit only once per store", () => {
     const a = atom(0)
     const aOnInit = mock(() => {})
     ;(a as any).INTERNAL_onInit = aOnInit
@@ -1126,11 +1144,10 @@ test.todo("should call onInit only once per store", () => {
     }
     testInStore(createStore())
     testInStore(createStore())
-    // jotai also tests with deriveStore(store, ...) which is not implemented
+    // Jotai also tests deriveStore(store, ...), which this adapter does not expose.
 })
 
-// Requires INTERNAL_onInit (jotai internal)
-test.todo("should pass store and atomState to the atom initializer", () => {
+test("should pass store and atomState to the atom initializer", () => {
     const store = createStore()
     const a = atom(null)
 
@@ -1534,4 +1551,61 @@ test("does not recompute derived atom redundantly when store.set in read uses re
 
     expect(store.get(derivedAtom)).toBe(1)
     expect(listener).toHaveBeenCalledTimes(1)
+})
+
+test("notifies subscriber when a nested no-op store.set and a subscription happen inside the outer write (#3353)", () => {
+    const store = createStore()
+    const a = atom(0)
+    const derivedAtom = atom((get) => get(a))
+    const b = atom(0)
+
+    const listener = mock(() => {})
+    store.sub(derivedAtom, listener)
+
+    const w = atom(null, (_get, set) => {
+        set(a, 1)
+        store.set(b, store.get(b))
+        store.sub(b, () => {})()
+    })
+    store.set(w)
+
+    expect(store.get(derivedAtom)).toBe(1)
+    expect(listener).toHaveBeenCalledTimes(1)
+})
+
+test("notifies subscriber of interrupt-derived atom after a synchronous event cascade of nested store.set (#3353)", () => {
+    const store = createStore()
+    const interruptAtom = atom<{ resume: () => void } | undefined>(undefined)
+    const isInterruptedAtom = atom((get) => get(interruptAtom) !== undefined)
+    const dataAtom = atom(0)
+
+    const emitterListeners = new Set<() => void>()
+    const externalState = 0
+
+    let unsub = store.sub(dataAtom, () => {})
+    emitterListeners.add(() => {
+        store.set(dataAtom, externalState)
+        unsub()
+        unsub = store.sub(dataAtom, () => {})
+    })
+
+    const listener = mock(() => {})
+    store.sub(isInterruptedAtom, listener)
+
+    const startInterruptAtom = atom(null, (_get, set) => {
+        set(interruptAtom, {
+            resume: () => emitterListeners.forEach((l) => l()),
+        })
+    })
+    const finishInterruptActionAtom = atom(null, (get, set) => {
+        const interrupt = get(interruptAtom)
+        set(interruptAtom, undefined)
+        interrupt?.resume()
+    })
+
+    store.set(startInterruptAtom)
+    expect(listener).toHaveBeenCalledTimes(1)
+    store.set(finishInterruptActionAtom)
+    expect(store.get(isInterruptedAtom)).toBe(false)
+    expect(listener).toHaveBeenCalledTimes(2)
 })

--- a/packages/@valdres-react/jotai/src/atom.ts
+++ b/packages/@valdres-react/jotai/src/atom.ts
@@ -42,6 +42,42 @@ const addOnMountInterceptor = (target: any) => {
     return target
 }
 
+// Jotai libraries can attach an INTERNAL_onInit hook that receives the store
+// the first time an atom is touched in that store. Valdres already has an
+// equivalent per-store primitive-atom hook, but its callback receives internal
+// store data. Bridge the two while preserving Valdres hooks such as atomWithLazy.
+const addOnInitInterceptor = (target: any) => {
+    let coreOnInit = target.onInit
+    let jotaiOnInit: ((store: any) => void) | undefined
+    const combinedOnInit = (setSelf: any, data: any) => {
+        coreOnInit?.(setSelf, data)
+        const store = getStoreById(data.id)
+        if (store) jotaiOnInit?.(store)
+    }
+
+    Object.defineProperty(target, "onInit", {
+        get() {
+            return coreOnInit || jotaiOnInit ? combinedOnInit : undefined
+        },
+        set(onInit) {
+            coreOnInit = onInit
+        },
+        configurable: true,
+        enumerable: true,
+    })
+    Object.defineProperty(target, "INTERNAL_onInit", {
+        get() {
+            return jotaiOnInit
+        },
+        set(onInit) {
+            jotaiOnInit = onInit
+        },
+        configurable: true,
+        enumerable: true,
+    })
+    return target
+}
+
 const isAsyncFunction = (fn: Function) =>
     Object.prototype.toString.call(fn) === "[object AsyncFunction]"
 
@@ -120,6 +156,6 @@ export const atom = (get: any, set?: any) => {
         return addOnMountInterceptor(selector)
     } else {
         const newAtom = valdresAtom(get, { equal: Object.is })
-        return addOnMountInterceptor(newAtom)
+        return addOnMountInterceptor(addOnInitInterceptor(newAtom))
     }
 }

--- a/packages/@valdres-react/jotai/src/createStore.ts
+++ b/packages/@valdres-react/jotai/src/createStore.ts
@@ -1,5 +1,8 @@
 import { store as valdresCreateStore, isPromiseLike, isSelector } from "valdres"
-import { Transaction } from "valdres/adapter-internals/v1"
+import {
+    SelectorEvaluationError,
+    Transaction,
+} from "valdres/adapter-internals/v1"
 import { registerStore } from "./storeRegistry"
 
 export const createStore = (id?: string) => {
@@ -7,6 +10,16 @@ export const createStore = (id?: string) => {
 
     // Register for setSelf lookup.
     registerStore(store.id, store)
+
+    const throwJotaiAtomError = (error: unknown): never => {
+        if (
+            error instanceof SelectorEvaluationError &&
+            Object.getPrototypeOf(error) === SelectorEvaluationError.prototype
+        ) {
+            throw error.cause
+        }
+        throw error
+    }
 
     // --- Transaction-based write batching ---
     // Jotai defers all subscriber notifications until the entire write batch
@@ -66,7 +79,18 @@ export const createStore = (id?: string) => {
     // internally, and returning Promise.resolve() breaks useSyncExternalStore
     // (new Promise object each call → infinite re-render, plus Suspense throws
     // on any Promise value including resolved ones).
-    const rawGet = store.get
+    const valdresGet = store.get
+
+    // Jotai surfaces the original error thrown by an atom read. Valdres wraps
+    // selector failures with a diagnostic trace, so unwrap that adapter-facing
+    // boundary while preserving the richer error for native Valdres callers.
+    const rawGet = ((state: any) => {
+        try {
+            return valdresGet(state)
+        } catch (error) {
+            throwJotaiAtomError(error)
+        }
+    }) as typeof store.get
 
     // Jotai's store.get() returns a Promise for async atoms even after
     // resolution. Valdres unwraps resolved values, so we re-wrap them.
@@ -105,11 +129,15 @@ export const createStore = (id?: string) => {
         const prevTxn = activeTxn
         activeTxn = txn
         try {
-            return jotaiWrappedSub(state, callback, ...rest)
-        } finally {
-            activeTxn = prevTxn
-            txn.commit()
-            flushDeferred()
+            try {
+                return jotaiWrappedSub(state, callback, ...rest)
+            } finally {
+                activeTxn = prevTxn
+                txn.commit()
+                flushDeferred()
+            }
+        } catch (error) {
+            return throwJotaiAtomError(error)
         }
     }
 

--- a/packages/valdres/package.json
+++ b/packages/valdres/package.json
@@ -29,7 +29,7 @@
     },
     "devDependencies": {
         "@testing-library/react": "16.3.0",
-        "jotai": "2.19.0",
+        "jotai": "2.20.2",
         "mitata": "^1.0.34",
         "react": "19.1.1",
         "react-dom": "19.1.1",

--- a/packages/valdres/src/adapter-internals/v1.ts
+++ b/packages/valdres/src/adapter-internals/v1.ts
@@ -1,2 +1,3 @@
 export { Transaction } from "../lib/adapterTransaction"
 export { storeAdapter } from "../lib/storeAdapter"
+export { SelectorEvaluationError } from "../errors/SelectorEvaluationError"

--- a/packages/valdres/src/lib/mountAtom.ts
+++ b/packages/valdres/src/lib/mountAtom.ts
@@ -629,7 +629,11 @@ export const mountTransitiveDeps = (
         }
         const deps = data.stateDependencies.get(current)
         if (deps) {
-            for (const dep of deps) {
+            // Dependencies are recorded in read order. Push them in reverse so
+            // the LIFO traversal mounts siblings in that same observable order.
+            const orderedDeps = Array.from(deps) as State[]
+            for (let i = orderedDeps.length - 1; i >= 0; i--) {
+                const dep = orderedDeps[i]!
                 if (!seen.has(dep)) stack.push(dep)
             }
         }


### PR DESCRIPTION
## Summary

- update the Jotai compatibility target to 2.20.2 and record the exact upstream test SHA
- port the relevant upstream store regressions and enable nine previously skipped compatibility tests
- fix sibling dependency mount order, preserve original selector errors at the Jotai adapter boundary, and bridge primitive atom `INTERNAL_onInit`
- retain the single development-only mutation-during-read warning as an intentional todo

## Staff review notes

- rebased onto the latest `main` opaque-store refactor and exposed `SelectorEvaluationError` only through the versioned adapter-internals boundary
- exact-prototype error unwrapping avoids changing circular-dependency error behavior
- upstream changes outside the compatibility surface (`atomWithStorage`, `unwrap`, and Jotai internals) were intentionally not copied
- changesets included for patch releases of `valdres` and `@valdres-react/jotai`

## Validation

- `bun install --frozen-lockfile`
- `bun run build`
- `bun run build:types`
- `bun --filter 'valdres' typecheck:types`\n- `bun run test`\n- `bun --filter '@valdres-react/jotai' test` — 130 pass, 1 todo, 0 fail\n- `bunx changeset status --since=origin/main`\n- `git diff --check origin/main...HEAD`