### PR TITLE
refactor(valdres): stage transactions in a mutation draft and commit single-store transactions through CommitPlan

### DIFF
--- a/.changeset/great-drafts-commit.md
+++ b/.changeset/great-drafts-commit.md
@@ -1,0 +1,5 @@
+---
+"valdres": patch
+---
+
+Transaction staging now lives in a dedicated MutationDraft write overlay, and every single-store transaction commit executes through the shared CommitPlan engine. Two deliberate edge-case fixes ride along: (1) when reporting an unset during a transaction commit itself fails (for example a throwing function default evaluated by the report's parent read-through), the first captured commit error — such as an earlier onSet hook error — now surfaces instead of being masked by the reporting failure; (2) transaction staging now validates schemas before dev-freezing, so validators observe the same (unfrozen) value representation as direct writes.

--- a/packages/valdres/src/lib/architectureInstrumentation.ts
+++ b/packages/valdres/src/lib/architectureInstrumentation.ts
@@ -16,6 +16,8 @@ export type ArchitectureCounters = {
     dependencyEdgeVisits: number
     schedulerQueueEnqueues: number
     schedulerQueueDequeues: number
+    /** Admitted `runCommitPlan` executions — one per engine-sequenced commit. */
+    commitPlanRuns: number
 }
 
 export type ArchitectureInstrumentation = {
@@ -36,6 +38,7 @@ export const createArchitectureInstrumentation =
             dependencyEdgeVisits: 0,
             schedulerQueueEnqueues: 0,
             schedulerQueueDequeues: 0,
+            commitPlanRuns: 0,
         },
         settledSelectors: new WeakMap(),
         settledStores: new WeakSet(),
@@ -44,6 +47,11 @@ export const createArchitectureInstrumentation =
 export const recordSelectorEvaluation = (data: StoreData): void => {
     const instrumentation = data.architectureInstrumentation
     if (instrumentation) instrumentation.counters.selectorEvaluations++
+}
+
+export const recordCommitPlanRun = (data: StoreData): void => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.commitPlanRuns++
 }
 
 export const recordSelectorSettlement = (

--- a/packages/valdres/src/lib/architecturePerformance.test.ts
+++ b/packages/valdres/src/lib/architecturePerformance.test.ts
@@ -76,6 +76,8 @@ describe("deterministic architecture performance gates", () => {
             dependencyEdgeVisits: 0,
             schedulerQueueEnqueues: 0,
             schedulerQueueDequeues: 0,
+            // A scalar direct write settles without an engine plan.
+            commitPlanRuns: 0,
         })
     })
 
@@ -166,6 +168,34 @@ describe("deterministic architecture performance gates", () => {
         )
 
         for (const cleanup of cleanups) cleanup()
+    })
+
+    test("single-store transactions execute exactly one commit plan per shape", () => {
+        const ordinaryStore = store()
+        const ordinaryAtom = atom(0)
+        const ordinary = measureArchitecture(ordinaryStore, () => {
+            ordinaryStore.txn(txn => txn.set(ordinaryAtom, 1))
+        })
+        expect(ordinary.commitPlanRuns).toBe(1)
+
+        const hookedStore = store()
+        const hookedAtom = atom(0, { onSet: noop })
+        const hooked = measureArchitecture(hookedStore, () => {
+            hookedStore.txn(txn => txn.set(hookedAtom, 1))
+        })
+        expect(hooked.commitPlanRuns).toBe(1)
+
+        const cleanupStore = store()
+        const cleanupAtom = atom(0)
+        const removedAtom = atom(1)
+        cleanupStore.set(removedAtom, 2)
+        const cleanup = measureArchitecture(cleanupStore, () => {
+            cleanupStore.txn(txn => {
+                txn.set(cleanupAtom, 1)
+                txn.unset(removedAtom)
+            })
+        })
+        expect(cleanup.commitPlanRuns).toBe(1)
     })
 
     test("a deliberately duplicated single-store settlement is detected", () => {

--- a/packages/valdres/src/lib/commitEngine.test.ts
+++ b/packages/valdres/src/lib/commitEngine.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, mock, test } from "bun:test"
 import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
 import { store } from "../store"
 import type { SettleFn } from "../types/SettleFn"
+import type { TransactionSettleFn } from "../types/TransactionSettleFn"
 import {
     createGuardedScalarCommit,
     runCommitPlan,
@@ -319,6 +321,109 @@ describe("commitEngine", () => {
             ).toThrow(hookError)
             expect(settle).toHaveBeenCalledTimes(1)
             expect(flush).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe("transaction settlement", () => {
+        test("dispatches atoms, cleanup lists, report, and errors to the settle fn verbatim", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const a = atom(1)
+            const unset = [atom(2)]
+            const errors = createCommitErrors()
+            const settle = mock((() => {}) as TransactionSettleFn)
+
+            runCommitPlan({
+                data,
+                settlement: {
+                    kind: "transaction",
+                    atoms: [a],
+                    deleted: undefined,
+                    unset,
+                    settle,
+                },
+                onSets: [],
+                errors,
+                report: "set",
+            })
+
+            expect(settle).toHaveBeenCalledTimes(1)
+            expect(settle).toHaveBeenCalledWith(
+                [a],
+                undefined,
+                unset,
+                data,
+                "set",
+                errors,
+            )
+        })
+
+        test("a no-work transaction settlement skips settle but still runs hooks and rethrows their first error", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const hookError = new Error("hook")
+            const hooked = atom(0, {
+                onSet: () => {
+                    throw hookError
+                },
+            })
+            const settle = mock((() => {}) as TransactionSettleFn)
+
+            expect(() =>
+                runCommitPlan({
+                    data,
+                    settlement: {
+                        kind: "transaction",
+                        atoms: [],
+                        deleted: undefined,
+                        unset: undefined,
+                        settle,
+                    },
+                    onSets: [[hooked, 1, data]],
+                    errors: createCommitErrors(),
+                    report: undefined,
+                }),
+            ).toThrow(hookError)
+            expect(settle).not.toHaveBeenCalled()
+        })
+
+        test("cleanup-only settlements (deleted or unset, no updated atoms) still settle", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const family = atomFamily<number, [string]>(0)
+            const member = family("x")
+
+            const deleteSettle = mock((() => {}) as TransactionSettleFn)
+            runCommitPlan({
+                data,
+                settlement: {
+                    kind: "transaction",
+                    atoms: [],
+                    deleted: [member],
+                    unset: undefined,
+                    settle: deleteSettle,
+                },
+                onSets: [],
+                errors: createCommitErrors(),
+                report: undefined,
+            })
+            expect(deleteSettle).toHaveBeenCalledTimes(1)
+
+            const unsetSettle = mock((() => {}) as TransactionSettleFn)
+            runCommitPlan({
+                data,
+                settlement: {
+                    kind: "transaction",
+                    atoms: [],
+                    deleted: undefined,
+                    unset: [atom(0)],
+                    settle: unsetSettle,
+                },
+                onSets: [],
+                errors: createCommitErrors(),
+                report: undefined,
+            })
+            expect(unsetSettle).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/packages/valdres/src/lib/commitEngine.ts
+++ b/packages/valdres/src/lib/commitEngine.ts
@@ -2,6 +2,7 @@ import type { Atom } from "../types/Atom"
 import type { CommitPlan } from "../types/CommitPlan"
 import type { SettleFn } from "../types/SettleFn"
 import type { StoreData } from "../types/StoreData"
+import { recordCommitPlanRun } from "./architectureInstrumentation"
 import { recordCommitError, throwCommitError } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
 import { getStoreRuntime } from "./getStoreRuntime"
@@ -9,10 +10,10 @@ import { runOnSets } from "./runOnSets"
 
 /**
  * The commit engine: the single owner of commit sequencing for the migrated
- * write shapes (ordinary direct writes, non-global bulk writes, and local
- * reset/unset/delete operations). A commit
- * has nine phases; this header is the honest map of where each one lives —
- * the engine does NOT execute all nine itself:
+ * write shapes (ordinary direct writes, non-global bulk writes, local
+ * reset/unset/delete operations, and single-store transaction commits). A
+ * commit has nine phases; this header is the honest map of where each one
+ * lives — the engine does NOT execute all nine itself:
  *
  *   1. Validate/normalize staged writes — in the coordinators: `setAtom`
  *      inline (updater resolve, schema, equality bail incl. the scope-shadow
@@ -37,7 +38,8 @@ import { runOnSets } from "./runOnSets"
  * (see test/import-cycles) — the sequencer must not be hard-wired to the
  * propagation layer it sequences.
  *
- * Global transaction fan-out remains behind its existing adapter. Async atom,
+ * Global and cross-scope transaction fan-out remain behind their existing
+ * adapters. Async atom,
  * native async selector, and revalidation settlement enter this coordinator;
  * simple no-hook shapes use module-static entries from `createScalarCommit`
  * below; their bound operation owns any required apply, propagation,
@@ -76,6 +78,18 @@ export const runHookedDirectWrite = <Value>(
     if (hasHookError) throw hookError
 }
 
+// Module-level phase gates: runCommitPlan is on the per-commit hot path of
+// every migrated write shape, so its guards must not allocate per run.
+const settlementHasWork = (settlement: CommitPlan["settlement"]) =>
+    settlement.kind === "none" ||
+    settlement.kind === "selector" ||
+    settlement.atoms.length > 0 ||
+    (settlement.kind === "transaction" &&
+        (settlement.deleted !== undefined || settlement.unset !== undefined))
+
+const planShouldContinue = (plan: CommitPlan) =>
+    plan.continueAfterError !== false || !plan.errors.hasError
+
 /**
  * Execute a prepared local commit: phase 3 (deferred hooks, first error
  * retained) → optional pre-settle reporting → phases 4–7 (one typed settlement)
@@ -89,12 +103,6 @@ export const runHookedDirectWrite = <Value>(
  */
 export const runCommitPlan = (plan: CommitPlan) => {
     const settlement = plan.settlement
-    const hasWork = () =>
-        settlement.kind === "none" ||
-        settlement.kind === "selector" ||
-        settlement.atoms.length > 0
-    const shouldContinue = () =>
-        plan.continueAfterError !== false || !plan.errors.hasError
     let commitRoot: StoreData | undefined
     let completed = false
 
@@ -102,6 +110,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
     // cancelled, or disposed async result cannot open a commit boundary or run
     // any user code merely by arriving late.
     if (plan.admit && !plan.admit()) return false
+    recordCommitPlanRun(plan.data)
     if (plan.beginCommit) commitRoot = plan.beginCommit(plan.data)
     try {
         let applied = true
@@ -118,8 +127,8 @@ export const runCommitPlan = (plan: CommitPlan) => {
 
         if (
             applied &&
-            hasWork() &&
-            shouldContinue() &&
+            settlementHasWork(settlement) &&
+            planShouldContinue(plan) &&
             plan.beforeSettle &&
             plan.report
         ) {
@@ -130,7 +139,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
             }
         }
 
-        if (applied && hasWork() && shouldContinue()) {
+        if (applied && settlementHasWork(settlement) && planShouldContinue(plan)) {
             try {
                 if (settlement.kind === "update") {
                     settlement.settle(
@@ -147,6 +156,15 @@ export const runCommitPlan = (plan: CommitPlan) => {
                         undefined,
                         plan.report,
                     )
+                } else if (settlement.kind === "transaction") {
+                    settlement.settle(
+                        settlement.atoms,
+                        settlement.deleted,
+                        settlement.unset,
+                        plan.data,
+                        plan.report,
+                        plan.errors,
+                    )
                 } else if (settlement.kind === "selector") {
                     settlement.settle(
                         settlement.selector,
@@ -159,7 +177,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
             }
         }
 
-        if (applied && hasWork() && shouldContinue() && plan.afterSettle) {
+        if (applied && settlementHasWork(settlement) && planShouldContinue(plan) && plan.afterSettle) {
             try {
                 plan.afterSettle()
             } catch (error) {
@@ -167,7 +185,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
             }
         }
 
-        if (shouldContinue() && plan.flushReport) {
+        if (planShouldContinue(plan) && plan.flushReport) {
             try {
                 plan.flushReport()
             } catch (error) {

--- a/packages/valdres/src/lib/mutationDraft.ts
+++ b/packages/valdres/src/lib/mutationDraft.ts
@@ -1,0 +1,68 @@
+import type { MutationDraft } from "../types/MutationDraft"
+
+/**
+ * Lifecycle helpers for a transaction's write overlay. Deliberately free of
+ * runtime imports: the draft is pure staging data, so this module stays a leaf
+ * outside the core write-path import cycle (see test/import-cycles). All
+ * tree-aware staging logic (parent chains, scoped recursion, family-index
+ * cloning) lives with the transaction context that owns the draft.
+ */
+
+/** A fresh overlay. `values` is eager (every transaction stages something);
+ *  the remaining collections allocate lazily on first use, preserving the
+ *  allocation profile of the historical per-field staging state. */
+export const createMutationDraft = (): MutationDraft => ({
+    values: new Map(),
+    unsets: undefined,
+    deletes: undefined,
+    dirtyFamilyIndexes: undefined,
+    initializedAtoms: undefined,
+    dirty: false,
+    selectorCache: undefined,
+    selectorRuntime: undefined,
+    selectorCircularDependencies: undefined,
+    hasCommitEffects: false,
+})
+
+/**
+ * Discard every staged mutation and tear down speculative evaluation state:
+ * revoke live evaluation contexts and abort in-flight selector work so an
+ * abandoned overlay can never publish a result into the committed store.
+ * Called on abort/disposal only — a committed transaction keeps its (already
+ * applied) staging state exactly as the historical fields did.
+ */
+export const resetMutationDraft = (draft: MutationDraft): void => {
+    const runtime = draft.selectorRuntime
+    if (runtime) {
+        runtime.readOverlayActive = false
+        for (const context of runtime.latestEvalContext.values()) {
+            context.revoke()
+        }
+        for (const controller of runtime.abortControllers.values()) {
+            controller.abort()
+        }
+        runtime.latestEvalContext.clear()
+        runtime.abortControllers.clear()
+        runtime.stateDependencies.clear()
+        draft.selectorRuntime = undefined
+    }
+    draft.values.clear()
+    draft.initializedAtoms?.clear()
+    draft.initializedAtoms = undefined
+    draft.deletes?.clear()
+    draft.deletes = undefined
+    draft.unsets?.clear()
+    draft.unsets = undefined
+    draft.selectorCache?.clear()
+    draft.selectorCache = undefined
+    draft.selectorCircularDependencies = undefined
+    draft.dirtyFamilyIndexes?.clear()
+    draft.dirtyFamilyIndexes = undefined
+    draft.dirty = false
+    draft.hasCommitEffects = false
+}
+
+/** Unsets or deletes force the multi-pass settlement arm; plain staged values
+ *  keep the bulk-write fast paths. */
+export const draftHasCleanupMutations = (draft: MutationDraft): boolean =>
+    !!(draft.unsets?.size || draft.deletes?.size)

--- a/packages/valdres/src/lib/normalizeStagedValue.ts
+++ b/packages/valdres/src/lib/normalizeStagedValue.ts
@@ -1,0 +1,43 @@
+import type { Atom } from "../types/Atom"
+import type { StoreData } from "../types/StoreData"
+import { deepFreeze } from "../utils/deepFreeze"
+import { isPromiseLike } from "../utils/isPromiseLike"
+import { IS_PROD } from "./IS_PROD"
+import { validateSchema } from "./validateSchema"
+
+/**
+ * Staging-time normalization shared by every transaction write path
+ * (`Transaction.set`, `batchSetFamilyAtoms`, and any future staging entry).
+ *
+ * Order is contractual: validate FIRST, then dev-freeze. Direct writes
+ * validate the raw value in `setAtom` and freeze later in `setValueInData`,
+ * so a schema must observe the same (unfrozen) representation no matter which
+ * write path delivered the value. A schema failure throws here, inside the
+ * user's transaction callback, so commit never runs and the transaction stays
+ * atomic; promise-like values skip both steps and are validated after
+ * settlement by coordinateAsyncWrite.
+ *
+ * The freeze decision mirrors `setValueInData` (which keeps its copy inline
+ * for the hot primitive-set path — keep the two in sync): respect
+ * `atom.mutable` and production mode, and never freeze a promise-like, which
+ * must stay usable until the async-write coordinator normalizes it at commit.
+ * Freezing at staging (not only at commit) is what makes staged values
+ * immutable within the transaction body.
+ */
+export const normalizeStagedValue = <V>(
+    atom: Atom<any>,
+    resolved: V,
+    data: StoreData,
+): V => {
+    resolved = validateSchema(atom, resolved, data)
+    if (
+        !atom.mutable &&
+        !IS_PROD &&
+        resolved !== null &&
+        (typeof resolved === "object" || typeof resolved === "function") &&
+        !isPromiseLike(resolved)
+    ) {
+        resolved = deepFreeze(resolved)
+    }
+    return resolved
+}

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -25,6 +25,7 @@ import {
     reconcileLivenessAfterChurn,
     unmountOrphanedDeps,
 } from "./mountAtom"
+import { recordCommitError, type CommitErrors } from "./commitErrors"
 import {
     changeListenerRegistry,
     createChangeSink,
@@ -33,9 +34,17 @@ import {
     reportAtomChanges,
     reportDeletedAtoms,
     reportSelectorChanges,
+    reportUnsetAtom,
     type ChangeReport,
     type ChangeSink,
 } from "./notifyChangeListeners"
+// Intra-cycle edge (both modules live in the recorded core SCC): the
+// transaction settlement owns the unset report/re-delegate sequencing that the
+// transaction's inline commit previously hand-rolled.
+import {
+    effectiveValueAfterUnset,
+    reDelegateScopeSubscriptions,
+} from "./unsetValue"
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import { hasInheritedDependencyBranches } from "./inheritedDependencyBranches"
 import { setValueInData } from "./setValueInData"
@@ -808,6 +817,103 @@ export const settleCommit = (
         flags.skipFamilyIndexUpdate,
         flags.reportAtoms,
     )
+
+/**
+ * Typed commit-engine entry (phases 4–7) for a single-store transaction commit
+ * that includes cleanup mutations. One deferred-notification unit: propagate
+ * the updated atoms, then the deleted family members, then the unset atoms
+ * (reporting each unset's distinct removal record first), fire every collected
+ * subscriber once, and re-establish parent delegates for the unset atoms LAST
+ * so a firing scope-local callback's idempotent delegate drop cannot undo the
+ * fresh delegate. Each pass records its own error and lets the later passes
+ * run — one pass failing must not starve delivery of already-applied writes.
+ *
+ * The unset report loop is deliberately unwrapped: a throw there (reachable
+ * when a scope's parent read-through evaluates a throwing function default)
+ * skips the remaining passes exactly as the historical inline sequencing did.
+ * Under the engine that error is recorded into the plan's `CommitErrors`
+ * rather than escaping raw, so the FIRST captured commit error (e.g. an
+ * earlier onSet hook error) is the one that surfaces — a deliberate
+ * consistency fix over the historical masking behavior.
+ */
+export const settleTransactionCommit = (
+    updatedAtoms: Atom<any>[],
+    deletedAtoms: AtomFamilyAtom<any, any>[] | undefined,
+    unsetAtoms: Atom<any>[] | undefined,
+    data: StoreData,
+    report: ChangeReport | undefined,
+    errors: CommitErrors,
+) => {
+    const notify: NotifyTarget = new Map()
+    if (updatedAtoms.length > 0) {
+        try {
+            propagateAtomUpdate(updatedAtoms, data, false, notify, report)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+    if (deletedAtoms) {
+        try {
+            propagateDeletedAtoms(
+                deletedAtoms,
+                data,
+                undefined,
+                undefined,
+                undefined,
+                notify,
+                report,
+            )
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+    if (unsetAtoms) {
+        // Atoms first (emitted as "unset" via reportUnsetAtom), then propagate
+        // with reportAtoms=false so dependent-selector recomputes are reported
+        // too — without re-surfacing the atom (its value is gone from
+        // data.values) as a "set".
+        if (report) {
+            for (const atom of unsetAtoms) {
+                reportUnsetAtom(
+                    atom,
+                    data,
+                    effectiveValueAfterUnset(atom, data),
+                    report,
+                )
+            }
+        }
+        try {
+            propagateAtomUpdate(
+                unsetAtoms,
+                data,
+                false,
+                notify,
+                report,
+                false,
+                false,
+            )
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+    try {
+        notifyDeferred(notify)
+    } catch (error) {
+        recordCommitError(errors, error)
+    }
+    if (unsetAtoms) {
+        // Re-delegate AFTER firing: the deferred scope-local callback
+        // idempotently drops its delegate, so the fresh parent delegate is
+        // established last even when a callback threw.
+        for (const atom of unsetAtoms) {
+            try {
+                reDelegateScopeSubscriptions(atom, data)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+    }
+}
 
 // Scope-recursive entry: re-evaluate selectors that depend on these atoms in
 // this scope and cross into nested scopes. Skips collecting direct atom and

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -1,11 +1,12 @@
 import type { Atom } from "../types/Atom"
 import type { BulkWriteIntent } from "../types/CommitIntent"
+import type { CommitPlan } from "../types/CommitPlan"
 import type { InternalAtom } from "../types/InternalAtom"
 import type { StoreData } from "../types/StoreData"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
 import { isPromiseLike } from "../utils/isPromiseLike"
 import { runCommitPlan } from "./commitEngine"
-import { BULK_WITH_EFFECTS_SILENT, SETTLE_DEFAULT } from "./commitIntents"
+import { SETTLE_DEFAULT } from "./commitIntents"
 import {
     createCommitErrors,
     recordCommitError,
@@ -20,8 +21,9 @@ import {
 import {
     createChangeSink,
     flushChangeSink,
-    type ChangeReport,
+    type ChangeSink,
 } from "./notifyChangeListeners"
+import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import {
     notifyDeferred,
     propagateAtomUpdate,
@@ -38,13 +40,14 @@ const noOnSets: DeferredOnSet[] = []
 const FRESH_ATOM_FAST_PATH_MIN = 256
 
 /**
- * Bulk-write coordinator of the commit engine: the single-store transaction
- * commit delegate. Phases 1–2 run through writeAtoms; a hook-free commit
- * settles immediately (allocation-free — shared empty queue, shared frozen
- * flags); a hooked non-global commit runs phases 3–9 through runCommitPlan.
- * Global fan-out is unmigrated: peer values are still applied here (they
- * belong to the write phase), and when any peer changed, the multi-store
- * sequencing below runs as a legacy adapter.
+ * Bulk-write coordinator of the commit engine, invoked directly by a
+ * single-store transaction commit whose overlay stages effectful writes but no
+ * cleanup mutations. Phases 1–2 run through writeAtoms; an explicitly hook-free
+ * intent settles immediately (allocation-free — shared empty queue, shared
+ * frozen flags); a hooked non-global commit runs phases 3–9 through
+ * runCommitPlan. Global fan-out is unmigrated: peer values are still applied
+ * here (they belong to the write phase), and when any peer changed, the
+ * multi-store sequencing below runs as a legacy adapter.
  */
 export const commitAtoms = (
     pairs: Map<Atom<any>, any>,
@@ -199,47 +202,146 @@ const tryWriteFreshSimpleAtoms = (
     return true
 }
 
+// ——— Reusable hook-free transaction plan ———
+// The dominant transaction shape (no hooks, no cleanup mutations) commits
+// through runCommitPlan with ZERO per-commit allocations: one module-static
+// plan/settlement/errors trio plus static apply/flush operations reading
+// module-static arguments — the plan-shaped sibling of the engine's
+// `createScalarCommit` entries. At most one such commit is in flight per
+// synchronous frame in the common case; a nested commit (a subscriber opening
+// a new transaction while an outer commit is delivering) finds the statics
+// busy and falls back to a fresh plan. Every field is reset in `finally` so
+// the statics never retain a store, sink, or atom list past their commit.
+const EMPTY_UPDATED_ATOMS: Atom<any>[] = []
+let hookFreeBusy = false
+let hookFreePairs: Map<Atom<any>, any> = undefined!
+let hookFreeData: StoreData = undefined!
+let hookFreeInitialized: Set<Atom> = undefined!
+let hookFreeSink: ChangeSink | undefined
+
+const hookFreeSettlement = {
+    kind: "update" as const,
+    atoms: EMPTY_UPDATED_ATOMS,
+    settle: settleCommit,
+    flags: SETTLE_DEFAULT,
+}
+
+const hookFreeApply = () => {
+    if (
+        hookFreeSink === undefined &&
+        hookFreePairs.size >= FRESH_ATOM_FAST_PATH_MIN &&
+        tryWriteFreshSimpleAtoms(hookFreePairs, hookFreeData)
+    ) {
+        return
+    }
+    // Assigned (not pushed) so a large batch pays no second copy.
+    hookFreeSettlement.atoms = writeAtoms(
+        hookFreePairs,
+        hookFreeData,
+        hookFreeInitialized,
+        true,
+        noOnSets,
+    )
+}
+
+const hookFreeFlushReport = () => flushChangeSink(hookFreeSink!)
+
+const hookFreeErrors = createCommitErrors()
+
+const hookFreePlan: CommitPlan = {
+    data: undefined as unknown as StoreData,
+    settlement: hookFreeSettlement,
+    apply: hookFreeApply,
+    onSets: noOnSets,
+    errors: hookFreeErrors,
+    report: undefined,
+    flushReport: undefined,
+    beginCommit: undefined,
+    endCommit: undefined,
+}
+
 /**
- * TEMPORARY TRANSACTION ADAPTER — transactions are intentionally outside this
- * commit-engine migration. Preserve their established hook-free fast path and
- * positional call shape; only the effectful slow path delegates to the typed
- * bulk coordinator, which remains the sole owner of hook/error/notification
- * sequencing. This adapter can disappear when transactions are migrated as a
- * dedicated change.
+ * Hook-free bulk commit entry, invoked directly by a single-store transaction
+ * commit whose overlay carries no onSet-bearing atoms (and therefore no
+ * globals — every global atom carries a marker hook) and no cleanup
+ * mutations. The whole commit is one CommitPlan: the write phase runs as the
+ * plan's `apply` (inside the boundary, exactly where the historical inline
+ * sequencing put it), settlement is the shared update primitive, and the plan
+ * owns the outer commit-end boundary and the deferred onChange flush. Large
+ * unobserved initialization batches take the fresh-atom specialization above
+ * as the apply fast path. Sharing the frozen empty onSet queue is safe:
+ * writeAtoms(skipOnSet=true) never enqueues, and runOnSets only reads.
  */
-export const setAtoms = (
+export const commitHookFreeAtoms = (
     pairs: Map<Atom<any>, any>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
-    skipOnSet = false,
-    report?: ChangeReport,
-    hasCommitEffects = true,
+    sink: ChangeSink | undefined,
 ) => {
-    if (skipOnSet || !hasCommitEffects) {
-        if (
-            report === undefined &&
-            pairs.size >= FRESH_ATOM_FAST_PATH_MIN &&
-            tryWriteFreshSimpleAtoms(pairs, data)
-        ) {
-            return
+    if (hookFreeBusy) {
+        // Nested hook-free commit: the statics are mid-flight for the outer
+        // commit, so this (rare) shape pays the per-commit plan allocation.
+        const settlement = {
+            kind: "update" as const,
+            atoms: [] as Atom<any>[],
+            settle: settleCommit,
+            flags: SETTLE_DEFAULT,
         }
-        const updatedAtoms = writeAtoms(
-            pairs,
+        runCommitPlan({
             data,
-            initializedAtomsSet,
-            true,
-            noOnSets,
-        )
-        if (updatedAtoms.length > 0) {
-            propagateAtomUpdate(updatedAtoms, data, false, undefined, report)
-        }
+            settlement,
+            apply: () => {
+                if (
+                    sink === undefined &&
+                    pairs.size >= FRESH_ATOM_FAST_PATH_MIN &&
+                    tryWriteFreshSimpleAtoms(pairs, data)
+                ) {
+                    return
+                }
+                settlement.atoms = writeAtoms(
+                    pairs,
+                    data,
+                    initializedAtomsSet,
+                    true,
+                    noOnSets,
+                )
+            },
+            onSets: noOnSets,
+            errors: createCommitErrors(),
+            report: sink,
+            flushReport: sink ? () => flushChangeSink(sink) : undefined,
+            beginCommit:
+                commitEndRegistry.count === 0 ? undefined : beginCommit,
+            endCommit: commitEndRegistry.count === 0 ? undefined : endCommit,
+        })
         return
     }
-
-    commitAtoms(
-        pairs,
-        data,
-        initializedAtomsSet,
-        report ? { onSet: "collect", report } : BULK_WITH_EFFECTS_SILENT,
-    )
+    hookFreeBusy = true
+    hookFreePairs = pairs
+    hookFreeData = data
+    hookFreeInitialized = initializedAtomsSet
+    hookFreeSink = sink
+    hookFreePlan.data = data
+    hookFreePlan.report = sink
+    hookFreePlan.flushReport = sink === undefined ? undefined : hookFreeFlushReport
+    const withBoundary = commitEndRegistry.count !== 0
+    hookFreePlan.beginCommit = withBoundary ? beginCommit : undefined
+    hookFreePlan.endCommit = withBoundary ? endCommit : undefined
+    try {
+        runCommitPlan(hookFreePlan)
+    } finally {
+        hookFreeBusy = false
+        hookFreePairs = undefined!
+        hookFreeData = undefined!
+        hookFreeInitialized = undefined!
+        hookFreeSink = undefined
+        hookFreeSettlement.atoms = EMPTY_UPDATED_ATOMS
+        hookFreePlan.data = undefined as unknown as StoreData
+        hookFreePlan.report = undefined
+        hookFreePlan.flushReport = undefined
+        hookFreePlan.beginCommit = undefined
+        hookFreePlan.endCommit = undefined
+        hookFreeErrors.hasError = false
+        hookFreeErrors.firstError = undefined
+    }
 }

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -400,7 +400,7 @@ describe("transaction", () => {
         release()
         expect(await latest).toBe(2)
         expect(
-            transactionRef._selectorRuntime.stateDependencies
+            transactionRef._draft.selectorRuntime.stateDependencies
                 .get(asyncCount)
                 .has(count),
         ).toBe(true)
@@ -576,12 +576,14 @@ describe("transaction", () => {
             txn.set(a, 1)
             const familyValue = (
                 txn as unknown as {
-                    _atomMap: Map<
-                        unknown,
-                        { __index: { renderedArray: unknown } }
-                    >
+                    _draft: {
+                        values: Map<
+                            unknown,
+                            { __index: { renderedArray: unknown } }
+                        >
+                    }
                 }
-            )._atomMap.get(family)!
+            )._draft.values.get(family)!
 
             // Staging membership only dirties the index. Rendering here would
             // copy + sort after every set and make K staged members superlinear.
@@ -1157,5 +1159,200 @@ describe("transaction", () => {
         const settled = await settleWithin(suspense)
         expect(settled).toEqual({ kind: "resolved", value: "done" })
         expect(store1.get(emptyAtom)).toBe("done")
+    })
+})
+
+describe("single-store cleanup commits through the commit engine", () => {
+    test("a cleanup transaction with a global write runs the user onSet before any subscriber and reports onChange last", () => {
+        const store1 = store()
+        const store2 = store()
+        const events: string[] = []
+        const globalCounter = atom(0, {
+            global: true,
+            onSet: () => events.push("onSet"),
+        })
+        const localAtom = atom(1)
+        store1.set(localAtom, 2)
+        store2.get(globalCounter)
+        store1.sub(globalCounter, () => events.push("sub:global@store1"))
+        store2.sub(globalCounter, () => events.push("sub:global@store2"))
+        store1.sub(localAtom, () => events.push("sub:local"))
+        store1.onChange(() => events.push("onChange"))
+
+        store1.txn(txn => {
+            txn.set(globalCounter, 5)
+            txn.unset(localAtom)
+        })
+
+        // Hooks fire after every local and peer write, before any delivery;
+        // the origin store's onChange flushes after every subscriber. The
+        // relative order of independent subscribers is incidental (a bag).
+        expect(events[0]).toBe("onSet")
+        expect(events.at(-1)).toBe("onChange")
+        expect(events.slice(1, -1).sort()).toEqual([
+            "sub:global@store1",
+            "sub:global@store2",
+            "sub:local",
+        ])
+        expect(store2.get(globalCounter)).toBe(5)
+        expect(store1.get(localAtom)).toBe(1)
+    })
+
+    test("a throwing user hook in a global cleanup transaction surfaces without starving peer or unset-dependent notifications", () => {
+        const store1 = store()
+        const store2 = store()
+        const seen: string[] = []
+        const globalCounter = atom(0, {
+            global: true,
+            onSet: () => {
+                throw new Error("hook boom")
+            },
+        })
+        const localAtom = atom(1)
+        const localTenfold = selector(get => get(localAtom) * 10)
+        store1.set(localAtom, 2)
+        store2.get(globalCounter)
+        store2.sub(globalCounter, () => seen.push("sub:global@store2"))
+        store1.sub(localTenfold, () => seen.push("sub:selector"))
+
+        expect(() =>
+            store1.txn(txn => {
+                txn.set(globalCounter, 7)
+                txn.unset(localAtom)
+            }),
+        ).toThrow("hook boom")
+
+        expect(store2.get(globalCounter)).toBe(7)
+        expect(store1.get(localAtom)).toBe(1)
+        expect(store1.get(localTenfold)).toBe(10)
+        expect(seen.sort()).toEqual(["sub:global@store2", "sub:selector"])
+    })
+
+    test("a global write combined with a family delete (no unsets) commits atomically through the fan-out arm", () => {
+        const store1 = store()
+        const store2 = store()
+        const family = atomFamily<number, [string]>(0)
+        const globalCounter = atom(0, { global: true })
+        const member = family("a")
+        const seen: string[] = []
+        store1.set(member, 1)
+        store2.get(globalCounter)
+        store2.sub(globalCounter, () => seen.push("sub:global@store2"))
+        store1.sub(family, () => seen.push("sub:family"))
+
+        store1.txn(txn => {
+            txn.set(globalCounter, 3)
+            txn.del(member)
+        })
+
+        expect(store2.get(globalCounter)).toBe(3)
+        expect(store1.get(family)).toEqual([])
+        expect(seen.sort()).toEqual(["sub:family", "sub:global@store2"])
+    })
+
+    test("a transaction started by a subscriber during a hook-free commit falls back safely", () => {
+        // The reusable static hook-free plan must detect the nested commit
+        // and fall back to a fresh plan without cross-contaminating state.
+        const store1 = store()
+        const outer = atom(0)
+        const inner = atom(0)
+        const commitEnds = mock(() => {})
+        let cascaded = false
+        store1.onCommitEnd(commitEnds)
+        store1.sub(outer, () => {
+            if (!cascaded) {
+                cascaded = true
+                store1.txn(txn => txn.set(inner, 42))
+            }
+        })
+
+        store1.txn(txn => txn.set(outer, 1))
+
+        expect(store1.get(outer)).toBe(1)
+        expect(store1.get(inner)).toBe(42)
+        // The nested boundary coalesces into the outer commit.
+        expect(commitEnds).toHaveBeenCalledTimes(1)
+    })
+
+    test("schema validators observe the same unfrozen representation across direct, staged, and family-batch writes", () => {
+        // Guards the shared normalizeStagedValue contract: validation runs
+        // BEFORE the staging-time dev-freeze, exactly as setAtom validates the
+        // raw value before setValueInData freezes at write.
+        const observedFrozen: boolean[] = []
+        const recordingSchema = {
+            parse(value: unknown) {
+                if ((value as { probe?: boolean })?.probe) {
+                    observedFrozen.push(Object.isFrozen(value))
+                }
+                return value
+            },
+        }
+        const store1 = store()
+        const directAtom = atom(
+            { probe: false, n: 0 },
+            { schemaValidation: true, schema: recordingSchema as any },
+        )
+        const stagedAtom = atom(
+            { probe: false, n: 0 },
+            { schemaValidation: true, schema: recordingSchema as any },
+        )
+        const family = atomFamily<{ probe: boolean; n: number }, [string]>(
+            { probe: false, n: 0 },
+            { schemaValidation: true, schema: recordingSchema as any },
+        )
+
+        store1.set(directAtom, { probe: true, n: 1 })
+        store1.txn(txn => txn.set(stagedAtom, { probe: true, n: 2 }))
+        store1.txn(txn =>
+            txn.batchSetFamilyAtoms(family, [
+                [family("a"), { probe: true, n: 3 }],
+            ]),
+        )
+
+        expect(observedFrozen).toEqual([false, false, false])
+        expect(Object.isFrozen(store1.get(directAtom))).toBe(true)
+        expect(Object.isFrozen(store1.get(stagedAtom))).toBe(true)
+        expect(Object.isFrozen(store1.get(family("a")))).toBe(true)
+        expect(store1.get(directAtom)).toEqual({ probe: true, n: 1 })
+        expect(store1.get(stagedAtom)).toEqual({ probe: true, n: 2 })
+        expect(store1.get(family("a"))).toEqual({ probe: true, n: 3 })
+    })
+
+    test("an unset-report failure surfaces the first captured commit error instead of masking it", () => {
+        // Pins the deliberate arbitration change documented on
+        // settleTransactionCommit: historically the report read-through's own
+        // error escaped raw and masked an earlier recorded hook error.
+        let defaultEvaluations = 0
+        const boom = atom(() => {
+            defaultEvaluations += 1
+            if (defaultEvaluations > 1) throw new Error("default boom")
+            return 1
+        })
+        const hooked = atom(0, {
+            onSet: () => {
+                throw new Error("hook boom")
+            },
+        })
+        const store1 = store()
+        const scoped = store1.scope("request")
+        const changes: unknown[] = []
+
+        // The scope claims its own shadow; the root's default materializes at
+        // most once. De-materialize the root so the unset report's parent
+        // read-through must re-evaluate the (now throwing) default.
+        scoped.txn(txn => txn.set(boom, 5))
+        store1.unset(boom)
+        scoped.onChange(change => changes.push(change))
+
+        expect(() =>
+            scoped.txn(txn => {
+                txn.set(hooked, 1)
+                txn.unset(boom)
+            }),
+        ).toThrow("hook boom")
+
+        expect(defaultEvaluations).toBeGreaterThan(1)
+        expect(scoped.get(hooked)).toBe(1)
+        expect(changes.length).toBeGreaterThan(0)
     })
 })

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -2,14 +2,13 @@ import type { Atom } from "../types/Atom"
 import type { AtomFamily } from "../types/AtomFamily"
 import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { GetValue } from "../types/GetValue"
+import type { MutationDraft } from "../types/MutationDraft"
 import type { State } from "../types/State"
 import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import type { StoreChangeSource } from "../types/StoreChangeSource"
 import type { TransactionFn } from "../types/TransactionFn"
 import { SchemaValidationError } from "../errors/SchemaValidationError"
-import { deepFreeze } from "../utils/deepFreeze"
-import { validateSchema } from "./validateSchema"
 import {
     createStoreDisposedError,
     DISPOSED_STORE_PENDING,
@@ -30,6 +29,7 @@ import {
 import { getState } from "./getState"
 import { getAtomInitValue } from "./initAtom"
 import { isFunction } from "./isFunction"
+import { normalizeStagedValue } from "./normalizeStagedValue"
 import {
     changeListenerRegistry,
     createChangeSink,
@@ -38,16 +38,19 @@ import {
     type ChangeSink,
 } from "./notifyChangeListeners"
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
-import { IS_PROD } from "./IS_PROD"
+import { runCommitPlan } from "./commitEngine"
 import {
     createCommitErrors,
     recordCommitError,
     throwCommitError,
+    type CommitErrors,
 } from "./commitErrors"
+import { BULK_WITH_EFFECTS_SILENT } from "./commitIntents"
 import {
     applyGlobalOnSets,
     beginGlobalCommit,
     endGlobalCommit,
+    type StoreAtomUpdates,
 } from "./globalAtomFanOut"
 import {
     cloneAtomFamilyIndex,
@@ -56,13 +59,19 @@ import {
     renderAtomFamilyIndex,
 } from "./atomFamilyIndex"
 import {
+    createMutationDraft,
+    draftHasCleanupMutations,
+    resetMutationDraft,
+} from "./mutationDraft"
+import {
     notifyDeferred,
     propagateAtomUpdate,
     propagateDeletedAtoms,
+    settleTransactionCommit,
     type NotifyTarget,
 } from "./propagateUpdatedAtoms"
 import { runOnSets, type DeferredOnSet } from "./runOnSets"
-import { setAtoms } from "./setAtoms"
+import { commitAtoms, commitHookFreeAtoms } from "./setAtoms"
 import { writeAtoms } from "./writeAtoms"
 import {
     evaluateSelectorValue,
@@ -83,19 +92,32 @@ type CommitWrite = {
 
 const TRANSACTION_OPEN = 0
 const TRANSACTION_COMMITTING = 1
-const TRANSACTION_CLOSED = 2
+const TRANSACTION_COMMITTED = 2
+const TRANSACTION_ABORTED = 3
+const TRANSACTION_DISPOSED = 4
 
 type TransactionState =
     | typeof TRANSACTION_OPEN
     | typeof TRANSACTION_COMMITTING
-    | typeof TRANSACTION_CLOSED
+    | typeof TRANSACTION_COMMITTED
+    | typeof TRANSACTION_ABORTED
+    | typeof TRANSACTION_DISPOSED
+
+/** How a working tree ended without committing: consumer abort (including a
+ *  throwing callback) or store disposal. */
+type TerminalCancelState =
+    | typeof TRANSACTION_ABORTED
+    | typeof TRANSACTION_DISPOSED
 
 const transactionStateName = (state: TransactionState) =>
     state === TRANSACTION_OPEN
         ? "open"
         : state === TRANSACTION_COMMITTING
           ? "committing"
-          : "closed"
+          : // Committed, aborted, and disposed are tracked distinctly for
+            // lifecycle ownership, but every terminal handle reports the
+            // historical "closed" so misuse errors stay byte-identical.
+            "closed"
 
 const throwTransactionStateError = (
     state: TransactionState,
@@ -114,22 +136,6 @@ const EXECUTE_TRANSACTION = Symbol("executeTransaction")
 const COMMIT_TRANSACTION = Symbol("commitTransaction")
 const ABORT_TRANSACTION = Symbol("abortTransaction")
 const CANCEL_TRANSACTION = Symbol("cancelTransaction")
-// const findDependencies = (
-//     state: State,
-//     data: StoreData,
-//     result = new Set(),
-// ) => {
-//     const dependents = data.stateDependents.get(state)
-//     if (dependents?.size) {
-//         for (const dependent of dependents) {
-//             if (!result.has(dependent)) {
-//                 result.add(dependent)
-//                 findDependencies(dependent, data, result)
-//             }
-//         }
-//     }
-//     return result
-// }
 
 const deleteAtomFamilyAtoms = (
     set: Set<AtomFamilyAtom<any, any>>,
@@ -142,31 +148,30 @@ const deleteAtomFamilyAtoms = (
     })
 }
 
+// Detach the own value + bookkeeping for each unset atom that actually had
+// one; returns those atoms so the commit can propagate and report them.
+// Called in the write phase so every store's values are final before any
+// propagation pass runs.
+const applyUnsets = (unsetSet: Set<Atom>, data: StoreData): Atom[] => {
+    const unsetAtoms: Atom[] = []
+    for (const atom of unsetSet) {
+        if (detachOwnValue(atom, data)) unsetAtoms.push(atom)
+    }
+    return unsetAtoms
+}
+
+
 export class TransactionContext {
     private readonly _data: StoreData
     private _parentTransaction: TransactionContext | undefined
-    private _dirty = false
     private readonly _name: string | undefined
     private _state: TransactionState = TRANSACTION_OPEN
     private _scopedTransactions: undefined | Map<string, TransactionContext>
-    private _initializedAtomsSet: any
-    private _deleteSet: any
-    private _unsetSet: Set<Atom<any>> | undefined
-    private _selectorCache: any
-    private _selectorRuntime: SelectorEvaluationRuntime | undefined
-    private _selectorCircularDependencySet: WeakSet<any> | undefined
-    private _atomMap: Map<any, any>
+    // Everything this level stages before commit lives in one write overlay —
+    // see MutationDraft. The context itself keeps only lifecycle and tree
+    // structure, so staging can be read independently from commit execution.
+    private readonly _draft: MutationDraft
     private _lifecycleResources: StoreResources | undefined
-    // Allocated only for transactions that clone/mutate family membership.
-    // Ordinary-atom and existing-family-member transactions keep their commit
-    // path allocation-free and never scan `_atomMap` looking for families.
-    private _dirtyFamilyIndexes:
-        | Set<AtomFamily<any, [any, ...any[]]>>
-        | undefined
-    // Global atoms always carry an onSet marker, so this one bit covers every
-    // write that needs phased hook/fan-out handling. Transactions containing
-    // only ordinary atoms retain the original allocation-light commit path.
-    private _hasCommitEffects = false
     constructor(
         data: StoreData,
         parentTransaction?: TransactionContext,
@@ -176,14 +181,14 @@ export class TransactionContext {
         this._data = data
         this._parentTransaction = parentTransaction
         this._name = name
-        this._atomMap = new Map()
+        this._draft = createMutationDraft()
         if (childTransaction) {
             this._scopedTransactions = new Map([
                 [childTransaction._data.id, childTransaction],
             ])
         }
         this._lifecycleResources = trackStoreTransaction(data, this)
-        if (!this._lifecycleResources) this.cancelTree()
+        if (!this._lifecycleResources) this.cancelTree(TRANSACTION_DISPOSED)
     }
 
     private assertOpen(operation: string): void {
@@ -198,44 +203,18 @@ export class TransactionContext {
         throwTransactionStateError(this._state, operation)
     }
 
-    /** Close a working tree and release resources that were never committed. */
-    private cancelTree(): void {
-        this._state = TRANSACTION_CLOSED
+    /** Close a working tree and release resources that were never committed.
+     *  `terminal` records why: consumer abort or store disposal. */
+    private cancelTree(terminal: TerminalCancelState): void {
+        this._state = terminal
         this.untrackLifecycle()
         if (this._scopedTransactions) {
             for (const transaction of this._scopedTransactions.values()) {
-                transaction.cancelTree()
+                transaction.cancelTree(terminal)
             }
             this._scopedTransactions.clear()
         }
-        const runtime = this._selectorRuntime
-        if (runtime) {
-            runtime.readOverlayActive = false
-            for (const context of runtime.latestEvalContext.values()) {
-                context.revoke()
-            }
-            for (const controller of runtime.abortControllers.values()) {
-                controller.abort()
-            }
-            runtime.latestEvalContext.clear()
-            runtime.abortControllers.clear()
-            runtime.stateDependencies.clear()
-            this._selectorRuntime = undefined
-        }
-        this._atomMap.clear()
-        this._initializedAtomsSet?.clear()
-        this._initializedAtomsSet = undefined
-        this._deleteSet?.clear()
-        this._deleteSet = undefined
-        this._unsetSet?.clear()
-        this._unsetSet = undefined
-        this._selectorCache?.clear()
-        this._selectorCache = undefined
-        this._selectorCircularDependencySet = undefined
-        this._dirtyFamilyIndexes?.clear()
-        this._dirtyFamilyIndexes = undefined
-        this._dirty = false
-        this._hasCommitEffects = false
+        resetMutationDraft(this._draft)
     }
 
     private untrackLifecycle(): void {
@@ -256,17 +235,18 @@ export class TransactionContext {
     /** Disposal-only cancellation: idempotent and valid after terminal mark. */
     [CANCEL_TRANSACTION](): void {
         const root = this._parentTransaction ? this.rootTransaction() : this
-        root.cancelTree()
+        root.cancelTree(TRANSACTION_DISPOSED)
     }
 
     private hasTxnOrData = (state: State): boolean => {
-        if (this._atomMap.has(state)) return true
+        const draft = this._draft
+        if (draft.values.has(state)) return true
         // An unset buffered at this level (and not superseded by a later set)
         // makes this scope provide no value: the committed shadow still sits in
         // this._data.values until commit, so we must NOT read it — fall through
         // to a parent transaction, or report "not here" so `get` reads through
         // the committed parent chain.
-        if (this._unsetSet?.has(state)) {
+        if (draft.unsets?.has(state)) {
             return this._parentTransaction
                 ? this._parentTransaction.hasTxnOrData(state)
                 : false
@@ -278,10 +258,11 @@ export class TransactionContext {
     }
 
     private valueFromTxnOrData: GetValue = (state: State) => {
-        if (this._atomMap.has(state)) {
-            return this._atomMap.get(state)
+        const draft = this._draft
+        if (draft.values.has(state)) {
+            return draft.values.get(state)
         }
-        if (this._unsetSet?.has(state)) {
+        if (draft.unsets?.has(state)) {
             return this._parentTransaction
                 ? this._parentTransaction.valueFromTxnOrData(state)
                 : undefined
@@ -306,13 +287,13 @@ export class TransactionContext {
                     // boundary, so materialize the latest membership here.
                     const rendered = renderAtomFamilyIndex(value.__index)
                     if (
-                        this._atomMap.get(state) === value &&
+                        this._draft.values.get(state) === value &&
                         rendered !== value
                     ) {
-                        this._atomMap.set(state, rendered)
-                        this._dirtyFamilyIndexes?.delete(state)
-                        if (this._dirtyFamilyIndexes?.size === 0) {
-                            this._dirtyFamilyIndexes = undefined
+                        this._draft.values.set(state, rendered)
+                        this._draft.dirtyFamilyIndexes?.delete(state)
+                        if (this._draft.dirtyFamilyIndexes?.size === 0) {
+                            this._draft.dirtyFamilyIndexes = undefined
                         }
                     }
                     return rendered
@@ -323,7 +304,7 @@ export class TransactionContext {
             // committed value is still in this._data.values until commit, so we
             // must NOT read it: read through the parent chain (scope) or compute
             // the atom's default (root) instead.
-            if (this._unsetSet?.has(state)) {
+            if (this._draft.unsets?.has(state)) {
                 return this._data.parent
                     ? getState(
                           state,
@@ -338,9 +319,9 @@ export class TransactionContext {
             }
             return getState(state, this._data, this.initializedAtomsSet)
         } else if (isSelector(state)) {
-            if (this._dirty) {
+            if (this._draft.dirty) {
                 this.selectorCache.clear()
-                this._dirty = false
+                this._draft.dirty = false
             } else if (this.selectorCache.has(state)) {
                 // If the selector is cached and not dirty, return the cached value
                 return this.selectorCache.get(state)
@@ -372,39 +353,27 @@ export class TransactionContext {
             resolved = value
         }
 
-        // Freeze settled non-primitives so values are immutable within the
-        // transaction. Promise-like inputs are normalized by the async-write
-        // coordinator at commit and must remain usable until then. Respect
-        // atom.mutable and production mode. Kept inline (not shared, to avoid a
-        // call on the write hot path).
-        if (
-            !atom.mutable &&
-            !IS_PROD &&
-            resolved !== null &&
-            (typeof resolved === "object" || typeof resolved === "function") &&
-            !isPromiseLike(resolved)
-        ) {
-            resolved = deepFreeze(resolved)
-        }
-        // Validate at staging time (inside the txn body), not at commit: a
-        // failure throws here, so the user's callback aborts and commit never
-        // runs — the transaction stays atomic. Promise-like values are skipped
-        // here and validated after settlement by coordinateAsyncWrite during the
-        // commit path. This also covers stores using implicit batched txns.
-        resolved = validateSchema(atom, resolved, this._data)
-        this._atomMap.set(atom, resolved)
-        if (!this._hasCommitEffects && atom.onSet) {
-            this._hasCommitEffects = true
+        // Staging-time freeze + validation (see normalizeStagedValue): a schema
+        // failure throws inside the user's callback, so commit never runs and
+        // the transaction stays atomic. This also covers stores using implicit
+        // batched txns.
+        resolved = normalizeStagedValue(atom, resolved, this._data)
+        // One draft load for the whole staging body: bulk staging loops (5k+
+        // member updates) are Bencher-gated, so keep the per-set load profile
+        // identical to the historical direct fields.
+        const draft = this._draft
+        draft.values.set(atom, resolved)
+        if (!draft.hasCommitEffects && atom.onSet) {
+            draft.hasCommitEffects = true
         }
         // A set supersedes an unset of the same atom buffered earlier in this txn
         // (last write wins, regardless of order). Symmetric to `unset` dropping
         // any buffered set.
-        this._unsetSet?.delete(atom)
-        this.invalidateSelectorCache()
-
+        draft.unsets?.delete(atom)
+        if (!draft.dirty) draft.dirty = true
         if (isFamilyAtom(atom)) {
-            const ownFamilyValue = this._atomMap.has(atom.family)
-                ? this._atomMap.get(atom.family)
+            const ownFamilyValue = draft.values.has(atom.family)
+                ? draft.values.get(atom.family)
                 : this._data.values.has(atom.family)
                   ? this._data.values.get(atom.family)
                   : undefined
@@ -416,11 +385,11 @@ export class TransactionContext {
                 !ownFamilyValue?.__index ||
                 !hasOwnFamilyAtom(ownFamilyValue.__index, atom)
             ) {
-                if (!this._atomMap.has(atom.family)) {
+                if (!draft.values.has(atom.family)) {
                     // @ts-ignore
                     this.cloneFamilyIntoTxn(atom.family)
                 }
-                const index = this._atomMap.get(atom.family).__index
+                const index = draft.values.get(atom.family).__index
                 index.created.set(atom, performance.now())
                 index.deleted.delete(atom)
                 this.recursivelyUpdateAtomFamilyIndexes(atom.family)
@@ -437,8 +406,10 @@ export class TransactionContext {
             | undefined = undefined,
     ) => {
         this.assertOpen("write to")
-        let ownFamilyValue = this._atomMap.has(family)
-            ? this._atomMap.get(family)
+        // One draft load for the whole bulk loop (see Transaction.set).
+        const draft = this._draft
+        let ownFamilyValue = draft.values.has(family)
+            ? draft.values.get(family)
             : this._data.values.has(family)
               ? this._data.values.get(family)
               : undefined
@@ -450,49 +421,37 @@ export class TransactionContext {
                 throw new Error("Atom does not belong to the provided family")
             }
             let resolved = value
-            // Match Transaction.set's immutability contract. The branch stays
-            // allocation-free for primitives, which dominate hydration and the
-            // existing bulk benchmark.
-            if (
-                !atom.mutable &&
-                !IS_PROD &&
-                resolved !== null &&
-                (typeof resolved === "object" ||
-                    typeof resolved === "function") &&
-                !isPromiseLike(resolved)
-            ) {
-                resolved = deepFreeze(resolved)
-            }
-            // Validate like Transaction.set so this public bulk path cannot be
-            // used to bypass a store's schema boundary. Hydrate's lenient mode
-            // supplies a per-entry handler so invalid members can be skipped
-            // without giving up one grouped write per family.
+            // Freeze + validate like Transaction.set (normalizeStagedValue) so
+            // this public bulk path cannot be used to bypass a store's schema
+            // boundary. Hydrate's lenient mode supplies a per-entry handler so
+            // invalid members can be skipped without giving up one grouped
+            // write per family.
             if (!onSchemaError) {
-                resolved = validateSchema(atom, resolved, this._data)
+                resolved = normalizeStagedValue(atom, resolved, this._data)
             } else {
                 try {
-                    resolved = validateSchema(atom, resolved, this._data)
+                    resolved = normalizeStagedValue(atom, resolved, this._data)
                 } catch (error) {
                     if (!(error instanceof SchemaValidationError)) throw error
                     onSchemaError(error)
                     continue
                 }
             }
-            this._atomMap.set(atom, resolved)
+            draft.values.set(atom, resolved)
             if (!staged) {
                 staged = true
-                this.invalidateSelectorCache()
+                if (!draft.dirty) draft.dirty = true
             }
-            if (!this._hasCommitEffects && atom.onSet) {
-                this._hasCommitEffects = true
+            if (!draft.hasCommitEffects && atom.onSet) {
+                draft.hasCommitEffects = true
             }
-            this._unsetSet?.delete(atom)
+            draft.unsets?.delete(atom)
 
             if (!index || !hasOwnFamilyAtom(index, atom)) {
-                if (!this._atomMap.has(family)) {
+                if (!draft.values.has(family)) {
                     // @ts-ignore
                     this.cloneFamilyIntoTxn(family)
-                    ownFamilyValue = this._atomMap.get(family)
+                    ownFamilyValue = draft.values.get(family)
                     index = ownFamilyValue.__index
                 }
                 index.created.set(atom, performance.now())
@@ -507,19 +466,19 @@ export class TransactionContext {
 
     del = (atom: AtomFamilyAtom<any, any>) => {
         this.assertOpen("write to")
-        if (!this._atomMap.has(atom.family)) {
+        if (!this._draft.values.has(atom.family)) {
             // @ts-ignore
             this.cloneFamilyIntoTxn(atom.family)
         }
-        const index = this._atomMap.get(atom.family).__index
+        const index = this._draft.values.get(atom.family).__index
         index.created.delete(atom)
         index.deleted.set(atom, performance.now())
         this.recursivelyUpdateAtomFamilyIndexes(atom.family)
         if (this._data.values.has(atom)) {
             this.deleteSet.add(atom)
         }
-        if (this._atomMap.has(atom)) {
-            this._atomMap.delete(atom)
+        if (this._draft.values.has(atom)) {
+            this._draft.values.delete(atom)
         }
         this.invalidateSelectorCache()
     }
@@ -530,22 +489,10 @@ export class TransactionContext {
         // An unset in the same txn supersedes a set of the same atom — drop any
         // buffered write so the atom reverts (re-inherits on a scope / reverts to
         // its default on a root) rather than being re-written.
-        this._atomMap.delete(atom)
-        if (!this._unsetSet) this._unsetSet = new Set()
-        this._unsetSet.add(atom)
+        this._draft.values.delete(atom)
+        if (!this._draft.unsets) this._draft.unsets = new Set()
+        this._draft.unsets.add(atom)
         this.invalidateSelectorCache()
-    }
-
-    // Detach the own value + bookkeeping for each unset atom that actually had
-    // one; returns those atoms so the commit can propagate and report them.
-    // Called in the write phase so every store's values are final before any
-    // propagation pass runs.
-    private applyUnsets = (unsetSet: Set<Atom>, data: StoreData): Atom[] => {
-        const unsetAtoms: Atom[] = []
-        for (const atom of unsetSet) {
-            if (detachOwnValue(atom, data)) unsetAtoms.push(atom)
-        }
-        return unsetAtoms
     }
 
     scope = <Callback extends TransactionFn>(
@@ -589,12 +536,12 @@ export class TransactionContext {
             this._data,
             this.initializedAtomsSet,
         ) as V | Promise<V>
-        this._atomMap.set(atom, value)
-        if (!this._hasCommitEffects && atom.onSet) {
-            this._hasCommitEffects = true
+        this._draft.values.set(atom, value)
+        if (!this._draft.hasCommitEffects && atom.onSet) {
+            this._draft.hasCommitEffects = true
         }
         // reset writes the default; it supersedes a buffered unset of the atom.
-        this._unsetSet?.delete(atom)
+        this._draft.unsets?.delete(atom)
         this.invalidateSelectorCache()
         return value
     };
@@ -604,8 +551,8 @@ export class TransactionContext {
         autoCommit = true,
     ): ReturnType<Callback> {
         this.assertOpen("execute")
-        if (this._selectorRuntime)
-            this._selectorRuntime.readOverlayActive = true
+        if (this._draft.selectorRuntime)
+            this._draft.selectorRuntime.readOverlayActive = true
         try {
             const result = callback(this) as ReturnType<Callback>
             if (isPromiseLike(result)) {
@@ -625,12 +572,12 @@ export class TransactionContext {
                 // Preserve the callback error even if it disposed the store.
                 // This internal cancellation intentionally bypasses the public
                 // lifecycle assertion while still draining speculative work.
-                root[CANCEL_TRANSACTION]()
+                root.cancelTree(TRANSACTION_ABORTED)
             }
             throw error
         } finally {
-            if (this._selectorRuntime) {
-                this._selectorRuntime.readOverlayActive = false
+            if (this._draft.selectorRuntime) {
+                this._draft.selectorRuntime.readOverlayActive = false
             }
         }
     }
@@ -649,9 +596,13 @@ export class TransactionContext {
         try {
             root.commitOpenTransaction(source)
         } finally {
-            root._state = TRANSACTION_CLOSED
+            // Terminal mark only: a committed tree keeps its (already applied)
+            // staging state, exactly as the historical fields did — retained
+            // handles may still be inspected, and in-flight speculative async
+            // selector work settles through the overlay runtime.
+            root._state = TRANSACTION_COMMITTED
             if (root._scopedTransactions) {
-                root.setScopedTreeState(TRANSACTION_CLOSED)
+                root.setScopedTreeState(TRANSACTION_COMMITTED)
             }
             root.untrackTree()
         }
@@ -663,7 +614,7 @@ export class TransactionContext {
         if (root._scopedTransactions) {
             root.assertScopedTreeOpen("abort")
         }
-        root.cancelTree()
+        root.cancelTree(TRANSACTION_ABORTED)
     }
 
     private rootTransaction(): TransactionContext {
@@ -691,6 +642,35 @@ export class TransactionContext {
     }
 
     private commitOpenTransaction(source?: StoreChangeSource): void {
+        // The ordinary single-store arm — no hooks (and therefore no globals:
+        // every global atom carries a marker onSet) and no cleanup mutations —
+        // translates its whole commit into one CommitPlan that owns the outer
+        // commit-end boundary and the deferred onChange flush. The remaining
+        // arms share their write phase with the unmigrated global fan-out
+        // adapter, whose branch is only known after that phase, so their outer
+        // boundary and flush stay below until the cross-scope/global migration.
+        if (
+            !this._scopedTransactions &&
+            !this._draft.hasCommitEffects &&
+            !draftHasCleanupMutations(this._draft)
+        ) {
+            // Staging materialization only (one copy + sort per dirty family
+            // working index) — unobservable, so it may precede the boundary.
+            this.renderDirtyAtomFamilyIndexes()
+            // With no listener anywhere no sink is allocated, so the
+            // Bencher-gated txn hot path keeps its shape.
+            const sink =
+                changeListenerRegistry.count === 0
+                    ? undefined
+                    : createChangeSink(this._name, source)
+            commitHookFreeAtoms(
+                this._draft.values,
+                this._data,
+                new Set<Atom>(),
+                sink,
+            )
+            return
+        }
         // Commit boundary for store.onCommitEnd: listeners fire once, when the
         // outermost boundary closes — after every subscriber callback and after
         // the onChange flush below. The inner propagation passes also open
@@ -740,148 +720,87 @@ export class TransactionContext {
     }
 
     private commitWork = (sink: ChangeSink | undefined) => {
-        // Single-store fast path: no scoped transactions to coordinate.
+        // Single-store path: no scoped transactions to coordinate. Translate
+        // the finalized overlay into the commit engine — the bulk coordinator,
+        // or a CommitPlan for cleanup mutations. (The hook-free arm committed
+        // its own plan from commitOpenTransaction.) Only global peer fan-out
+        // stays on its legacy adapter (see below).
         if (!this._scopedTransactions) {
             this.renderDirtyAtomFamilyIndexes()
+            const draft = this._draft
+            // Commit-scoped initialization set — deliberately NOT the draft's
+            // body-read set: atoms lazily initialized while the callback ran
+            // must not be re-propagated by the write phase.
             const initializedAtomsSet = new Set<Atom>()
-            if (!this._unsetSet?.size && !this._deleteSet?.size) {
-                setAtoms(
-                    this._atomMap,
+            if (!draftHasCleanupMutations(draft)) {
+                commitAtoms(
+                    draft.values,
                     this._data,
                     initializedAtomsSet,
-                    false,
-                    sink,
-                    this._hasCommitEffects,
+                    sink
+                        ? { onSet: "collect", report: sink }
+                        : BULK_WITH_EFFECTS_SILENT,
                 )
                 return
             }
 
-            // Deletes/unsets require multiple propagation passes. Complete ALL
-            // mutations first, then hooks, then every propagation/notification.
+            // Cleanup commit: deletes/unsets require multiple propagation
+            // passes. Complete ALL mutations first (phases 1–2 inline), then
+            // hand the plan to the engine for hooks, settlement, cleanup
+            // ordering, and error arbitration.
             const onSets: DeferredOnSet[] = []
             const updatedAtoms = writeAtoms(
-                this._atomMap,
+                draft.values,
                 this._data,
                 initializedAtomsSet,
                 false,
                 onSets,
             )
-            const deleted = this._deleteSet?.size
-                ? [...this._deleteSet]
+            const deleted = draft.deletes?.size
+                ? [...draft.deletes]
                 : undefined
-            if (this._deleteSet?.size) {
-                deleteAtomFamilyAtoms(this._deleteSet, this._data)
+            if (draft.deletes?.size) {
+                deleteAtomFamilyAtoms(draft.deletes, this._data)
             }
-            const unsetAtoms = this._unsetSet?.size
-                ? this.applyUnsets(this._unsetSet, this._data)
+            const unsetAtoms = draft.unsets?.size
+                ? applyUnsets(draft.unsets, this._data)
                 : []
 
             const errors = createCommitErrors()
+            // Global peers are writes too: apply them all while still in the
+            // write phase. An empty map means every peer was value-equal — a
+            // local plan handles that exactly like no globals at all.
             const globalUpdates = applyGlobalOnSets(onSets, errors)
-            runOnSets(onSets, errors)
+            if (globalUpdates && globalUpdates.size > 0) {
+                // Hooks fire after every local and peer write, before any
+                // propagation — same order the plan path gets from the engine.
+                runOnSets(onSets, errors)
+                this.commitCleanupWithGlobalFanOut(
+                    updatedAtoms,
+                    deleted,
+                    unsetAtoms,
+                    sink,
+                    errors,
+                    globalUpdates,
+                )
+                return
+            }
 
-            const notify: NotifyTarget = new Map()
-            const globalSink =
-                globalUpdates && globalUpdates.size > 0
-                    ? createChangeSink(undefined, "set")
-                    : undefined
-            const commitRoots = globalSink
-                ? beginGlobalCommit(this._data, globalUpdates!)
-                : []
-            // Global peers historically surface as direct `set` changes and
-            // report before the transaction origin.
-            if (globalUpdates) {
-                for (const [peer, atoms] of globalUpdates) {
-                    try {
-                        propagateAtomUpdate(
-                            atoms,
-                            peer,
-                            false,
-                            notify,
-                            globalSink,
-                        )
-                    } catch (error) {
-                        recordCommitError(errors, error)
-                    }
-                }
-            }
-            if (updatedAtoms.length > 0) {
-                try {
-                    propagateAtomUpdate(
-                        updatedAtoms,
-                        this._data,
-                        false,
-                        notify,
-                        sink,
-                    )
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            if (deleted) {
-                try {
-                    propagateDeletedAtoms(
-                        deleted,
-                        this._data,
-                        undefined,
-                        undefined,
-                        undefined,
-                        notify,
-                        sink,
-                    )
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            if (unsetAtoms.length > 0) {
-                if (sink) {
-                    for (const atom of unsetAtoms) {
-                        reportUnsetAtom(
-                            atom,
-                            this._data,
-                            effectiveValueAfterUnset(atom, this._data),
-                            sink,
-                        )
-                    }
-                }
-                try {
-                    propagateAtomUpdate(
-                        unsetAtoms,
-                        this._data,
-                        false,
-                        notify,
-                        sink,
-                        false,
-                        false,
-                    )
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            try {
-                notifyDeferred(notify)
-            } catch (error) {
-                recordCommitError(errors, error)
-            }
-            if (globalSink) {
-                try {
-                    flushChangeSink(globalSink)
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-                endGlobalCommit(commitRoots, errors)
-            }
-            // Re-delegate AFTER firing: the deferred scope-local callback
-            // idempotently drops its delegate, so the fresh parent delegate is
-            // established last even when a callback threw.
-            for (const atom of unsetAtoms) {
-                try {
-                    reDelegateScopeSubscriptions(atom, this._data)
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            throwCommitError(errors)
+            runCommitPlan({
+                data: this._data,
+                settlement: {
+                    kind: "transaction",
+                    atoms: updatedAtoms,
+                    deleted,
+                    unset: unsetAtoms.length > 0 ? unsetAtoms : undefined,
+                    settle: settleTransactionCommit,
+                },
+                onSets,
+                errors,
+                report: sink,
+                // continueAfterError stays default: a hook error must not
+                // starve settlement of already-applied writes.
+            })
             return
         }
 
@@ -908,20 +827,20 @@ export class TransactionContext {
             const txn = entry.txn
             txn.renderDirtyAtomFamilyIndexes()
             entry.updatedAtoms = writeAtoms(
-                txn._atomMap,
+                txn._draft.values,
                 entry.data,
                 new Set<Atom>(),
                 false,
                 entry.onSets,
             )
-            if (txn._deleteSet?.size) {
-                deleteAtomFamilyAtoms(txn._deleteSet, entry.data)
-                entry.deleted = [...txn._deleteSet]
+            if (txn._draft.deletes?.size) {
+                deleteAtomFamilyAtoms(txn._draft.deletes, entry.data)
+                entry.deleted = [...txn._draft.deletes]
             }
-            if (txn._unsetSet?.size) {
+            if (txn._draft.unsets?.size) {
                 // Detach shadows in the write phase so every store's values are
                 // final before any propagation pass reads through the chain.
-                entry.unsetAtoms = txn.applyUnsets(txn._unsetSet, entry.data)
+                entry.unsetAtoms = applyUnsets(txn._draft.unsets, entry.data)
             }
         }
 
@@ -1064,6 +983,112 @@ export class TransactionContext {
         throwCommitError(errors)
     }
 
+    /**
+     * LEGACY GLOBAL FAN-OUT ADAPTER (unmigrated). A single-store cleanup
+     * commit whose staged writes changed at least one global peer settles the
+     * whole multi-store unit here instead of through a CommitPlan: every
+     * store's selectors settle before any subscriber fires, and no store's
+     * error starves a later store. Callers have already applied every local
+     * and peer value and run the deferred hooks. Global write planning moves
+     * onto the engine with the cross-scope migration.
+     */
+    private commitCleanupWithGlobalFanOut(
+        updatedAtoms: Atom[],
+        deleted: AtomFamilyAtom<any, any>[] | undefined,
+        unsetAtoms: Atom[],
+        sink: ChangeSink | undefined,
+        errors: CommitErrors,
+        globalUpdates: StoreAtomUpdates,
+    ): void {
+        const notify: NotifyTarget = new Map()
+        const globalSink = createChangeSink(undefined, "set")
+        const commitRoots = beginGlobalCommit(this._data, globalUpdates)
+        // Global peers historically surface as direct `set` changes and
+        // report before the transaction origin.
+        for (const [peer, atoms] of globalUpdates) {
+            try {
+                propagateAtomUpdate(atoms, peer, false, notify, globalSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        if (updatedAtoms.length > 0) {
+            try {
+                propagateAtomUpdate(
+                    updatedAtoms,
+                    this._data,
+                    false,
+                    notify,
+                    sink,
+                )
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        if (deleted) {
+            try {
+                propagateDeletedAtoms(
+                    deleted,
+                    this._data,
+                    undefined,
+                    undefined,
+                    undefined,
+                    notify,
+                    sink,
+                )
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        if (unsetAtoms.length > 0) {
+            if (sink) {
+                for (const atom of unsetAtoms) {
+                    reportUnsetAtom(
+                        atom,
+                        this._data,
+                        effectiveValueAfterUnset(atom, this._data),
+                        sink,
+                    )
+                }
+            }
+            try {
+                propagateAtomUpdate(
+                    unsetAtoms,
+                    this._data,
+                    false,
+                    notify,
+                    sink,
+                    false,
+                    false,
+                )
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        try {
+            notifyDeferred(notify)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        try {
+            flushChangeSink(globalSink)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        endGlobalCommit(commitRoots, errors)
+        // Re-delegate AFTER firing: the deferred scope-local callback
+        // idempotently drops its delegate, so the fresh parent delegate is
+        // established last even when a callback threw.
+        for (const atom of unsetAtoms) {
+            try {
+                reDelegateScopeSubscriptions(atom, this._data)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+        throwCommitError(errors)
+    }
+
     // Depth-first pre-order: this store, then each nested scope. Produces a
     // root-first plan used directly for the notify pass and reversed for the
     // write pass (so descendants are written before their ancestors).
@@ -1084,40 +1109,42 @@ export class TransactionContext {
     }
 
     private get selectorCache() {
-        if (!this._selectorCache) this._selectorCache = new Map()
-        return this._selectorCache
+        if (!this._draft.selectorCache) this._draft.selectorCache = new Map()
+        return this._draft.selectorCache
     }
 
     private invalidateSelectorCache() {
-        if (!this._dirty) this._dirty = true
+        if (!this._draft.dirty) this._draft.dirty = true
     }
 
     private get selectorRuntime(): SelectorEvaluationRuntime {
-        if (!this._selectorRuntime) {
-            this._selectorRuntime = {
+        if (!this._draft.selectorRuntime) {
+            this._draft.selectorRuntime = {
                 abortControllers: new Map(),
                 latestEvalContext: new Map(),
                 stateDependencies: new Map(),
                 readOverlayActive: true,
             }
         }
-        return this._selectorRuntime
+        return this._draft.selectorRuntime
     }
 
     private get selectorCircularDependencySet() {
-        if (!this._selectorCircularDependencySet) {
-            this._selectorCircularDependencySet = new WeakSet()
+        if (!this._draft.selectorCircularDependencies) {
+            this._draft.selectorCircularDependencies = new WeakSet()
         }
-        return this._selectorCircularDependencySet
+        return this._draft.selectorCircularDependencies
     }
     private get deleteSet() {
-        if (!this._deleteSet) this._deleteSet = new Set()
-        return this._deleteSet
+        if (!this._draft.deletes) this._draft.deletes = new Set()
+        return this._draft.deletes
     }
 
     private get initializedAtomsSet() {
-        if (!this._initializedAtomsSet) this._initializedAtomsSet = new Set()
-        return this._initializedAtomsSet
+        if (!this._draft.initializedAtoms) {
+            this._draft.initializedAtoms = new Set()
+        }
+        return this._draft.initializedAtoms
     }
 
     private scopedTransaction(scopeId: string) {
@@ -1142,8 +1169,8 @@ export class TransactionContext {
                 parentIndex,
                 moveUpIfParent,
             )
-        const currentFamilyIndex = this._atomMap.has(family)
-            ? this._atomMap.get(family).__index
+        const currentFamilyIndex = this._draft.values.has(family)
+            ? this._draft.values.get(family).__index
             : this._data.values.has(family)
               ? this._data.values.get(family).__index
               : (this.get(family) as any).__index
@@ -1161,15 +1188,15 @@ export class TransactionContext {
         // it — permanently stale. Registering in scopeValueIndex (trackScopeValue)
         // and keeping the parentIndex link mirrors initFamilyIndex exactly.
         // TRUE first materialization: the scope has no working index for this
-        // family yet — neither in this txn (_atomMap) nor committed (data.values).
-        // The `!_atomMap.has` guard is essential: cloneFamilyIntoTxn is re-invoked
-        // on a scoped txn via the recursion below whenever an ancestor re-clones,
-        // and at that point the scope may already hold its own accumulated
-        // created/deleted in _atomMap — which must be preserved (cloned), not
-        // reset to an empty child index.
+        // family yet — neither staged in this txn's draft nor committed
+        // (data.values). The `!draft.values.has` guard is essential:
+        // cloneFamilyIntoTxn is re-invoked on a scoped txn via the recursion
+        // below whenever an ancestor re-clones, and at that point the scope may
+        // already hold its own accumulated created/deleted in its draft — which
+        // must be preserved (cloned), not reset to an empty child index.
         const scopeFirstMaterialization =
             this._data.parent &&
-            !this._atomMap.has(family) &&
+            !this._draft.values.has(family) &&
             !this._data.values.has(family)
         let clonedIndex
         if (scopeFirstMaterialization) {
@@ -1206,7 +1233,7 @@ export class TransactionContext {
         const unrenderedFamilyValue: any[] = []
         // @ts-ignore
         unrenderedFamilyValue.__index = clonedIndex
-        this._atomMap.set(family, unrenderedFamilyValue)
+        this._draft.values.set(family, unrenderedFamilyValue)
         this.markAtomFamilyIndexDirty(family)
     }
 
@@ -1223,25 +1250,27 @@ export class TransactionContext {
     }
 
     private markAtomFamilyIndexDirty(atomFamily: AtomFamily<any, any>) {
-        const currentIndex = this._atomMap.get(atomFamily).__index
+        const currentIndex = this._draft.values.get(atomFamily).__index
         currentIndex.rendered = null
         currentIndex.renderedArray = null
-        if (!this._dirtyFamilyIndexes) this._dirtyFamilyIndexes = new Set()
-        this._dirtyFamilyIndexes.add(atomFamily)
+        if (!this._draft.dirtyFamilyIndexes) {
+            this._draft.dirtyFamilyIndexes = new Set()
+        }
+        this._draft.dirtyFamilyIndexes.add(atomFamily)
     }
 
     /** Materialize every dirty family working index immediately before this
      *  transaction writes. Updating a Map value does not disturb insertion
      *  order, so atom/family propagation order remains unchanged. */
     private renderDirtyAtomFamilyIndexes() {
-        const dirtyFamilyIndexes = this._dirtyFamilyIndexes
+        const dirtyFamilyIndexes = this._draft.dirtyFamilyIndexes
         if (!dirtyFamilyIndexes) return
         for (const state of dirtyFamilyIndexes) {
-            const value = this._atomMap.get(state)
+            const value = this._draft.values.get(state)
             const rendered = renderAtomFamilyIndex(value.__index)
-            if (rendered !== value) this._atomMap.set(state, rendered)
+            if (rendered !== value) this._draft.values.set(state, rendered)
         }
-        this._dirtyFamilyIndexes = undefined
+        this._draft.dirtyFamilyIndexes = undefined
     }
 }
 

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -11,15 +11,16 @@ import { setValueInData } from "./setValueInData"
  * Write phase (commit phases 1–2) for a single store. Applies every value in
  * `pairs` to `data.values`, returning the atoms whose value actually changed
  * (the propagation set), merged with any atoms lazily initialized during the
- * equality checks. This does NOT propagate — see `setAtoms` (single-store
- * fast path) or the transaction commit pipeline (cross-scope path) for notify.
+ * equality checks. This does NOT propagate — the bulk coordinators in
+ * `setAtoms.ts`, the transaction CommitPlan, and the cross-scope transaction
+ * pipeline own notify.
  *
  * Hook and global handling are deliberately collection-only. The caller first
  * completes every local/global write, then runs `onSetQueue`, then propagates.
  * This keeps a throwing hook from interrupting either the write or propagation
- * phase. The boolean remains here because transactions are not migrated by the
- * commit-engine change; typed bulk coordinators translate their intent at their
- * own boundary.
+ * phase. The boolean remains positional because the unmigrated cross-scope
+ * transaction arm still calls it directly; typed bulk coordinators translate
+ * their intent at their own boundary.
  */
 export const writeAtoms = (
     pairs: Map<Atom<any>, any>,

--- a/packages/valdres/src/types/CommitIntent.ts
+++ b/packages/valdres/src/types/CommitIntent.ts
@@ -17,10 +17,11 @@ export type DirectWriteIntent = {
 export type OnSetPolicy = "collect" | "skip"
 
 /**
- * Intent for a staged bulk write (`setAtoms` — the single-store transaction
- * commit delegate). Collapses the historical implicit `skipOnSet` ×
- * `hasCommitEffects` mode combination into one field, and carries the phase-6
- * delivery target explicitly (undefined = no onChange listener anywhere).
+ * Intent for a staged bulk write (`commitAtoms` — invoked directly by a
+ * single-store transaction commit). Collapses the historical implicit
+ * `skipOnSet` × `hasCommitEffects` mode combination into one field, and
+ * carries the phase-6 delivery target explicitly (undefined = no onChange
+ * listener anywhere).
  */
 export type BulkWriteIntent = {
     readonly onSet: OnSetPolicy

--- a/packages/valdres/src/types/CommitPlan.ts
+++ b/packages/valdres/src/types/CommitPlan.ts
@@ -9,6 +9,7 @@ import type { SettleFn } from "./SettleFn"
 import type { Selector } from "./Selector"
 import type { SelectorSettleFn } from "./SelectorSettleFn"
 import type { StoreData } from "./StoreData"
+import type { TransactionSettleFn } from "./TransactionSettleFn"
 
 type UpdateSettlement = {
     kind: "update"
@@ -34,6 +35,18 @@ type SelectorSettlement = {
     settle: SelectorSettleFn
 }
 
+/** A single-store transaction commit with cleanup mutations: updated atoms,
+ *  deleted family members, and unset atoms settle as one deferred-notification
+ *  unit. `deleted`/`unset` are undefined (never empty) when absent so the
+ *  engine's has-work guard stays a plain presence check. */
+type TransactionSettlement = {
+    kind: "transaction"
+    atoms: Atom<any>[]
+    deleted: AtomFamilyAtom<any, any>[] | undefined
+    unset: Atom<any>[] | undefined
+    settle: TransactionSettleFn
+}
+
 type NoSettlement = {
     kind: "none"
 }
@@ -42,6 +55,7 @@ type CommitSettlement =
     | UpdateSettlement
     | DeleteSettlement
     | SelectorSettlement
+    | TransactionSettlement
     | NoSettlement
 
 /**
@@ -52,8 +66,9 @@ type CommitSettlement =
  *
  * `settlement` is a typed description of an existing propagation primitive.
  * Update/reset/unset plans use `settleCommit` with shared `SettleFlags`;
- * deletion uses `settleDeletedCommit`; native async selectors use their
- * downstream-only settlement; guarded cleanup uses `kind: "none"`.
+ * deletion uses `settleDeletedCommit`; a single-store transaction commit with
+ * cleanup mutations uses `settleTransactionCommit`; native async selectors use
+ * their downstream-only settlement; guarded cleanup uses `kind: "none"`.
  *
  * Optional phase callbacks stay declarative: the engine owns their order.
  * `beforeSettle` lets unset prepend its distinct removal change record;
@@ -61,10 +76,11 @@ type CommitSettlement =
  * re-delegation; `flushReport` drains a deliberately deferred onChange sink.
  * The callbacks are absent from ordinary bulk plans.
  *
- * Scope note: local plans still model one store and one settlement. Cross-scope
- * transactions and ordinary global writes remain behind their adapters; async
- * global settlement delegates its multi-store phase without adding a local
- * begin/end boundary.
+ * Scope note: local plans still model one store and one settlement — including
+ * single-store transaction commits, whose finalized overlay translates into a
+ * plan. Cross-scope transactions and ordinary global writes remain behind
+ * their adapters; async global settlement delegates its multi-store phase
+ * without adding a local begin/end boundary.
  */
 export type CommitPlan = {
     data: StoreData

--- a/packages/valdres/src/types/MutationDraft.ts
+++ b/packages/valdres/src/types/MutationDraft.ts
@@ -1,0 +1,50 @@
+import type { SelectorEvaluationRuntime } from "../lib/initSelector"
+import type { Atom } from "./Atom"
+import type { AtomFamily } from "./AtomFamily"
+import type { AtomFamilyAtom } from "./AtomFamilyAtom"
+import type { Selector } from "./Selector"
+
+/**
+ * The write overlay of one transaction level: everything a transaction stages
+ * against a single store before commit, and nothing about how a commit
+ * executes. A transaction context owns exactly one draft per store level;
+ * commit translates the finalized draft into a `CommitPlan` (or, for the
+ * unmigrated cross-scope/global shapes, into the legacy fan-out sequencing).
+ *
+ * The overlay layers over committed store state in read precedence order:
+ * staged `values` → `unsets` tombstone (fall through to the parent chain) →
+ * committed `data.values` → parent transaction. Speculative selector reads are
+ * memoized in `selectorCache` and evaluated against `selectorRuntime` so an
+ * aborted transaction can never rewrite the committed selector graph.
+ */
+export type MutationDraft = {
+    /** Staged atom values, plus family-index carrier arrays for families whose
+     *  membership this transaction changes. */
+    values: Map<any, any>
+    /** Unset tombstones: atoms whose own value is detached at commit so they
+     *  revert (re-inherit on a scope, de-materialize on a root). */
+    unsets: Set<Atom<any>> | undefined
+    /** Family-member delete tombstones that also have a committed value to
+     *  remove (membership-only deletes live in the staged family index). */
+    deletes: Set<AtomFamilyAtom<any, any>> | undefined
+    /** Families whose staged working index needs one render (copy + sort)
+     *  before the next observation boundary: a family read or the commit. */
+    dirtyFamilyIndexes: Set<AtomFamily<any, [any, ...any[]]>> | undefined
+    /** Atoms lazily initialized by overlay reads during the transaction body.
+     *  Distinct from the commit-scoped initialization set the write phase
+     *  allocates: body-initialized atoms must not be re-propagated. */
+    initializedAtoms: Set<Atom<any>> | undefined
+    /** Overlay revision marker. Every staging operation sets it; the next
+     *  overlay selector read drops `selectorCache` and clears it. */
+    dirty: boolean
+    /** Speculative selector-read cache (read-your-writes memoization). */
+    selectorCache: Map<Selector<any>, any> | undefined
+    /** Isolated evaluation bookkeeping for overlay selector reads — see
+     *  `SelectorEvaluationRuntime`. */
+    selectorRuntime: SelectorEvaluationRuntime | undefined
+    /** Per-transaction circular-dependency guard for overlay selector reads. */
+    selectorCircularDependencies: WeakSet<any> | undefined
+    /** True once any staged atom carries an onSet hook (global atoms always
+     *  do), selecting the phased hook/fan-out commit path. */
+    hasCommitEffects: boolean
+}

--- a/packages/valdres/src/types/TransactionSettleFn.ts
+++ b/packages/valdres/src/types/TransactionSettleFn.ts
@@ -1,0 +1,23 @@
+import type { CommitErrors } from "../lib/commitErrors"
+import type { ChangeReport } from "../lib/notifyChangeListeners"
+import type { Atom } from "./Atom"
+import type { AtomFamilyAtom } from "./AtomFamilyAtom"
+import type { StoreData } from "./StoreData"
+
+/**
+ * Settlement (phases 4–7) of a single-store transaction commit that includes
+ * cleanup mutations: one deferred-notification pass over the updated atoms,
+ * the deleted family members, and the unset atoms, in that order, firing every
+ * collected subscriber once at the end. Statically `settleTransactionCommit`;
+ * passed by reference into the commit engine so the engine never imports the
+ * propagation layer. Unlike the single-settlement shapes it records per-pass
+ * errors into `errors` itself — one pass failing must not starve the others.
+ */
+export type TransactionSettleFn = (
+    updatedAtoms: Atom<any>[],
+    deletedAtoms: AtomFamilyAtom<any, any>[] | undefined,
+    unsetAtoms: Atom<any>[] | undefined,
+    data: StoreData,
+    report: ChangeReport | undefined,
+    errors: CommitErrors,
+) => void

--- a/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
+++ b/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
@@ -44,6 +44,9 @@ one side of a PR comparison.
 - `schedulerQueueEnqueues` / `schedulerQueueDequeues`: ready/resweep selector
   queue work where a queue exists. The one-selector linear fast path correctly
   reports zero.
+- `commitPlanRuns`: admitted `runCommitPlan` executions. Every single-store
+  transaction commit shape (ordinary, hooked, cleanup) must execute exactly
+  one plan; scalar direct writes correctly report zero.
 
 The collector is an internal optional `StoreData` field. It is attached only for
 one synchronous test/benchmark window, inherited by scopes created during that


### PR DESCRIPTION
Prompt 7 of the commit-engine migration (follows #257, #258, #259). Reduces single-store transaction internals to a **MutationDraft** write overlay and delegates commit execution to **CommitPlan**. Public transaction API and behavior are preserved, with two deliberate, changeset-recorded edge-case fixes.

## What changed

- **Staging is a write overlay.** `TransactionContext` keeps only lifecycle and tree structure; every staged mutation (values + family-index carriers, unset/delete tombstones, dirty family indexes, overlay revision, speculative selector cache/runtime) lives in one `MutationDraft` (`types/MutationDraft.ts`, `lib/mutationDraft.ts`). Lifecycle tracks committed/aborted/disposed distinctly; terminal handles still report `"closed"`, so misuse errors are byte-identical.
- **Every single-store commit executes exactly one CommitPlan** (gate-enforced via a new `commitPlanRuns` architecture counter):
  - hook-free arm → `commitHookFreeAtoms` runs a **module-static reusable plan** (zero per-commit allocations; a nested commit from a subscriber falls back to a fresh plan) owning `apply` (with the fresh-atom specialization), the outer commit-end boundary, and the deferred onChange flush;
  - hooked arm → `commitAtoms` (one `update`-settlement plan);
  - cleanup arm → new `kind:"transaction"` settlement; `settleTransactionCommit` (propagation layer) owns the update → delete → unset-report → unset → deferred-notify → re-delegate unit with per-pass error recording.
  `runCommitPlan`'s phase gates are module-level helpers (no per-run closures). The `setAtoms` "TEMPORARY TRANSACTION ADAPTER" is deleted. Engine/propagation/notification/fan-out modules still import nothing from transactions; the import-cycle baseline is untouched.
- **Shared staging normalization** (`lib/normalizeStagedValue.ts`): validate **before** dev-freeze, so schema validators observe the same unfrozen representation as direct writes (parity test covers direct, staged, and family-batch writes). Bulk staging loops hoist the draft to a single load, keeping the per-set profile identical to the historical direct fields.
- **Out of scope (next change):** cross-scope planning and global peer fan-out stay on their documented legacy adapters — their executor branch is only knowable mid write phase, so the hooked/cleanup arms' outer boundary stays in `commitOpenTransaction` until that migration.

## Deliberate behavior fixes

1. An unset-report failure during a transaction commit (reachable via a scoped store + throwing function default + onChange) now records into first-error commit arbitration instead of masking an earlier `onSet` hook error. Test-pinned.
2. Transaction staging validates schemas before freezing — a validator that rejects frozen inputs now behaves identically across `store.set` and `store.txn`.

## Verification

- Full suite 1047 pass / 0 fail: trace oracle, both fuzzers (500 + 8000 seeds), invariant checker, import-cycle guard, all txn/adapter/scope tests; plus new coverage: global+cleanup hook ordering, throwing-hook non-starvation, global+delete fan-out, engine `kind:"transaction"` dispatch/has-work, arbitration pin, frozen-representation parity, exactly-one-plan gates, nested hook-free fallback.
- Typecheck, builds, deterministic architecture gates, retained-memory gates (Node 8/8; Bun at head-vs-base parity — the "single-store transactions" Bun ceiling is unreachable locally for origin/main too: 230 vs 230 B/unit; the CI runner observes ~157).
- **Bencher (CI, green):** the hot `txn: staged set + selector read` runs at parity-to-faster than base (−4…−34% across interleaved pairs) after making the hook-free plan allocation-free; batch txn benches flat to faster.

### Note on two flaky benches on the CI runner

Across four consecutive `benchmark_pr` runs of the same code, `atomFamily: txn update 5,000 existing members` (Node) and `architecture: create + dispose scope` (Node) show a **pre-existing bimodal ~2× slow-mode that strikes base and PR alike**: run 1 the PR drew the slow mode 2/3 (alert), run 2 the *base* drew it 2/3, run 4 the base drew it 3/3. Isolated single-file runs are stable on both sides; the mode only appears in full-suite processes. Worth a follow-up on `main` (e.g. explicit warm-up for those benches), independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)