### PR TITLE
refactor(valdres): commit cross-scope transactions through one tree-level CommitPlan

### DIFF
--- a/.changeset/tree-level-cross-scope-commit.md
+++ b/.changeset/tree-level-cross-scope-commit.md
@@ -1,0 +1,19 @@
+---
+"valdres": patch
+---
+
+Cross-scope transaction commits now execute one tree-level CommitPlan that
+settles each affected store exactly once against the union of its own writes,
+inherited changes, and any folded global-peer updates. Observable deltas: a
+selector spanning several scopes evaluates once per store per commit instead of
+once per reaching pass (an async spanning selector creates one promise per
+commit instead of two); a custom `equal` receives the same per-reaching-pass
+trigger sets as before — consulted in reaching order for exactly the groups
+whose dirty chain reached that selector — so an impure predicate counting calls
+sees fewer of them; a global peer that is itself part of the transaction's
+store tree settles once instead of once in the peer pass and again in the tree;
+and an unset-report failure during a cross-scope commit records into
+first-error commit arbitration (and no longer starves other stores'
+settlement) instead of escaping raw. Subscriber delivery order, first-error
+arbitration, and onChange payload order keep their historical per-reaching-
+group causal positions.

--- a/packages/valdres/src/lib/adapterTransaction.test.ts
+++ b/packages/valdres/src/lib/adapterTransaction.test.ts
@@ -57,6 +57,33 @@ describe("adapter transaction lifecycle", () => {
         )
     })
 
+    test("abort discards a cross-scope working tree without any observable event", () => {
+        const root = store()
+        const child = root.scope("abort-scope")
+        const rootAtom = atom(1)
+        const scopeAtom = atom(10)
+        child.set(scopeAtom, 10)
+        const rootCb: number[] = []
+        const scopeCb: number[] = []
+        root.sub(rootAtom, () => rootCb.push(root.get(rootAtom)))
+        child.sub(scopeAtom, () => scopeCb.push(child.get(scopeAtom)))
+
+        const txn = new Transaction(root)
+        txn.set(rootAtom, 2)
+        txn.scope("abort-scope", scoped => scoped.set(scopeAtom, 20))
+        expect(txn.get(rootAtom)).toBe(2) // read-your-writes before abort
+        txn.abort()
+
+        // Every level's draft is discarded; nothing committed, nothing fired.
+        expect(root.get(rootAtom)).toBe(1)
+        expect(child.get(scopeAtom)).toBe(10)
+        expect(rootCb).toEqual([])
+        expect(scopeCb).toEqual([])
+        expect(() => txn.commit()).toThrow(
+            "Cannot commit transaction while it is closed",
+        )
+    })
+
     test("every callback operation rejects use after close", () => {
         const store1 = store()
         store1.scope("child")

--- a/packages/valdres/src/lib/architecturePerformance.test.ts
+++ b/packages/valdres/src/lib/architecturePerformance.test.ts
@@ -226,7 +226,7 @@ describe("deterministic architecture performance gates", () => {
         cleanup()
     })
 
-    test("deep cross-scope transactions expose repeated settlement passes", () => {
+    test("deep cross-scope transactions settle each affected store once", () => {
         const root = store()
         const level1 = root.scope("level-1")
         const level2 = level1.scope("level-2")
@@ -253,14 +253,121 @@ describe("deterministic architecture performance gates", () => {
         })
         reportCounts("Cross-scope transaction, depth 3", counts)
 
-        expect(counts.selectorEvaluations).toBe(3)
-        expect(counts.selectorSettlements).toBe(3)
-        expect(counts.duplicateSelectorSettlements).toBe(2)
+        // The tree-level CommitPlan visits each store once with the union of
+        // its own and inherited triggers, so the spanning selector evaluates
+        // once for the whole commit — not once per reaching ancestor pass.
+        expect(counts.selectorEvaluations).toBe(1)
+        expect(counts.selectorSettlements).toBe(1)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
         expect(counts.affectedStoresSettled).toBe(1)
-        expect(counts.storeSettlementPasses).toBe(3)
-        expect(counts.duplicateStoreSettlements).toBe(2)
+        expect(counts.storeSettlementPasses).toBe(1)
+        expect(counts.duplicateStoreSettlements).toBe(0)
+        expect(counts.commitPlanRuns).toBe(1)
         cleanup()
         root.dispose()
+    })
+
+    test("cross-scope update + delete + unset settles the spanning selector once", () => {
+        // The union walk covers every mutation kind in one per-store
+        // settlement: a selector depending on an updated root atom, a
+        // root-deleted family member, AND a scope-unset atom evaluates once.
+        const root = store()
+        const scope = root.scope("mixed")
+        const family = atomFamily<string>(undefined)
+        const first = family("first")
+        const second = family("second")
+        root.set(first, "a")
+        root.set(second, "b")
+        const rootValue = atom(0)
+        const scopeValue = atom(0)
+        scope.set(scopeValue, 7)
+        const spanning = selector(
+            get => `${get(family).length}:${get(rootValue)}:${get(scopeValue)}`,
+        )
+        const cleanup = scope.sub(spanning, noop)
+        expect(scope.get(spanning)).toBe("2:0:7")
+
+        const counts = measureArchitecture(root, () => {
+            root.txn(txn => {
+                txn.del(second)
+                txn.set(rootValue, 1)
+                txn.scope("mixed", scopeTxn => scopeTxn.unset(scopeValue))
+            })
+        })
+        reportCounts("Cross-scope update + delete + unset", counts)
+
+        expect(scope.get(spanning)).toBe("1:1:0")
+        expect(counts.selectorEvaluations).toBe(1)
+        expect(counts.selectorSettlements).toBe(1)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
+        expect(counts.storeSettlementPasses).toBe(1)
+        expect(counts.duplicateStoreSettlements).toBe(0)
+        expect(counts.commitPlanRuns).toBe(1)
+        cleanup()
+        root.dispose()
+    })
+
+    test("global-containing cross-scope transactions run one commit plan", () => {
+        const shared = atom(0, { global: true })
+        const origin = store()
+        const scope = origin.scope("g-scope")
+        const scoped = atom(0)
+        scope.set(scoped, 0)
+        const peer = store()
+        peer.get(shared)
+
+        const counts = measureArchitecture([origin, peer], () => {
+            origin.txn(txn => {
+                txn.set(shared, 1)
+                txn.scope("g-scope", scopeTxn => scopeTxn.set(scoped, 2))
+            })
+        })
+        reportCounts("Cross-scope transaction with global peer", counts)
+
+        expect(counts.commitPlanRuns).toBe(1)
+        expect(peer.get(shared)).toBe(1)
+        expect(scope.get(scoped)).toBe(2)
+        origin.dispose()
+        peer.dispose()
+    })
+
+    test("a global peer that is also a plan store settles once", () => {
+        // The plan root touches the global atom (making it a fan-out peer of
+        // the scope's write) AND carries its own local write. The peer update
+        // folds into the root's single tree-walk settlement — a spanning
+        // selector evaluates once, never once in a peer pass plus once in the
+        // walk.
+        const shared = atom(0, { global: true })
+        const origin = store()
+        const scope = origin.scope("gp-scope")
+        const local = atom(0)
+        origin.get(shared) // origin is now an attached peer of `shared`
+        const outside = store()
+        outside.get(shared) // a genuine non-plan peer keeps the legacy pass
+        const spanning = selector(get => get(local) + get(shared))
+        const cleanup = origin.sub(spanning, noop)
+        origin.get(spanning)
+
+        const counts = measureArchitecture([origin, outside], () => {
+            origin.txn(txn => {
+                txn.set(local, 1)
+                txn.scope("gp-scope", scopeTxn => scopeTxn.set(shared, 5))
+            })
+        })
+        reportCounts("Cross-scope txn, overlapping plan/peer store", counts)
+
+        expect(origin.get(shared)).toBe(5)
+        expect(outside.get(shared)).toBe(5)
+        expect(origin.get(spanning)).toBe(6)
+        expect(counts.selectorEvaluations).toBe(1)
+        expect(counts.selectorSettlements).toBe(1)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
+        expect(counts.storeSettlementPasses).toBe(1)
+        expect(counts.duplicateStoreSettlements).toBe(0)
+        expect(counts.commitPlanRuns).toBe(1)
+        cleanup()
+        origin.dispose()
+        outside.dispose()
     })
 
     test("global fan-out settles each affected store once", () => {

--- a/packages/valdres/src/lib/asyncCrossScopeNotification.test.ts
+++ b/packages/valdres/src/lib/asyncCrossScopeNotification.test.ts
@@ -6,12 +6,12 @@ import { store } from "../store"
 // An ASYNC (Promise-returning) selector spanning a root atom and a scope atom,
 // observed by a scope subscriber across a single cross-scope transaction.
 //
-// The cross-scope commit writes the whole tree, then runs ONE propagation pass
-// per store (root-first), deferring all subscriber notification to commit-end
-// (see propagateUpdatedAtoms.NotifyTarget / transaction.commit). The PR's
-// "fires exactly once with the final value" guarantee is for SYNCHRONOUS
-// selectors. A Promise-returning selector cannot honor that at commit time — its
-// committed value IS a pending promise — so its observable contract is:
+// The cross-scope commit writes the whole tree, then settles each affected
+// store ONCE through the tree-level CommitPlan (settleTransactionTreeCommit),
+// deferring all subscriber notification to commit-end. The "fires exactly once
+// with the final value" guarantee is for SYNCHRONOUS selectors. A
+// Promise-returning selector cannot honor that at commit time — its committed
+// value IS a pending promise — so its observable contract is:
 //
 //   1 commit-end fire (delivering the pending promise) + 1 resolution fire
 //   (delivering the resolved final value, from handleSelectorResult's .then,
@@ -85,18 +85,16 @@ describe("async selector spanning root + scope under a cross-scope txn", () => {
         })
 
         // CRUCIAL: the commit-end notification fires EXACTLY ONCE, even though
-        // the async selector is reachable by two store-passes (root's
-        // propagateToScopes + the scope's own pass). The deferred NotifyTarget
-        // accumulates the subscriber into one per-store set and fires it once.
+        // the async selector's triggers span two stores. The tree-level commit
+        // visits the scope once and the deferred NotifyTarget fires the
+        // subscriber once.
         expect(cb.mock.calls.length - callsBeforeCommit).toBe(1)
 
-        // The selector BODY ran once per reaching pass (no cross-pass dedup for
-        // promise selectors — the reference-equality check never prunes a fresh
-        // promise), so two new promises were created during the commit. This is
-        // the documented cost of dropping the dedup guard, not a notification
-        // duplication.
-        expect(evals - evalsBeforeCommit).toBe(2)
-        expect(resolvers.length - resolversBeforeCommit).toBe(2)
+        // The selector BODY also ran exactly once — the scope's single visit
+        // collects both the inherited root trigger and the scope's own trigger
+        // before evaluating — so ONE new promise was created by the commit.
+        expect(evals - evalsBeforeCommit).toBe(1)
+        expect(resolvers.length - resolversBeforeCommit).toBe(1)
 
         // What the single commit-end fire delivered: a PENDING PROMISE (the
         // committed value of an async selector mid-flight). NOT a stale numeric
@@ -105,9 +103,6 @@ describe("async selector spanning root + scope under a cross-scope txn", () => {
         expect(S.get(sum)).toBeInstanceOf(Promise)
 
         // --- the eventual promise RESOLUTION (separate, later microtask) ---
-        // Resolve every promise created during the commit. Only the last-stored
-        // one is the live value; handleSelectorResult's stale-promise guard
-        // drops the others, so resolution notifies exactly once regardless.
         for (let i = resolversBeforeCommit; i < resolvers.length; i++) {
             resolvers[i]()
         }
@@ -120,12 +115,14 @@ describe("async selector spanning root + scope under a cross-scope txn", () => {
         expect(S.get(sum)).toBe(22)
     })
 
-    test("resolution notifies exactly once and with the final value, whichever commit-promise resolves first", async () => {
-        // The selector body runs twice during the commit, producing two promises
-        // with identical inputs (r=2, s=20). Only the last-stored promise is the
-        // live value. This pins that resolving them in REVERSE order still yields
-        // exactly one resolution fire delivering 22 — the stale-promise guard
-        // discards the non-live promise's resolution.
+    test("resolution notifies once with the final value, whichever in-flight promise resolves first", async () => {
+        // Each cross-scope commit creates ONE promise (the scope settles once),
+        // so two back-to-back commits leave two in-flight promises with
+        // different inputs. Only the last-stored promise is the live value.
+        // This pins that resolving them in REVERSE order — the live one first,
+        // then the superseded one — still yields exactly one resolution fire
+        // delivering the final value: the stale-promise guard discards the
+        // superseded promise's resolution.
         const root = store()
         const S = root.scope("S")
         const r = atom(1, { name: "acs2-r" })
@@ -160,22 +157,27 @@ describe("async selector spanning root + scope under a cross-scope txn", () => {
             t.set(r, 2)
             t.scope("S", st => st.set(s, 20))
         })
+        root.txn(t => {
+            t.set(r, 3)
+            t.scope("S", st => st.set(s, 30))
+        })
+        // One promise per commit (each commit settles the scope once), and one
+        // commit-end fire per commit, each delivering the then-pending promise.
         expect(resolvers.length - resolversBeforeCommit).toBe(2)
-        // one commit-end fire, delivering the pending promise
-        expect(cb.mock.calls.length - callsBeforeCommit).toBe(1)
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(2)
         expect(observed[observed.length - 1]).toBe("PROMISE")
 
-        // Resolve REVERSE: last-created first, then the earlier (non-live) one.
+        // Resolve REVERSE: last-created (live) first, then the superseded one.
         resolvers[resolvers.length - 1]()
         await flush()
         resolvers[resolversBeforeCommit]()
         await flush()
 
-        // Exactly one resolution fire total (the second commit-promise's
-        // resolution is dropped as stale), and the final value is 22.
-        expect(cb.mock.calls.length - callsBeforeCommit).toBe(2)
-        expect(observed).toEqual([11, "PROMISE", 22])
-        expect(S.get(sum)).toBe(22)
+        // Exactly one resolution fire total (the superseded promise's
+        // resolution is dropped as stale), and the final value is 33.
+        expect(cb.mock.calls.length - callsBeforeCommit).toBe(3)
+        expect(observed).toEqual([11, "PROMISE", "PROMISE", 33])
+        expect(S.get(sum)).toBe(33)
     })
 
     test("deterministic via awaiting the committed promise (no controlled resolvers)", async () => {

--- a/packages/valdres/src/lib/commitEngine.ts
+++ b/packages/valdres/src/lib/commitEngine.ts
@@ -38,12 +38,14 @@ import { runOnSets } from "./runOnSets"
  * (see test/import-cycles) — the sequencer must not be hard-wired to the
  * propagation layer it sequences.
  *
- * Global and cross-scope transaction fan-out remain behind their existing
- * adapters. Async atom,
- * native async selector, and revalidation settlement enter this coordinator;
- * simple no-hook shapes use module-static entries from `createScalarCommit`
- * below; their bound operation owns any required apply, propagation,
- * observers, reporting, and local boundary.
+ * Cross-scope transaction commits enter the engine through the
+ * `transactionTree` settlement (their global peer updates ride the settlement,
+ * so the whole multi-store unit is one plan). Ordinary direct global writes
+ * and single-store global cleanup remain behind their existing adapters.
+ * Async atom, native async selector, and revalidation settlement enter this
+ * coordinator; simple no-hook shapes use module-static entries from
+ * `createScalarCommit` below; their bound operation owns any required apply,
+ * propagation, observers, reporting, and local boundary.
  */
 
 /**
@@ -80,12 +82,36 @@ export const runHookedDirectWrite = <Value>(
 
 // Module-level phase gates: runCommitPlan is on the per-commit hot path of
 // every migrated write shape, so its guards must not allocate per run.
+const treeHasWork = (
+    entries: Extract<
+        CommitPlan["settlement"],
+        { kind: "transactionTree" }
+    >["entries"],
+) => {
+    for (const entry of entries) {
+        if (
+            entry.updatedAtoms.length > 0 ||
+            entry.deleted !== undefined ||
+            (entry.unsetAtoms !== undefined && entry.unsetAtoms.length > 0)
+        ) {
+            return true
+        }
+    }
+    return false
+}
+
 const settlementHasWork = (settlement: CommitPlan["settlement"]) =>
     settlement.kind === "none" ||
     settlement.kind === "selector" ||
-    settlement.atoms.length > 0 ||
-    (settlement.kind === "transaction" &&
-        (settlement.deleted !== undefined || settlement.unset !== undefined))
+    (settlement.kind === "transactionTree"
+        ? // Changed global peers are settlement work even when every write in
+          // the local tree was value-equal.
+          settlement.globalUpdates !== undefined ||
+          treeHasWork(settlement.entries)
+        : settlement.atoms.length > 0 ||
+          (settlement.kind === "transaction" &&
+              (settlement.deleted !== undefined ||
+                  settlement.unset !== undefined)))
 
 const planShouldContinue = (plan: CommitPlan) =>
     plan.continueAfterError !== false || !plan.errors.hasError
@@ -162,6 +188,13 @@ export const runCommitPlan = (plan: CommitPlan) => {
                         settlement.deleted,
                         settlement.unset,
                         plan.data,
+                        plan.report,
+                        plan.errors,
+                    )
+                } else if (settlement.kind === "transactionTree") {
+                    settlement.settle(
+                        settlement.entries,
+                        settlement.globalUpdates,
                         plan.report,
                         plan.errors,
                     )

--- a/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
+++ b/packages/valdres/src/lib/crossScopeStaleSelector.test.ts
@@ -13,21 +13,25 @@ const mulberry32 = (seed: number) => () => {
 
 // Regression for the "stale position / stale connector line" bug.
 //
-// A cross-scope commit (and the single-store update+delete commit) runs one
-// propagation pass per store. The original cross-scope work (beta.5 #168) added
-// a per-commit dedup guard so a selector reachable by more than one pass
-// evaluated once — but it (a) keyed by selector object, skipping a scope's copy
-// of a selector also live in the root, and (b) locked in a value an early pass
-// computed from an intermediate selector a later pass corrected. Either way the
-// selector (and its whole subtree) was left stale — e.g. drag a node and drop
-// it back outside any dropzone (a pure revert) and the subtree settles one row
-// too low because a layout selector kept a value derived from a now-stale input.
+// The original cross-scope work (beta.5 #168) ran one propagation pass per
+// store and added a per-commit dedup guard so a selector reachable by more
+// than one pass evaluated once — but it (a) keyed by selector object, skipping
+// a scope's copy of a selector also live in the root, and (b) locked in a
+// value an early pass computed from an intermediate selector a later pass
+// corrected. Either way the selector (and its whole subtree) was left stale —
+// e.g. drag a node and drop it back outside any dropzone (a pure revert) and
+// the subtree settles one row too low because a layout selector kept a value
+// derived from a now-stale input.
 //
-// The fix removed the cross-pass dedup guard entirely: every value is written
-// first, then each store re-derives its OWN selectors against that final state
-// (a selector reachable by two passes is recomputed in each — the equality
-// check prunes the redundant result), and subscribers are notified once at the
-// end. So each store's copy of a selector ends on its correct final value.
+// The fix removed the cross-pass dedup guard entirely; the cross-scope commit
+// now goes further and settles each store exactly ONCE through the tree-level
+// CommitPlan: every value across the tree is written first, then each store
+// collects the COMPLETE union of its own and inherited triggers before one
+// topologically-ordered evaluation, and subscribers are notified once at the
+// end. Each store's copy of a selector is evaluated once, on its correct final
+// value — a restructure, not a skip guard, so neither #168 failure mode can
+// recur. (The single-store update+delete commit keeps its per-kind passes; see
+// the NotifyTarget warning in propagateUpdatedAtoms.)
 
 describe("cross-scope stale intermediate selector", () => {
     test("scope selector spanning a root atom + an intermediate scope selector stays fresh", () => {
@@ -213,23 +217,35 @@ describe("cross-scope stale intermediate selector", () => {
 
             for (let step = 0; step < 12; step++) {
                 const rc: [number, number][] = []
-                const sc: [number, number][] = []
+                // Scope ops mix sets with shadow-removing unsets ("unset" of a
+                // non-shadowed atom is a legal no-op); applied in list order in
+                // both the txn and the model, so intra-txn set/unset sequences
+                // match the draft's last-op-wins semantics.
+                const sc: [number, number | "unset"][] = []
                 const m = 1 + Math.floor(rnd() * 3)
                 for (let j = 0; j < m; j++) {
                     const ai = Math.floor(rnd() * nAtoms)
-                    const v = Math.floor(rnd() * 30)
-                    if (rnd() < 0.5) rc.push([ai, v])
-                    else sc.push([ai, v])
+                    if (rnd() < 0.5) {
+                        rc.push([ai, Math.floor(rnd() * 30)])
+                    } else if (rnd() < 0.2) {
+                        sc.push([ai, "unset"])
+                    } else {
+                        sc.push([ai, Math.floor(rnd() * 30)])
+                    }
                 }
                 root.txn(t => {
                     for (const [ai, v] of rc) t.set(I.atoms[ai], v)
                     if (sc.length)
                         t.scope("S", st => {
-                            for (const [ai, v] of sc) st.set(I.atoms[ai], v)
+                            for (const [ai, v] of sc) {
+                                if (v === "unset") st.unset(I.atoms[ai])
+                                else st.set(I.atoms[ai], v)
+                            }
                         })
                 })
                 for (const [ai, v] of rc) rootVal[ai] = v
-                for (const [ai, v] of sc) scopeVal[ai] = v
+                for (const [ai, v] of sc)
+                    scopeVal[ai] = v === "unset" ? undefined : v
             }
 
             // independent oracle

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -45,6 +45,17 @@ import {
     effectiveValueAfterUnset,
     reDelegateScopeSubscriptions,
 } from "./unsetValue"
+// Intra-cycle edge (same recorded core SCC): the tree settlement brackets its
+// walk with the global peer sequencing the cross-scope transaction commit
+// previously hand-rolled inline.
+import {
+    beginGlobalCommit,
+    endGlobalCommit,
+} from "./globalAtomFanOut"
+import type {
+    TransactionTreeEntry,
+    TransactionTreeSettleFn,
+} from "../types/TransactionTreeSettleFn"
 import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import { hasInheritedDependencyBranches } from "./inheritedDependencyBranches"
 import { setValueInData } from "./setValueInData"
@@ -98,17 +109,23 @@ type AtomInput = Atom<any> | AtomFamilyAtom<any, any> | AtomFamily<any, any>
 //      was also live in the root (different value per store) — left stale.
 //   2. It locked in a value an early pass computed from an intermediate selector
 //      that a LATER pass corrected — also left stale.
-// The model here is deliberately dumb and robust instead: write every value
-// first, then each store re-derives its OWN selectors against that final state
-// (a selector reachable by two passes is simply recomputed in each — the
-// equality check discards the redundant result), then notify once. A selector's
-// value is a pure function of the committed atom state, and running passes
-// root-first means read-through ancestor values are already final, so the last
-// pass to touch a selector always lands on the correct value — no outer fixpoint
-// loop needed. If cross-scope-commit CPU ever matters, add dedup ONLY as a pure
-// optimization *behind* this guarantee: keyed per (store, selector), skipping
-// only a re-eval that is provably value-identical — never as a correctness
-// shortcut that suppresses a needed recompute.
+// Two models coexist behind the shared write-all-then-settle guarantee:
+//   - MULTI-PASS (single-store cleanup commits, global fan-out, immediate
+//     scoped updates): deliberately dumb and robust — each pass re-derives a
+//     store's selectors against final state; a selector reachable by two
+//     passes is simply recomputed in each (the equality check discards the
+//     redundant result), and passes run root-first so the last pass to touch a
+//     selector always lands on the correct value. Any future dedup here must
+//     be keyed per (store, selector) and provably value-identical — never a
+//     correctness shortcut that suppresses a needed recompute.
+//   - VISIT-ONCE (settleTransactionTreeCommit, the cross-scope transaction
+//     commit): each store is visited exactly once with the COMPLETE union of
+//     its own and inherited triggers collected before evaluation, so the
+//     topological order puts intermediate selectors before spanning ones and
+//     one evaluation lands on the final value. That is a restructure, not a
+//     skip guard — nothing reachable is ever skipped, so neither #168 failure
+//     mode applies.
+// In both models notification is deferred and fires once per subscriber.
 type NotifyStoreEntry = {
     subscriptions: Set<Subscription>
     families: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
@@ -127,12 +144,122 @@ const notifyEntryFor = (
     return entry
 }
 
+// One reaching pass's triggers at one store during the cross-scope settlement
+// walk. `report` is the sink the group's changes historically targeted (the
+// global sink for peer-originated groups and their cascades; undefined = the
+// transaction's own sink). `set` is the lazily-built equality view.
+type TreeTriggerGroup = {
+    kind:
+        | typeof TREE_GROUP_INHERITED
+        | typeof TREE_GROUP_GLOBAL
+        | typeof TREE_GROUP_UPDATED
+        | typeof TREE_GROUP_DELETED
+        | typeof TREE_GROUP_UNSET
+    atoms: AtomInput[]
+    set: Set<any> | undefined
+    report: ChangeReport | undefined
+}
+const TREE_GROUP_INHERITED = 0
+const TREE_GROUP_GLOBAL = 1
+const TREE_GROUP_UPDATED = 2
+const TREE_GROUP_DELETED = 3
+const TREE_GROUP_UNSET = 4
+
+// Per-store settlement context for the cross-scope walk: the reaching-pass
+// groups in historical order and, per selector, WHICH groups reached it (its
+// trigger provenance — ascending group indices, first-reached first). Both the
+// public equal contract and report/subscriber causal ordering key off it.
+type TreeSettleContext = {
+    groups: TreeTriggerGroup[]
+    provenance: Map<Selector, number[]>
+    /** The static pre-settlement trigger union; atoms the evaluation lazily
+     *  initializes are exactly those in the live set but not here. */
+    baseUnion: Set<any>
+}
+
+const appendTreeProvenance = (
+    provenance: Map<Selector, number[]>,
+    selector: Selector,
+    groupIndex: number,
+) => {
+    const existing = provenance.get(selector)
+    if (!existing) provenance.set(selector, [groupIndex])
+    else if (!existing.includes(groupIndex)) {
+        // Collection runs groups in ascending order and downstream merges
+        // insert-sort, so `existing` stays ascending: first = first-reached.
+        let at = existing.length
+        while (at > 0 && existing[at - 1]! > groupIndex) at--
+        existing.splice(at, 0, groupIndex)
+    }
+}
+
+// Downstream provenance flow: a changed selector hands its reaching groups to
+// every dependent it dirties, mirroring how each historical pass reached the
+// dependent transitively.
+const mergeTreeProvenance = (
+    ctx: TreeSettleContext,
+    target: Selector,
+    source: Selector,
+) => {
+    const from = ctx.provenance.get(source)
+    if (!from) return
+    for (const groupIndex of from) {
+        appendTreeProvenance(ctx.provenance, target, groupIndex)
+    }
+}
+
+// Group-sequential equality for the cross-scope settlement walk. The selector
+// body ran ONCE (against final state), but its public `equal` contract still
+// sees the same per-reaching-pass trigger sets the historical multi-pass
+// commit delivered — consulted in reaching order for exactly the groups whose
+// dirty chain reached THIS selector, committing on the first group that
+// reports a change. Only when every reaching group reports equality is the
+// update suppressed, matching the historical chain where one pass's
+// suppression left the next pass's trigger set to decide. Atoms lazily
+// initialized during the settlement (present in the live evaluation set but
+// not in the static union) join the final consulted set, mirroring how they
+// joined the historical pass's mutating set. (Residue for impure predicates: a
+// group after the first "changed" is no longer consulted.)
+const treeEqualAcrossGroups = (
+    ctx: TreeSettleContext,
+    selector: Selector,
+    existingValue: unknown,
+    updatedValue: unknown,
+    liveAtoms: Set<Atom>,
+): boolean => {
+    const provenance = ctx.provenance.get(selector)
+    if (!provenance || provenance.length === 0) {
+        // Defensive: a selector with no recorded provenance (unreachable in
+        // practice) sees the full live set — the conservative superset.
+        return selector.equal(existingValue, updatedValue, liveAtoms)
+    }
+    const last = provenance.length - 1
+    for (let i = 0; i <= last; i++) {
+        const group = ctx.groups[provenance[i]!]!
+        let set = group.set
+        if (set === undefined) {
+            set = new Set(group.atoms)
+            group.set = set
+        }
+        if (i === last && liveAtoms.size > ctx.baseUnion.size) {
+            const augmented = new Set(set)
+            for (const atom of liveAtoms) {
+                if (!ctx.baseUnion.has(atom)) augmented.add(atom)
+            }
+            set = augmented
+        }
+        if (!selector.equal(existingValue, updatedValue, set)) return false
+    }
+    return true
+}
+
 const reEvaluateSelector = (
     selector: Selector,
     data: StoreData,
     updatedAtoms: Set<Atom>,
     depsChange: DepsChange,
     existingValue: unknown,
+    treeCtx?: TreeSettleContext,
 ): boolean => {
     if (!IS_PROD && data.architectureInstrumentation)
         recordSelectorSettlement(selector, data)
@@ -161,7 +288,15 @@ const reEvaluateSelector = (
         const areEqual =
             isPromiseLike(existingValue) || isPromiseLike(updatedValue)
                 ? existingValue === updatedValue
-                : selector.equal(existingValue, updatedValue, updatedAtoms)
+                : treeCtx === undefined
+                  ? selector.equal(existingValue, updatedValue, updatedAtoms)
+                  : treeEqualAcrossGroups(
+                        treeCtx,
+                        selector,
+                        existingValue,
+                        updatedValue,
+                        updatedAtoms,
+                    )
         if (areEqual) return false
         setValueInData(selector, updatedValue, data)
         return true
@@ -915,6 +1050,677 @@ export const settleTransactionCommit = (
     }
 }
 
+/**
+ * Settlement (phases 4–7) of a cross-scope transaction commit: ONE root-first
+ * walk over the affected store tree. Each store is visited exactly once and
+ * settled against the union of its own updated/deleted/unset writes and every
+ * inherited change that reaches it, so a selector evaluates at most once per
+ * (store, commit) — the proven-safe replacement for the historical
+ * one-propagation-pass-per-store model (see the NotifyTarget warning above:
+ * this is a visit-once restructure behind the write-all-then-settle guarantee,
+ * not a skip guard; nothing is deduplicated away, work is simply not repeated).
+ *
+ * Global peers (already written in the write phase) bracket the walk with the
+ * exact sequencing the transaction commit previously hand-rolled inline: peer
+ * propagation first (their fan-out retains its public direct-set metadata and
+ * precedes the originating transaction's reports), one deferred notify for
+ * peers + tree together, global sink flush, then the peer trees' commit-end
+ * boundaries. Unset re-delegation runs strictly last — the deferred
+ * scope-local callback idempotently drops its delegate, so the fresh parent
+ * delegate must be (re)established after firing.
+ *
+ * Error contract: each store's settlement and reporting record into `errors`
+ * and the walk continues — one store failing must not starve later stores,
+ * descendants, or subscriber delivery. Descent is constructed in the
+ * collection phase (no user code) so a throwing selector body, custom equal,
+ * onMount cleanup, or unset report can never hide an affected descendant.
+ *
+ * Boundary note: the caller's outer commit boundary governs; the walk opens no
+ * per-store boundaries (the historical inner per-pass boundaries were nested
+ * depth-counter no-ops). An onCommitEnd listener registered mid-commit by a
+ * hook therefore joins from the next commit, as on the single-store plan path.
+ */
+export const settleTransactionTreeCommit: TransactionTreeSettleFn = (
+    entries,
+    globalUpdates,
+    report,
+    errors,
+) => {
+    const notify: NotifyTarget = new Map()
+    const globalSink = globalUpdates
+        ? createChangeSink(undefined, "set")
+        : undefined
+    const commitRoots = globalUpdates
+        ? beginGlobalCommit(entries[0].data, globalUpdates)
+        : undefined
+    // Peers that are themselves plan stores fold into the walk (their global
+    // group settles together with the store's own and inherited triggers —
+    // one settlement per store, the plan's core guarantee). Only peers
+    // OUTSIDE the plan keep the per-tree propagation pass.
+    let foldedPeerAtoms: Map<StoreData, Atom[]> | undefined
+    if (globalUpdates) {
+        let planStores: Set<StoreData> | undefined
+        for (const [peer, atoms] of globalUpdates) {
+            if (!planStores) {
+                planStores = new Set()
+                for (const entry of entries) planStores.add(entry.data)
+            }
+            if (planStores.has(peer)) {
+                if (!foldedPeerAtoms) foldedPeerAtoms = new Map()
+                foldedPeerAtoms.set(peer, atoms)
+                continue
+            }
+            try {
+                propagateAtomUpdate(atoms, peer, false, notify, globalSink)
+            } catch (error) {
+                recordCommitError(errors, error)
+            }
+        }
+    }
+    const timestamp = performance.now()
+    settleTreeStore(
+        entries[0],
+        entries[0].data,
+        undefined,
+        foldedPeerAtoms,
+        globalSink,
+        notify,
+        report,
+        errors,
+        timestamp,
+    )
+    try {
+        notifyDeferred(notify)
+    } catch (error) {
+        recordCommitError(errors, error)
+    }
+    if (globalSink) {
+        try {
+            flushChangeSink(globalSink)
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+        endGlobalCommit(commitRoots!, errors)
+    }
+    // Re-delegate AFTER firing: the deferred scope-local callback idempotently
+    // drops its delegate, so the fresh parent delegate is established last.
+    for (const entry of entries) {
+        if (entry.unsetAtoms) {
+            for (const atom of entry.unsetAtoms) {
+                try {
+                    reDelegateScopeSubscriptions(atom, entry.data)
+                } catch (error) {
+                    recordCommitError(errors, error)
+                }
+            }
+        }
+    }
+}
+
+/** Per-store visit of the cross-scope settlement walk. Three phases:
+ *   A) collection + index bookkeeping + descent construction — no user code,
+ *      so the descent set exists even when a later phase throws;
+ *   B) one dirty-selector settlement against the union of every trigger, with
+ *      per-selector reaching-group provenance threaded through the dependency
+ *      graph for the public `equal` contract (see treeEqualAcrossGroups);
+ *   C) causal assembly: deferred subscribers are inserted and reports emitted
+ *      in reaching-group order — a selector first reached by an inherited (or
+ *      global-peer) trigger keeps its historical position BEFORE the store's
+ *      own-atom entries, and peer-originated groups keep reporting into the
+ *      global sink.
+ * Then recurse into children (plan entries ∪ branch-index scopes), root-first,
+ * each child receiving the group-structured subset of triggers that reach it. */
+const settleTreeStore = (
+    entry: TransactionTreeEntry | undefined,
+    data: StoreData,
+    inheritedGroups: TreeTriggerGroup[] | undefined,
+    foldedPeerAtoms: Map<StoreData, Atom[]> | undefined,
+    globalSink: ChangeSink | undefined,
+    notify: NotifyTarget,
+    report: ChangeReport | undefined,
+    errors: CommitErrors,
+    timestamp: number,
+) => {
+    // ---- Phase A: collection + bookkeeping (no user code) ----
+    const groups: TreeTriggerGroup[] = []
+    const provenance = new Map<Selector, number[]>()
+    const selectors = new Set<Selector>()
+    const triggerUnion = new Set<any>()
+    // Direct atom/family subscribers per group index (own-write and folded
+    // global groups only — inherited triggers reach only dependents; their
+    // direct subscriptions are delegated to the owning ancestor store).
+    const directSubs: (Set<Subscription> | undefined)[] = []
+
+    const peerAtoms = foldedPeerAtoms?.get(data)
+
+    const pushGroup = (group: TreeTriggerGroup): number => {
+        const index = groups.length
+        groups.push(group)
+        directSubs.push(undefined)
+        membershipChangedByGroup.push(undefined)
+        return index
+    }
+
+    const collectInheritedGroup = (group: TreeTriggerGroup) => {
+        const index = pushGroup(group)
+        for (const atom of group.atoms) {
+            const dependents = data.stateDependents.get(atom)
+            if (dependents && dependents.size > 0) {
+                for (const dependent of dependents) {
+                    if (!IS_PROD && data.architectureInstrumentation)
+                        recordDependencyEdgeVisit(data)
+                    selectors.add(dependent as Selector)
+                    appendTreeProvenance(
+                        provenance,
+                        dependent as Selector,
+                        index,
+                    )
+                }
+            }
+            triggerUnion.add(atom)
+        }
+    }
+
+    let updatedFamilyAtoms:
+        | Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+        | undefined
+    let deletedFamilyAtoms:
+        | Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+        | undefined
+    let unsetFamilyAtoms:
+        | Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+        | undefined
+    let peerFamilyAtoms:
+        | Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+        | undefined
+    // Families whose MEMBERSHIP changed, per group — each group's descent
+    // carries its own membership changes (and its own report sink).
+    const membershipChangedByGroup: (Set<AtomFamily<any>> | undefined)[] = []
+
+    // Own-write and folded-peer groups collect identically (deps + direct subs
+    // + family grouping) — exactly what the historical per-pass
+    // propagateAtomUpdate did; only reporting differs (phase C).
+    const collectOwnStyleGroup = (
+        group: TreeTriggerGroup,
+    ): {
+        index: number
+        familyAtoms: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>> | undefined
+    } => {
+        const index = pushGroup(group)
+        const subs = new Set<Subscription>()
+        directSubs[index] = subs
+        let familyAtoms:
+            | Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>
+            | undefined
+        for (const atom of group.atoms) {
+            const dependents = data.stateDependents.get(atom)
+            if (dependents && dependents.size > 0) {
+                for (const dependent of dependents) {
+                    if (!IS_PROD && data.architectureInstrumentation)
+                        recordDependencyEdgeVisit(data)
+                    selectors.add(dependent as Selector)
+                    appendTreeProvenance(
+                        provenance,
+                        dependent as Selector,
+                        index,
+                    )
+                }
+            }
+            addSetToSet(data.subscriptions.get(atom), subs)
+            triggerUnion.add(atom)
+            if (isFamilyAtom(atom)) {
+                if (!familyAtoms) familyAtoms = new Map()
+                let set = familyAtoms.get(atom.family)
+                if (!set) {
+                    set = new Set()
+                    familyAtoms.set(atom.family, set)
+                }
+                set.add(atom)
+            }
+        }
+        return { index, familyAtoms }
+    }
+    // Family ADD bookkeeping (mirrors propagateAtomUpdate): family
+    // subscriptions are member-change subscriptions and always collect; family
+    // DEPENDENTS run only when membership actually changed.
+    const applyFamilyAdds = (
+        familyAtoms: Map<AtomFamily<any>, Set<AtomFamilyAtom<any>>>,
+        groupIndex: number,
+    ) => {
+        const subs = directSubs[groupIndex]!
+        for (const [family, atoms] of familyAtoms) {
+            addSetToSet(data.subscriptions.get(family), subs)
+            if (addFamilyAtomsToSet(family, atoms, data, timestamp)) {
+                const dependents = data.stateDependents.get(family)
+                if (dependents && dependents.size > 0) {
+                    for (const dependent of dependents) {
+                        if (!IS_PROD && data.architectureInstrumentation)
+                            recordDependencyEdgeVisit(data)
+                        selectors.add(dependent as Selector)
+                        appendTreeProvenance(
+                            provenance,
+                            dependent as Selector,
+                            groupIndex,
+                        )
+                    }
+                }
+                let changed = membershipChangedByGroup[groupIndex]
+                if (!changed) {
+                    changed = new Set()
+                    membershipChangedByGroup[groupIndex] = changed
+                }
+                changed.add(family)
+            }
+        }
+    }
+
+    // The folded global-peer group comes FIRST: the historical global loop
+    // propagated every peer before any per-store transaction pass.
+    let peerGroupIndex = -1
+    if (peerAtoms) {
+        const collected = collectOwnStyleGroup({
+            kind: TREE_GROUP_GLOBAL,
+            atoms: peerAtoms,
+            set: undefined,
+            report: globalSink,
+        })
+        peerGroupIndex = collected.index
+        peerFamilyAtoms = collected.familyAtoms
+        if (peerFamilyAtoms) applyFamilyAdds(peerFamilyAtoms, peerGroupIndex)
+    }
+
+    if (inheritedGroups) {
+        for (const group of inheritedGroups) collectInheritedGroup(group)
+    }
+
+    const ownUpdated =
+        entry !== undefined && entry.updatedAtoms.length > 0
+            ? entry.updatedAtoms
+            : undefined
+    const ownDeleted = entry?.deleted
+    const ownUnset =
+        entry?.unsetAtoms !== undefined && entry.unsetAtoms.length > 0
+            ? entry.unsetAtoms
+            : undefined
+
+    let updatedGroupIndex = -1
+    if (ownUpdated) {
+        const collected = collectOwnStyleGroup({
+            kind: TREE_GROUP_UPDATED,
+            atoms: ownUpdated,
+            set: undefined,
+            report: undefined,
+        })
+        updatedGroupIndex = collected.index
+        updatedFamilyAtoms = collected.familyAtoms
+        if (updatedFamilyAtoms)
+            applyFamilyAdds(updatedFamilyAtoms, updatedGroupIndex)
+        // Committed family indexes may be freshly cloned transaction indexes:
+        // re-link shadowing child scopes before any evaluation (theirs happens
+        // later in the walk, but the delete bookkeeping below also reads them).
+        if (data.scopes.size > 0) {
+            for (const atom of ownUpdated) {
+                if (isAtomFamily(atom)) {
+                    recursivelyUpdateIndexes(data, atom)
+                }
+            }
+        }
+    }
+
+    let deletedGroupIndex = -1
+    if (ownDeleted) {
+        // Mirrors propagateDeletedAtoms: member deps + subs, then per-family
+        // deps + subs + index removal. A deleted member changes both its own
+        // value and family membership.
+        deletedGroupIndex = pushGroup({
+            kind: TREE_GROUP_DELETED,
+            atoms: ownDeleted,
+            set: undefined,
+            report: undefined,
+        })
+        const subs = new Set<Subscription>()
+        directSubs[deletedGroupIndex] = subs
+        for (const atom of ownDeleted) {
+            const dependents = data.stateDependents.get(atom)
+            if (dependents && dependents.size > 0) {
+                for (const dependent of dependents) {
+                    if (!IS_PROD && data.architectureInstrumentation)
+                        recordDependencyEdgeVisit(data)
+                    selectors.add(dependent as Selector)
+                    appendTreeProvenance(
+                        provenance,
+                        dependent as Selector,
+                        deletedGroupIndex,
+                    )
+                }
+            }
+            addSetToSet(data.subscriptions.get(atom), subs)
+            triggerUnion.add(atom)
+            if (isFamilyAtom(atom)) {
+                if (!deletedFamilyAtoms) deletedFamilyAtoms = new Map()
+                let set = deletedFamilyAtoms.get(atom.family)
+                if (!set) {
+                    set = new Set()
+                    deletedFamilyAtoms.set(atom.family, set)
+                }
+                set.add(atom)
+            }
+        }
+        if (deletedFamilyAtoms) {
+            for (const [family, familyAtoms] of deletedFamilyAtoms) {
+                const dependents = data.stateDependents.get(family)
+                if (dependents && dependents.size > 0) {
+                    for (const dependent of dependents) {
+                        if (!IS_PROD && data.architectureInstrumentation)
+                            recordDependencyEdgeVisit(data)
+                        selectors.add(dependent as Selector)
+                        appendTreeProvenance(
+                            provenance,
+                            dependent as Selector,
+                            deletedGroupIndex,
+                        )
+                    }
+                }
+                addSetToSet(data.subscriptions.get(family), subs)
+                deleteFamilyAtomsFromSet(family, familyAtoms, data, timestamp)
+            }
+        }
+    }
+
+    let unsetGroupIndex = -1
+    if (ownUnset) {
+        const collected = collectOwnStyleGroup({
+            kind: TREE_GROUP_UNSET,
+            atoms: ownUnset,
+            set: undefined,
+            report: undefined,
+        })
+        unsetGroupIndex = collected.index
+        unsetFamilyAtoms = collected.familyAtoms
+        if (unsetFamilyAtoms) applyFamilyAdds(unsetFamilyAtoms, unsetGroupIndex)
+    }
+
+    // Descent: plan children always; branch-index scopes for any trigger with
+    // registered inherited-dependency branches. Per-child group structure
+    // preserves reaching-pass granularity and each group's report sink.
+    let childGroups: Map<StoreData, TreeTriggerGroup[]> | undefined
+    const spreadGroup = (
+        atoms: AtomInput[],
+        groupReport: ChangeReport | undefined,
+    ) => {
+        let perChild: Map<StoreData, AtomInput[]> | undefined
+        for (const atom of atoms) {
+            const branches = data.inheritedDependencyBranches.get(atom)
+            if (!branches) continue
+            for (const scope of branches) {
+                if (!perChild) perChild = new Map()
+                const scopeAtoms = perChild.get(scope)
+                if (scopeAtoms) scopeAtoms.push(atom)
+                else perChild.set(scope, [atom])
+            }
+        }
+        if (perChild) {
+            if (!childGroups) childGroups = new Map()
+            for (const [scope, scopeAtoms] of perChild) {
+                const group: TreeTriggerGroup = {
+                    kind: TREE_GROUP_INHERITED,
+                    atoms: scopeAtoms,
+                    set: undefined,
+                    report: groupReport,
+                }
+                const list = childGroups.get(scope)
+                if (list) list.push(group)
+                else childGroups.set(scope, [group])
+            }
+        }
+    }
+    // A family OBJECT is scope-relevant only when its membership changed — a
+    // value-only member update reaches scope selectors via the member atom
+    // (the "family update, 100 scopes" hot path). Each group descends with its
+    // own membership changes and its own report sink.
+    const spreadValueGroup = (
+        atoms: AtomInput[],
+        groupIndex: number,
+        groupReport: ChangeReport | undefined,
+    ) => {
+        const changedFamilies = membershipChangedByGroup[groupIndex]
+        if (changedFamilies) {
+            const descent: AtomInput[] = atoms.slice()
+            for (const family of changedFamilies) {
+                if (!descent.includes(family)) descent.push(family)
+            }
+            spreadGroup(descent, groupReport)
+        } else {
+            spreadGroup(atoms, groupReport)
+        }
+    }
+    if (peerGroupIndex !== -1) {
+        // Peer cascades historically reported into the global sink.
+        spreadValueGroup(peerAtoms!, peerGroupIndex, globalSink)
+    }
+    if (inheritedGroups) {
+        for (const group of inheritedGroups) {
+            spreadGroup(group.atoms, group.report)
+        }
+    }
+    if (ownUpdated) {
+        spreadValueGroup(ownUpdated, updatedGroupIndex, undefined)
+    }
+    if (ownDeleted) {
+        // Members skip scopes that shadow them (branch index is pruned at atom
+        // shadows); families always propagate — a scope selector may observe
+        // only get(family), not the member.
+        const deleteDescent: AtomInput[] = ownDeleted.slice()
+        if (deletedFamilyAtoms) {
+            for (const family of deletedFamilyAtoms.keys()) {
+                if (!deleteDescent.includes(family)) deleteDescent.push(family)
+            }
+        }
+        spreadGroup(deleteDescent, undefined)
+    }
+    if (ownUnset) spreadValueGroup(ownUnset, unsetGroupIndex, undefined)
+
+    // ---- Phase B: one settlement against the union (selector bodies, custom
+    // equal, and liveness onMount/cleanup — user code, recorded + contained).
+    // Changed selectors are always tracked (evaluation order) — they drive the
+    // causal subscriber/report assembly below, not just onChange payloads. ----
+    const changedSelectors = new Set<Selector>()
+    const machineSubs = new Set<Subscription>()
+    if (selectors.size > 0) {
+        const treeCtx: TreeSettleContext = {
+            groups,
+            provenance,
+            baseUnion: triggerUnion,
+        }
+        try {
+            propagateDirtySelectors(
+                triggerUnion,
+                selectors,
+                data,
+                machineSubs,
+                updatedFamilyAtoms ?? new Map(),
+                false,
+                notify,
+                changedSelectors,
+                treeCtx,
+            )
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+
+    // ---- Phase C: causal assembly. Deferred subscribers are inserted in
+    // reaching-group order — for each group: its direct atom/family subs, then
+    // the subs of selectors FIRST reached by it (evaluation order) — so a
+    // selector first dirtied by an inherited trigger keeps its historical
+    // position before this store's own-atom subscribers, and first-error
+    // arbitration among throwing subscribers is unchanged. Reports follow the
+    // same order, each group into its own sink. ----
+    const firstProvenanceOf = (selector: Selector): number => {
+        const chain = provenance.get(selector)
+        return chain && chain.length > 0 ? chain[0]! : -1
+    }
+    let hasDirectSubs = false
+    for (const set of directSubs) {
+        if (set && set.size > 0) {
+            hasDirectSubs = true
+            break
+        }
+    }
+    let orderedSubs: Set<Subscription> | undefined
+    if (machineSubs.size > 0 || hasDirectSubs) {
+        orderedSubs = notify.get(data)?.subscriptions ?? new Set<Subscription>()
+        for (let index = 0; index < groups.length; index++) {
+            const direct = directSubs[index]
+            if (direct) addSetToSet(direct, orderedSubs)
+            for (const selector of changedSelectors) {
+                if (firstProvenanceOf(selector) === index) {
+                    addSetToSet(
+                        data.subscriptions.get(selector),
+                        orderedSubs,
+                    )
+                }
+            }
+        }
+        // Defensive remainder: anything the attribution missed (e.g. a
+        // subscription added mid-evaluation) keeps its delivery, deduped by
+        // the Set.
+        addSetToSet(machineSubs, orderedSubs)
+    }
+    // Promote this store's collected subscribers + changed family members into
+    // the tree accumulator (bookkeeping maps stay per-role — see
+    // collectFamilyAtomsForNotify — and merge here for notification only).
+    if (orderedSubs && orderedSubs.size > 0) {
+        collectForNotify(
+            notify,
+            data,
+            orderedSubs,
+            peerFamilyAtoms ?? updatedFamilyAtoms ?? new Map(),
+        )
+        if (peerFamilyAtoms && updatedFamilyAtoms)
+            collectForNotify(notify, data, orderedSubs, updatedFamilyAtoms)
+        if (deletedFamilyAtoms)
+            collectForNotify(notify, data, orderedSubs, deletedFamilyAtoms)
+        if (unsetFamilyAtoms)
+            collectForNotify(notify, data, orderedSubs, unsetFamilyAtoms)
+    }
+
+    // Reports, in the same reaching-group order. Selector entries are
+    // attributed to the group that FIRST reached them (the historical pass
+    // that reported them); each group reports into its own sink, so folded
+    // peer groups and their cascades keep the global sink's direct-set
+    // metadata.
+    if (changeListenerRegistry.count !== 0) {
+        const selectorActive =
+            changeListenerRegistry.selectorCount !== 0 &&
+            hasSelectorChangeListener(data)
+        const selectorsFirstReachedBy = (
+            index: number,
+        ): Set<Selector> | undefined => {
+            if (!selectorActive) return undefined
+            let result: Set<Selector> | undefined
+            for (const selector of changedSelectors) {
+                if (firstProvenanceOf(selector) === index) {
+                    if (!result) result = new Set()
+                    result.add(selector)
+                }
+            }
+            return result
+        }
+        try {
+            for (let index = 0; index < groups.length; index++) {
+                const group = groups[index]!
+                const groupReport = group.report ?? report
+                if (groupReport === undefined) continue
+                const changed = selectorsFirstReachedBy(index)
+                switch (group.kind) {
+                    case TREE_GROUP_INHERITED: {
+                        if (changed && changed.size > 0) {
+                            reportSelectorChanges(changed, data, groupReport)
+                        }
+                        break
+                    }
+                    case TREE_GROUP_GLOBAL:
+                    case TREE_GROUP_UPDATED: {
+                        reportAtomChanges(
+                            group.atoms as Atom[],
+                            data,
+                            groupReport,
+                            changed,
+                        )
+                        break
+                    }
+                    case TREE_GROUP_DELETED: {
+                        reportDeletedAtoms(
+                            group.atoms as AtomFamilyAtom<any, any>[],
+                            data,
+                            groupReport,
+                            changed,
+                        )
+                        break
+                    }
+                    case TREE_GROUP_UNSET: {
+                        for (const atom of group.atoms) {
+                            reportUnsetAtom(
+                                atom as Atom,
+                                data,
+                                effectiveValueAfterUnset(atom as Atom, data),
+                                groupReport,
+                            )
+                        }
+                        if (changed && changed.size > 0) {
+                            reportSelectorChanges(changed, data, groupReport)
+                        }
+                        break
+                    }
+                }
+            }
+        } catch (error) {
+            recordCommitError(errors, error)
+        }
+    }
+
+    // ---- Recurse: plan children merged with branch-index children, each
+    // visited exactly once. ----
+    if (entry?.children) {
+        for (const child of entry.children) {
+            if (!childGroups) childGroups = new Map()
+            if (!childGroups.has(child.data)) {
+                childGroups.set(child.data, EMPTY_GROUPS)
+            }
+        }
+    }
+    if (childGroups) {
+        for (const [childData, groupList] of childGroups) {
+            let childEntry: TransactionTreeEntry | undefined
+            if (entry?.children) {
+                for (const child of entry.children) {
+                    if (child.data === childData) {
+                        childEntry = child
+                        break
+                    }
+                }
+            }
+            settleTreeStore(
+                childEntry,
+                childData,
+                groupList === EMPTY_GROUPS ? undefined : groupList,
+                foldedPeerAtoms,
+                globalSink,
+                notify,
+                report,
+                errors,
+                timestamp,
+            )
+        }
+    }
+}
+
+// Shared frozen sentinel for plan children reached with no branch-visible
+// triggers — never mutated (spreadGroup only appends to lists it created).
+const EMPTY_GROUPS: TreeTriggerGroup[] = []
+
+
 // Scope-recursive entry: re-evaluate selectors that depend on these atoms in
 // this scope and cross into nested scopes. Skips collecting direct atom and
 // family subscribers — the parent scope already collected those, and family
@@ -1013,7 +1819,7 @@ const propagateToScopes = (
 }
 
 export const propagateDirtySelectors = (
-    updatedAtoms: Atom[],
+    updatedAtoms: Atom[] | ReadonlySet<Atom>,
     selectors: Set<Selector>,
     data: StoreData,
     subscriptions: Set<Subscription>,
@@ -1024,6 +1830,10 @@ export const propagateDirtySelectors = (
     // actually changed this pass, so the caller can report it via onChange.
     // Undefined on the hot path (no selector listener) — zero overhead.
     changedSelectors?: Set<Selector>,
+    // Cross-scope walk only: reaching-pass groups + per-selector provenance
+    // for the public `equal` contract (see treeEqualAcrossGroups). Undefined
+    // everywhere else — the single-set equality path is unchanged.
+    treeCtx?: TreeSettleContext,
 ) => {
     const updatedInitializedAtoms = new Set<Atom>(updatedAtoms)
     if (selectors.size > 0) {
@@ -1039,6 +1849,7 @@ export const propagateDirtySelectors = (
             updatedInitializedAtoms,
             isInitOnly,
             changedSelectors,
+            treeCtx,
         )
     }
     // When deferring a store-tree propagation or multi-pass commit, the caller
@@ -1104,6 +1915,7 @@ const propagateDownstreamTopo = (
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
     changedSelectors?: Set<Selector>,
+    treeCtx?: TreeSettleContext,
 ) => {
     const closure = new Set<Selector>(seeds)
     {
@@ -1186,6 +1998,7 @@ const propagateDownstreamTopo = (
         for (const d of downstream) {
             if (!IS_PROD && data.architectureInstrumentation)
                 recordDependencyEdgeVisit(data)
+            if (propagateChange && treeCtx) mergeTreeProvenance(treeCtx, d, selector)
             if (!closure.has(d)) {
                 // `d` is downstream of a just-changed selector but absent from
                 // the static closure, which means it was materialized AFTER the
@@ -1277,6 +2090,7 @@ const propagateDownstreamTopo = (
             updatedInitializedAtoms,
             depsChange,
             currentValue,
+            treeCtx,
         )
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
@@ -1356,6 +2170,7 @@ const propagateDownstreamTopo = (
         for (const d of downstream) {
             if (!IS_PROD && data.architectureInstrumentation)
                 recordDependencyEdgeVisit(data)
+            if (treeCtx) mergeTreeProvenance(treeCtx, d, selector)
             if (!work.has(d)) {
                 work.add(d)
                 if (!IS_PROD && data.architectureInstrumentation)
@@ -1386,6 +2201,7 @@ const propagateDownstreamTopo = (
             updatedInitializedAtoms,
             depsChange,
             currentValue,
+            treeCtx,
         )
         const added = depsChange.added as Set<State> | undefined
         const removed = depsChange.removed as Set<State> | undefined
@@ -1507,6 +2323,7 @@ const propagateSelectorUpdatesLinearFirst = (
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly: boolean,
     changedSelectors?: Set<Selector>,
+    treeCtx?: TreeSettleContext,
 ) => {
     let downstreamSeeds: Set<Selector> | undefined
     const orderedSelectors = orderInitialSelectors(selectors, data)
@@ -1541,6 +2358,7 @@ const propagateSelectorUpdatesLinearFirst = (
             updatedInitializedAtoms,
             depsChange,
             currentValue,
+            treeCtx,
         )
         // Casts work around a tsgo control-flow narrowing quirk where
         // property accesses lose their narrowing after a function call.
@@ -1571,6 +2389,7 @@ const propagateSelectorUpdatesLinearFirst = (
             for (const d of downstream) {
                 if (!IS_PROD && data.architectureInstrumentation)
                     recordDependencyEdgeVisit(data)
+                if (treeCtx) mergeTreeProvenance(treeCtx, d, selector)
                 if (selectors.has(d) && !processedInitialSelectors.has(d)) {
                     continue
                 }
@@ -1587,6 +2406,7 @@ const propagateSelectorUpdatesLinearFirst = (
             updatedInitializedAtoms,
             isInitOnly,
             changedSelectors,
+            treeCtx,
         )
     }
 }
@@ -1605,6 +2425,7 @@ const propagateSelectorUpdates = (
     updatedInitializedAtoms: Set<Atom>,
     isInitOnly = false,
     changedSelectors?: Set<Selector>,
+    treeCtx?: TreeSettleContext,
 ) => {
     if (selectors.size === 0) return
 
@@ -1632,6 +2453,7 @@ const propagateSelectorUpdates = (
             updatedInitializedAtoms,
             isInitOnly,
             changedSelectors,
+            treeCtx,
         )
     } finally {
         // Always release the collector — even if a user onMount/cleanup above threw

--- a/packages/valdres/src/lib/transaction.atomicScope.test.ts
+++ b/packages/valdres/src/lib/transaction.atomicScope.test.ts
@@ -561,14 +561,12 @@ describe("cross-scope transactions are atomically observable", () => {
 
     describe("union-propagation: serializable single notification", () => {
         test("a root+scope spanning selector is notified once with the final value", () => {
-            // The selector is reachable both via the root's propagateToScopes
-            // and via the scope's own propagation pass. With no cross-pass dedup
-            // guard it is recomputed in each reaching pass (the later pass
-            // reading the now-final inputs), but notification is deferred to the
-            // end of the commit — so the subscriber fires exactly once, with the
-            // fully-applied value. (The body running once per pass is the cost
-            // of dropping the dedup; the guarantee that matters is the single,
-            // final-valued notification.)
+            // The selector is reachable both via the root's write (inherited)
+            // and via the scope's own write. The tree-level commit visits the
+            // scope ONCE with the union of both triggers, so the body runs
+            // exactly once against the fully-applied state, and the deferred
+            // notification fires the subscriber exactly once with the final
+            // value.
             const root = store()
             const S = root.scope("S")
             const r = atom(1, { name: "dd-r" })
@@ -594,13 +592,14 @@ describe("cross-scope transactions are atomically observable", () => {
             })
 
             expect(S.get(sum)).toBe(22)
-            expect(evals - before).toBe(2) // recomputed once per reaching pass
+            expect(evals - before).toBe(1) // settled once against the union
             expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
 
         test("deeper spanning chain: each selector is notified once with its final value", () => {
             // r (root) and s (scope) feed a → b. Both a and b span the two
-            // stores; each is recomputed in both passes but observed once, final.
+            // stores; the single scope visit evaluates each once, in
+            // dependency order, against the final values.
             const root = store()
             const S = root.scope("S")
             const r = atom(1, { name: "dd2-r" })
@@ -635,9 +634,9 @@ describe("cross-scope transactions are atomically observable", () => {
 
             expect(S.get(a)).toBe(22)
             expect(S.get(b)).toBe(42)
-            // Final values are correct; bodies recompute per reaching pass.
-            expect(aEvals - aBefore).toBe(2)
-            expect(bEvals - bBefore).toBe(2)
+            // One evaluation each, on final values.
+            expect(aEvals - aBefore).toBe(1)
+            expect(bEvals - bBefore).toBe(1)
         })
 
         test("single-store update + delete: spanning selector is notified once with its final value", () => {
@@ -677,16 +676,18 @@ describe("cross-scope transactions are atomically observable", () => {
             expect(cb).toHaveBeenCalledTimes(1) // single, final-valued notification
         })
 
-        test("cross-scope: scope selector spanning a root atom + a root-deleted family recomputes per reaching pass, notified once", () => {
+        test("single-store txn cascading into a scope: spanning selector recomputes per pass, notified once", () => {
             // A selector in S depends on a root atom (updated) and a root family
-            // (member deleted), with S NOT shadowing the family. Both the update
-            // pass (propagateAtomUpdate, via the root atom) and the delete pass
-            // (propagateDeletedAtoms, via the family) cross-propagate into S, so
-            // the selector recomputes once per reaching pass — the same
-            // recompute-in-each-pass behavior the single-store root case above
-            // exhibits. Both passes read the fully-written state (writeAtoms has
-            // already rendered the deleted member out), so each lands on the
-            // final value and the equality check prunes the redundant result;
+            // (member deleted), with S NOT shadowing the family. The txn writes
+            // ONLY the root (no t.scope call), so it commits through the
+            // SINGLE-STORE cleanup settlement (settleTransactionCommit), whose
+            // update pass (propagateAtomUpdate, via the root atom) and delete
+            // pass (propagateDeletedAtoms, via the family) each cross-propagate
+            // into S — the selector recomputes once per reaching pass, exactly
+            // like the single-store root case above. (A txn that ALSO touched a
+            // scope would take the tree-level plan and evaluate once.) Both
+            // passes read the fully-written state, so each lands on the final
+            // value and the equality check prunes the redundant result;
             // deferred notification fires the subscriber exactly once.
             const root = store()
             const fam = atomFamily<string>(undefined, { name: "cud-fam" })
@@ -899,6 +900,522 @@ describe("cross-scope transactions are atomically observable", () => {
 
             expect(rootFires).toEqual([["c"]]) // never ["d"]
             expect(scopeFires).toEqual([["c"], ["d"]]) // sees root "c" (read-through) + own "d", once each
+        })
+    })
+
+    // Shadow REMOVAL inside a transaction: an unset staged in a scoped txn
+    // detaches the scope's own value in the write phase, so settlement (and
+    // every observer) sees the re-inherited chain value — including a value
+    // the SAME transaction wrote to an ancestor.
+    describe("unset inside a cross-scope txn (shadow removal)", () => {
+        test("scope-only unset re-inherits the pre-txn parent value", () => {
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(1, { name: "su-x" })
+            S.set(X, 10) // shadow
+            const cb = mock(() => {})
+            S.sub(X, cb)
+
+            root.txn(t => {
+                t.scope("S", st => st.unset(X))
+            })
+
+            expect(S.get(X)).toBe(1) // re-inherited
+            expect(root.get(X)).toBe(1)
+            expect(cb).toHaveBeenCalledTimes(1)
+
+            // Delegate re-established AFTER the notification: a later root
+            // write still reaches the scope subscriber through the chain.
+            root.set(X, 5)
+            expect(S.get(X)).toBe(5)
+            expect(cb).toHaveBeenCalledTimes(2)
+        })
+
+        test("root set + scope unset of the same atom lands on the NEW root value", () => {
+            // The leaf-first write phase detaches the scope shadow (re-opening
+            // the branch) BEFORE the root's write, so the scope's settlement
+            // and subscriber observe the root's new value — the atom reaches
+            // the scope both as its own unset and as an inherited change, and
+            // still settles once.
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(1, { name: "su2-x" })
+            S.set(X, 10)
+
+            let evals = 0
+            const derived = selector(
+                get => {
+                    evals++
+                    return get(X) * 2
+                },
+                { name: "su2-derived" },
+            )
+            const cb = mock(() => {})
+            S.sub(derived, cb)
+            S.get(derived)
+            const before = evals
+
+            root.txn(t => {
+                t.set(X, 5)
+                t.scope("S", st => st.unset(X))
+            })
+
+            expect(root.get(X)).toBe(5)
+            expect(S.get(X)).toBe(5) // re-inherits the value written this txn
+            expect(S.get(derived)).toBe(10)
+            expect(evals - before).toBe(1) // one settlement despite two triggers
+            expect(cb).toHaveBeenCalledTimes(1)
+
+            root.set(X, 6)
+            expect(S.get(derived)).toBe(12) // delegate survived
+        })
+
+        test("root-entry unset in a cross-scope txn de-materializes the root value", () => {
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(1, { name: "su3-x" })
+            const Y = atom(0, { name: "su3-y" })
+            S.set(Y, 0)
+            root.set(X, 5)
+            const cb = mock(() => {})
+            S.sub(Y, cb)
+
+            root.txn(t => {
+                t.unset(X)
+                t.scope("S", st => st.set(Y, 2))
+            })
+
+            expect(root.get(X)).toBe(1) // default re-initialized lazily
+            expect(S.get(Y)).toBe(2)
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    // The public equal contract across the tree-level commit: the selector
+    // body runs ONCE, but `equal` still sees the same per-reaching-pass
+    // trigger sets the historical multi-pass commit delivered — ancestor
+    // groups root-first, the store's own group last — committing on the first
+    // group that reports a change.
+    describe("selector.equal receives per-reaching-group trigger sets", () => {
+        const build = (
+            name: string,
+            equal: (a: number, b: number, updated?: Set<any>) => boolean,
+        ) => {
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: `${name}-r` })
+            const A = atom(10, { name: `${name}-a` })
+            S.set(A, 10)
+            const seen: Set<any>[] = []
+            const spanning = selector(
+                get => get(R) + get(A) * 1000,
+                {
+                    name: `${name}-span`,
+                    equal: (a: number, b: number, updated?: Set<any>) => {
+                        seen.push(new Set(updated))
+                        return equal(a, b, updated)
+                    },
+                },
+            )
+            const cb = mock(() => {})
+            S.sub(spanning, cb)
+            S.get(spanning)
+            seen.length = 0
+            return { root, S, R, A, spanning, seen, cb }
+        }
+
+        test("an equality ignoring scope-only triggers cannot suppress a root-triggered update", () => {
+            // Treat any change whose trigger set is ONLY the scope atom as
+            // equal. The first (root) group contains the root atom, so the
+            // update commits on the first group and the own group is never
+            // consulted — the reviewer scenario for the flat-union hazard.
+            const { S, root, R, A, spanning, seen, cb } = build(
+                "eqg1",
+                (_a, _b, updated) => !updated?.has(R) && !!updated?.has(A),
+            )
+            const { R: r, A: a } = { R, A } // narrow closure use
+            root.txn(t => {
+                t.set(r, 2)
+                t.scope("S", st => st.set(a, 20))
+            })
+
+            expect(S.get(spanning)).toBe(20002)
+            expect(cb).toHaveBeenCalledTimes(1)
+            expect(seen).toHaveLength(1) // committed on the first group
+            expect(seen[0]!.has(r)).toBe(true)
+            expect(seen[0]!.has(a)).toBe(false)
+        })
+
+        test("groups are consulted root-first until one reports a change", () => {
+            // Suppress the root-only group; commit on the group containing the
+            // scope atom — locking both the group order and their contents.
+            const refs: { R?: any; A?: any } = {}
+            const { S, root, R, A, spanning, seen } = build(
+                "eqg2",
+                (_a, _b, updated) => !updated?.has(refs.A),
+            )
+            refs.R = R
+            refs.A = A
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            expect(seen).toHaveLength(2)
+            expect([...seen[0]!]).toEqual([R]) // ancestor group, root-first
+            expect([...seen[1]!]).toEqual([A]) // the store's own group
+            expect(S.get(spanning)).toBe(20002)
+        })
+
+        test("only when every group reports equality is the update suppressed", () => {
+            const { root, R, A, seen, cb } = build("eqg3", () => true)
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            expect(seen).toHaveLength(2) // both groups consulted, in order
+            expect([...seen[0]!]).toEqual([R])
+            expect([...seen[1]!]).toEqual([A])
+            expect(cb).toHaveBeenCalledTimes(0) // suppressed by the custom equal
+        })
+
+        test("a group that never reached a selector is not consulted (default equality)", () => {
+            // The default deep equal treats any value found in the trigger set
+            // as unequal. A child selector that depends ONLY on the root atom
+            // but RETURNS the scope atom object must not be spuriously
+            // notified just because the same transaction also wrote that scope
+            // atom — the scope-atom group never reached this selector.
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "eqp1-r" })
+            const A = atom(10, { name: "eqp1-a" })
+            S.set(A, 10)
+            const listSel = selector(
+                get => {
+                    get(R)
+                    return [A]
+                },
+                { name: "eqp1-list" },
+            )
+            const cb = mock(() => {})
+            S.sub(listSel, cb)
+            S.get(listSel)
+
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            // deep-equal([A], [A], {R}) — A is not in the reaching set, the
+            // arrays are element-identical, so the value is unchanged.
+            expect(cb).toHaveBeenCalledTimes(0)
+            expect(S.get(listSel)).toEqual([A])
+        })
+
+        test("an atom lazily initialized during evaluation joins the consulted set", () => {
+            // A dynamic dependency initialized mid-settlement historically
+            // joined the reaching pass's mutating trigger set — the default
+            // equality must still see it and report the embedded-atom change.
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "eqp2-r" })
+            const A = atom(10, { name: "eqp2-a" })
+            const L = atom(99, { name: "eqp2-l" })
+            S.set(A, 10)
+            const listSel = selector(
+                get => {
+                    if (get(R) === 2) get(L) // lazily initializes L
+                    return [L]
+                },
+                { name: "eqp2-list" },
+            )
+            const cb = mock(() => {})
+            S.sub(listSel, cb)
+            S.get(listSel)
+
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            // The evaluation initialized L, so the consulted set is {R, L} and
+            // the embedded L makes the default equality report a change.
+            expect(cb).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    // Causal delivery order across the tree commit: a selector FIRST reached
+    // by an inherited trigger keeps its historical position before the
+    // store's own-atom subscribers — in the deferred subscriber sequence, in
+    // first-error arbitration, and in the onChange payload.
+    describe("causal ordering for inherited-first selectors", () => {
+        test("subscriber order and first-error arbitration follow reaching order", () => {
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "co-r" })
+            const A = atom(10, { name: "co-a" })
+            S.set(A, 10)
+            const span = selector(get => get(R) + get(A), { name: "co-span" })
+            const order: string[] = []
+            S.sub(span, () => {
+                order.push("selector")
+                throw new Error("selector boom")
+            })
+            S.sub(A, () => {
+                order.push("atom")
+                throw new Error("atom boom")
+            })
+            S.get(span)
+
+            // The selector's first trigger is the inherited root write, so its
+            // subscriber precedes the scope's own-atom subscriber — and when
+            // both throw, the selector's error is the surfaced first error.
+            expect(() =>
+                root.txn(t => {
+                    t.set(R, 2)
+                    t.scope("S", st => st.set(A, 20))
+                }),
+            ).toThrow("selector boom")
+            expect(order).toEqual(["selector", "atom"])
+        })
+
+        test("onChange places an inherited-first selector before the store's own atoms", () => {
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "co2-r" })
+            const A = atom(10, { name: "co2-a" })
+            S.set(A, 10)
+            const span = selector(get => get(R) + get(A), { name: "co2-span" })
+            S.sub(span, () => {})
+            S.get(span)
+            const calls: any[] = []
+            const unsub = root.onChange((changes: any) => calls.push(changes), {
+                selectors: true,
+            })
+
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            expect(calls).toHaveLength(1)
+            expect(
+                calls[0].map((c: any) => [c.kind ?? c.type, c.state]),
+            ).toEqual([
+                ["set", R],
+                ["selector", span],
+                ["set", A],
+            ])
+            unsub()
+        })
+    })
+
+    // Exact onChange payload order for cross-scope commits. Root-first
+    // per-store groups; within a store, selector entries ride the leading own
+    // group when one exists, and a pure unset store keeps its historical
+    // record-then-selectors order.
+    describe("cross-scope onChange payload order", () => {
+        test("scoped unset-only txn: unset record precedes the selector change", () => {
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(1, { name: "cpo1-x" })
+            S.set(X, 10)
+            const derived = selector(get => get(X) * 2, { name: "cpo1-d" })
+            S.sub(derived, () => {})
+            S.get(derived)
+            const calls: any[] = []
+            const unsub = root.onChange((changes: any) => calls.push(changes), {
+                selectors: true,
+            })
+
+            root.txn(t => {
+                t.scope("S", st => st.unset(X))
+            })
+
+            expect(calls).toHaveLength(1)
+            expect(
+                calls[0].map((c: any) => [c.kind ?? c.type, c.state]),
+            ).toEqual([
+                ["unset", X],
+                ["selector", derived],
+            ])
+            unsub()
+        })
+
+        test("root+scope txn: root group (atom then selector) precedes the scope group", () => {
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "cpo2-r" })
+            const A = atom(10, { name: "cpo2-a" })
+            S.set(A, 10)
+            const rootSel = selector(get => get(R) + 1, { name: "cpo2-rs" })
+            const scopeSel = selector(get => get(A) + 1, { name: "cpo2-ss" })
+            root.sub(rootSel, () => {})
+            S.sub(scopeSel, () => {})
+            root.get(rootSel)
+            S.get(scopeSel)
+            const calls: any[] = []
+            const unsub = root.onChange((changes: any) => calls.push(changes), {
+                selectors: true,
+            })
+
+            root.txn(t => {
+                t.set(R, 2)
+                t.scope("S", st => st.set(A, 20))
+            })
+
+            expect(calls).toHaveLength(1)
+            expect(
+                calls[0].map((c: any) => [c.kind ?? c.type, c.state]),
+            ).toEqual([
+                ["set", R],
+                ["selector", rootSel],
+                ["set", A],
+                ["selector", scopeSel],
+            ])
+            unsub()
+        })
+
+        test("update+unset in one scope: selector entries ride the update group, unset records follow", () => {
+            // The consolidated order is the tree-plan contract: with one
+            // evaluation per store there is one selector group per store, and
+            // it rides the leading updated-atom group.
+            const root = store()
+            const S = root.scope("S")
+            const X = atom(1, { name: "cpo3-x" })
+            const Y = atom(0, { name: "cpo3-y" })
+            S.set(X, 10)
+            S.set(Y, 0)
+            const span = selector(get => get(X) + get(Y), { name: "cpo3-s" })
+            S.sub(span, () => {})
+            S.get(span)
+            const calls: any[] = []
+            const unsub = root.onChange((changes: any) => calls.push(changes), {
+                selectors: true,
+            })
+
+            root.txn(t => {
+                t.scope("S", st => {
+                    st.set(Y, 7)
+                    st.unset(X)
+                })
+            })
+
+            expect(calls).toHaveLength(1)
+            expect(
+                calls[0].map((c: any) => [c.kind ?? c.type, c.state]),
+            ).toEqual([
+                ["set", Y],
+                ["selector", span],
+                ["unset", X],
+            ])
+            expect(S.get(span)).toBe(8) // X re-inherited (1) + Y (7)
+            unsub()
+        })
+    })
+
+    // A failing per-store phase must not starve settlement or delivery of the
+    // REST of the tree — including scopes the transaction never touched.
+    describe("cross-scope commit error continuation", () => {
+        test("a throwing unset report does not starve an untouched descendant scope", () => {
+            const root = store()
+            const S = root.scope("S")
+            const G = S.scope("G")
+            const R = atom(1, { name: "ec-r" })
+            // Function default that throws once armed: reporting the unset's
+            // effective value walks the chain and re-initializes it (the scope
+            // shadow was the only settled value).
+            let armed = false
+            const X = atom(
+                () => {
+                    if (armed) throw new Error("default boom")
+                    return 1
+                },
+                { name: "ec-x" },
+            )
+            S.set(X, 10) // scope shadow (initializes root X = 1 on the way)
+            root.unset(X) // drop the root's own value back to the lazy default
+            armed = true
+            const gSel = selector(get => get(R) * 100, { name: "ec-gsel" })
+            const gCb = mock(() => {})
+            G.sub(gSel, gCb)
+            G.get(gSel)
+            // A change listener forces the reporting phase to run.
+            const unsub = root.onChange(() => {})
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(R, 2)
+                    t.scope("S", st => st.unset(X))
+                }),
+            ).toThrow("default boom")
+
+            // Writes were applied and the untouched grandchild still settled
+            // and was notified, despite the throwing report in S.
+            expect(root.get(R)).toBe(2)
+            expect(G.get(gSel)).toBe(200)
+            expect(gCb).toHaveBeenCalledTimes(1)
+            unsub()
+        })
+
+        test("a throwing subscriber in one store does not starve another store's delivery", () => {
+            const root = store()
+            const S = root.scope("S")
+            const R = atom(1, { name: "es-r" })
+            const A = atom(10, { name: "es-a" })
+            S.set(A, 10)
+            const rootCb = mock(() => {
+                throw new Error("root sub boom")
+            })
+            const scopeCb = mock(() => {})
+            root.sub(R, rootCb)
+            S.sub(A, scopeCb)
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(R, 2)
+                    t.scope("S", st => st.set(A, 20))
+                }),
+            ).toThrow("root sub boom")
+
+            expect(rootCb).toHaveBeenCalledTimes(1)
+            expect(scopeCb).toHaveBeenCalledTimes(1) // still delivered
+            expect(root.get(R)).toBe(2)
+            expect(S.get(A)).toBe(20)
+        })
+    })
+
+    describe("nested-scope rollback", () => {
+        test("a throw inside a nested scope callback rolls back the whole tree", () => {
+            const root = store()
+            const S = root.scope("S")
+            const N = S.scope("N")
+            const R = atom(1, { name: "nr-r" })
+            const A = atom(10, { name: "nr-a" })
+            const B = atom(100, { name: "nr-b" })
+            S.set(A, 10)
+            N.set(B, 100)
+            const cb = mock(() => {})
+            root.sub(R, cb)
+
+            expect(() =>
+                root.txn(t => {
+                    t.set(R, 2)
+                    t.scope("S", st => {
+                        st.set(A, 20)
+                        st.scope("N", nt => {
+                            nt.set(B, 200)
+                            throw new Error("nested boom")
+                        })
+                    })
+                }),
+            ).toThrow("nested boom")
+
+            expect(root.get(R)).toBe(1)
+            expect(S.get(A)).toBe(10)
+            expect(N.get(B)).toBe(100)
+            expect(cb).toHaveBeenCalledTimes(0)
         })
     })
 })

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -68,8 +68,10 @@ import {
     propagateAtomUpdate,
     propagateDeletedAtoms,
     settleTransactionCommit,
+    settleTransactionTreeCommit,
     type NotifyTarget,
 } from "./propagateUpdatedAtoms"
+import type { TransactionTreeEntry } from "../types/TransactionTreeSettleFn"
 import { runOnSets, type DeferredOnSet } from "./runOnSets"
 import { commitAtoms, commitHookFreeAtoms } from "./setAtoms"
 import { writeAtoms } from "./writeAtoms"
@@ -80,13 +82,13 @@ import {
 import { noteStateValueChanged } from "./stateRevisions"
 
 /** One store's slot in a cross-scope commit. Collected root-first; written
- *  leaf-first (see commit) but notified root-first. */
-type CommitWrite = {
+ *  leaf-first (see commit) but settled root-first. Extends the settlement's
+ *  entry shape structurally so the finalized array is handed to the tree
+ *  CommitPlan zero-copy; `children` links direct scoped entries so the
+ *  settlement walk visits plan stores without reconstructing the tree. */
+type CommitWrite = TransactionTreeEntry & {
     txn: TransactionContext
-    data: StoreData
-    updatedAtoms: Atom[]
-    deleted: AtomFamilyAtom<any, any>[] | undefined
-    unsetAtoms: Atom[] | undefined
+    children: CommitWrite[] | undefined
     onSets: DeferredOnSet[]
 }
 
@@ -646,9 +648,10 @@ export class TransactionContext {
         // every global atom carries a marker onSet) and no cleanup mutations —
         // translates its whole commit into one CommitPlan that owns the outer
         // commit-end boundary and the deferred onChange flush. The remaining
-        // arms share their write phase with the unmigrated global fan-out
-        // adapter, whose branch is only known after that phase, so their outer
-        // boundary and flush stay below until the cross-scope/global migration.
+        // arms (including the cross-scope tree plan) keep their outer boundary
+        // and flush below: the single-store cleanup shape still shares its
+        // write phase with the unmigrated single-store global fan-out adapter,
+        // whose branch is only known after that phase.
         if (
             !this._scopedTransactions &&
             !this._draft.hasCommitEffects &&
@@ -805,11 +808,10 @@ export class TransactionContext {
         }
 
         // Cross-scope path: write the whole tree (root + every nested scope)
-        // first, then run a single notification pass per store. This guarantees
-        // no subscriber, onSet hook, or selector ever observes a half-applied
-        // transaction — root written while a scope isn't, or scope A written
-        // while scope B isn't. The final committed state is identical to the
-        // old sequential model; only the observation point moves.
+        // first, then settle each affected store exactly once through one
+        // tree-level CommitPlan. This guarantees no subscriber, onSet hook, or
+        // selector ever observes a half-applied transaction — root written
+        // while a scope isn't, or scope A written while scope B isn't.
         const plan: CommitWrite[] = []
         this.collectStores(plan)
 
@@ -858,129 +860,35 @@ export class TransactionContext {
         }
 
         // Every value across the tree and every global peer is now applied.
-        // Hooks fire root-first, all are attempted, and their first error is
-        // retained until propagation and notification have also completed.
+        // Hand the finalized plan to the commit engine as ONE tree-level
+        // CommitPlan: hooks fire root-first in phase 3 (the flatten preserves
+        // the historical per-entry order), then settleTransactionTreeCommit
+        // settles each affected store exactly once against the union of its
+        // own writes and inherited changes, fires every subscriber once, and
+        // brackets any global peer fan-out — see the walk's header. The outer
+        // commit-end boundary and the sink flush stay with
+        // commitOpenTransaction, exactly like the single-store cleanup plan.
+        const onSets: DeferredOnSet[] = []
         for (const entry of plan) {
-            runOnSets(entry.onSets, errors)
+            for (const deferred of entry.onSets) onSets.push(deferred)
         }
-
-        // One propagation pass per store, root-first (ancestors before
-        // descendants). Order matters: an ancestor's pass cross-propagates its
-        // atom changes into descendant scopes (propagateToScopes), so a scope
-        // selector that transitively depends on an ancestor atom is recomputed
-        // with final upstream values before — or again in — the scope's own pass.
-        //
-        // Defer all subscriber notification to the end of the commit. Each
-        // store's pass settles its own selectors against the fully-written
-        // state (root-first, so read-through ancestor values are final); firing
-        // only after every pass has run means every observer reads the final,
-        // consistent snapshot — never a value a later pass still corrects
-        // (serializable observation). There is deliberately NO cross-pass dedup
-        // guard: a selector reachable by two passes is simply recomputed in each
-        // (the equality check prunes the redundant result), and the deferred
-        // notification fires its subscriber exactly once. See the warning on
-        // NotifyTarget for why a dedup guard must not come back.
-        const notify: NotifyTarget = new Map()
-        const globalSink =
-            globalUpdates && globalUpdates.size > 0
-                ? createChangeSink(undefined, "set")
-                : undefined
-        const commitRoots = globalSink
-            ? beginGlobalCommit(this._data, globalUpdates!)
-            : []
-        // Global fan-out retains its public direct-set metadata and precedes
-        // the originating transaction's reports, as it did when fan-out lived
-        // inside the global atom's onSet wrapper.
-        if (globalUpdates) {
-            for (const [data, atoms] of globalUpdates) {
-                try {
-                    propagateAtomUpdate(atoms, data, false, notify, globalSink)
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-        }
-        for (const { data, updatedAtoms, deleted, unsetAtoms } of plan) {
-            if (updatedAtoms.length > 0) {
-                try {
-                    propagateAtomUpdate(updatedAtoms, data, false, notify, sink)
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            if (deleted) {
-                try {
-                    propagateDeletedAtoms(
-                        deleted,
-                        data,
-                        undefined,
-                        undefined,
-                        undefined,
-                        notify,
-                        sink,
-                    )
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-            if (unsetAtoms && unsetAtoms.length > 0) {
-                // Atoms first (emitted as "unset" via reportUnsetAtom), then
-                // propagate with reportAtoms=false so dependent-selector recomputes
-                // are reported too — without re-surfacing the atom (its value is
-                // gone from data.values) as a "set".
-                if (sink) {
-                    for (const atom of unsetAtoms) {
-                        reportUnsetAtom(
-                            atom,
-                            data,
-                            effectiveValueAfterUnset(atom, data),
-                            sink,
-                        )
-                    }
-                }
-                try {
-                    propagateAtomUpdate(
-                        unsetAtoms,
-                        data,
-                        false,
-                        notify,
-                        sink,
-                        false,
-                        false,
-                    )
-                } catch (error) {
-                    recordCommitError(errors, error)
-                }
-            }
-        }
-        try {
-            notifyDeferred(notify)
-        } catch (error) {
-            recordCommitError(errors, error)
-        }
-        if (globalSink) {
-            try {
-                flushChangeSink(globalSink)
-            } catch (error) {
-                recordCommitError(errors, error)
-            }
-            endGlobalCommit(commitRoots, errors)
-        }
-        // Re-delegate AFTER firing (notifyDeferred): the scope-local callback
-        // idempotently drops its delegate when it fires, so the fresh parent
-        // delegate must be (re)established last.
-        for (const { data, unsetAtoms } of plan) {
-            if (unsetAtoms) {
-                for (const atom of unsetAtoms) {
-                    try {
-                        reDelegateScopeSubscriptions(atom, data)
-                    } catch (error) {
-                        recordCommitError(errors, error)
-                    }
-                }
-            }
-        }
-        throwCommitError(errors)
+        runCommitPlan({
+            data: this._data,
+            settlement: {
+                kind: "transactionTree",
+                entries: plan,
+                globalUpdates:
+                    globalUpdates && globalUpdates.size > 0
+                        ? globalUpdates
+                        : undefined,
+                settle: settleTransactionTreeCommit,
+            },
+            onSets,
+            errors,
+            report: sink,
+            // continueAfterError stays default: a hook error must not starve
+            // settlement of already-applied writes.
+        })
     }
 
     /**
@@ -1090,20 +998,27 @@ export class TransactionContext {
     }
 
     // Depth-first pre-order: this store, then each nested scope. Produces a
-    // root-first plan used directly for the notify pass and reversed for the
-    // write pass (so descendants are written before their ancestors).
-    private collectStores = (plan: CommitWrite[]) => {
-        plan.push({
+    // root-first plan used directly for the settlement walk and reversed for
+    // the write pass (so descendants are written before their ancestors).
+    // `parent.children` links direct scoped entries for the walk.
+    private collectStores = (plan: CommitWrite[], parent?: CommitWrite) => {
+        const entry: CommitWrite = {
             txn: this,
             data: this._data,
             updatedAtoms: [],
             deleted: undefined,
             unsetAtoms: undefined,
+            children: undefined,
             onSets: [],
-        })
+        }
+        plan.push(entry)
+        if (parent) {
+            if (parent.children) parent.children.push(entry)
+            else parent.children = [entry]
+        }
         if (this._scopedTransactions) {
             for (const [, scopedTxn] of this._scopedTransactions) {
-                scopedTxn.collectStores(plan)
+                scopedTxn.collectStores(plan, entry)
             }
         }
     }

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -18,9 +18,9 @@ import { setValueInData } from "./setValueInData"
  * Hook and global handling are deliberately collection-only. The caller first
  * completes every local/global write, then runs `onSetQueue`, then propagates.
  * This keeps a throwing hook from interrupting either the write or propagation
- * phase. The boolean remains positional because the unmigrated cross-scope
- * transaction arm still calls it directly; typed bulk coordinators translate
- * their intent at their own boundary.
+ * phase. The boolean remains positional because the cross-scope transaction
+ * write loop calls it directly per store before building its tree CommitPlan;
+ * typed bulk coordinators translate their intent at their own boundary.
  */
 export const writeAtoms = (
     pairs: Map<Atom<any>, any>,

--- a/packages/valdres/src/types/CommitPlan.ts
+++ b/packages/valdres/src/types/CommitPlan.ts
@@ -1,4 +1,5 @@
 import type { CommitErrors } from "../lib/commitErrors"
+import type { StoreAtomUpdates } from "../lib/globalAtomFanOut"
 import type { ChangeReport } from "../lib/notifyChangeListeners"
 import type { NotifyTarget } from "../lib/propagateUpdatedAtoms"
 import type { DeferredOnSet } from "../lib/runOnSets"
@@ -10,6 +11,10 @@ import type { Selector } from "./Selector"
 import type { SelectorSettleFn } from "./SelectorSettleFn"
 import type { StoreData } from "./StoreData"
 import type { TransactionSettleFn } from "./TransactionSettleFn"
+import type {
+    TransactionTreeEntry,
+    TransactionTreeSettleFn,
+} from "./TransactionTreeSettleFn"
 
 type UpdateSettlement = {
     kind: "update"
@@ -47,6 +52,17 @@ type TransactionSettlement = {
     settle: TransactionSettleFn
 }
 
+/** A cross-scope transaction commit: the whole affected store tree settles as
+ *  one root-first walk, each store exactly once against the union of its own
+ *  writes and inherited changes. `entries` is the flat root-first plan;
+ *  `globalUpdates` is undefined (never empty) when no global peer changed. */
+type TransactionTreeSettlement = {
+    kind: "transactionTree"
+    entries: TransactionTreeEntry[]
+    globalUpdates: StoreAtomUpdates | undefined
+    settle: TransactionTreeSettleFn
+}
+
 type NoSettlement = {
     kind: "none"
 }
@@ -56,6 +72,7 @@ type CommitSettlement =
     | DeleteSettlement
     | SelectorSettlement
     | TransactionSettlement
+    | TransactionTreeSettlement
     | NoSettlement
 
 /**
@@ -67,8 +84,9 @@ type CommitSettlement =
  * `settlement` is a typed description of an existing propagation primitive.
  * Update/reset/unset plans use `settleCommit` with shared `SettleFlags`;
  * deletion uses `settleDeletedCommit`; a single-store transaction commit with
- * cleanup mutations uses `settleTransactionCommit`; native async selectors use
- * their downstream-only settlement; guarded cleanup uses `kind: "none"`.
+ * cleanup mutations uses `settleTransactionCommit`; a cross-scope transaction
+ * commit uses `settleTransactionTreeCommit`; native async selectors use their
+ * downstream-only settlement; guarded cleanup uses `kind: "none"`.
  *
  * Optional phase callbacks stay declarative: the engine owns their order.
  * `beforeSettle` lets unset prepend its distinct removal change record;
@@ -76,11 +94,14 @@ type CommitSettlement =
  * re-delegation; `flushReport` drains a deliberately deferred onChange sink.
  * The callbacks are absent from ordinary bulk plans.
  *
- * Scope note: local plans still model one store and one settlement — including
+ * Scope note: most plans model one store and one settlement — including
  * single-store transaction commits, whose finalized overlay translates into a
- * plan. Cross-scope transactions and ordinary global writes remain behind
- * their adapters; async global settlement delegates its multi-store phase
- * without adding a local begin/end boundary.
+ * plan. A cross-scope transaction commit models the whole affected store tree
+ * through the `transactionTree` settlement (its global peer updates ride the
+ * settlement so the entire commit stays one plan). Ordinary direct global
+ * writes and single-store global cleanup remain behind their adapters; async
+ * global settlement delegates its multi-store phase without adding a local
+ * begin/end boundary.
  */
 export type CommitPlan = {
     data: StoreData

--- a/packages/valdres/src/types/TransactionTreeSettleFn.ts
+++ b/packages/valdres/src/types/TransactionTreeSettleFn.ts
@@ -1,0 +1,43 @@
+import type { CommitErrors } from "../lib/commitErrors"
+import type { StoreAtomUpdates } from "../lib/globalAtomFanOut"
+import type { ChangeReport } from "../lib/notifyChangeListeners"
+import type { Atom } from "./Atom"
+import type { AtomFamilyAtom } from "./AtomFamilyAtom"
+import type { StoreData } from "./StoreData"
+
+/**
+ * One store's finalized slot in a cross-scope transaction commit. The write
+ * phase has already applied every value; the settlement walk reads these slots
+ * to settle each affected store exactly once. `deleted` is undefined (never
+ * empty) when absent; `unsetAtoms` may be an empty array (an unset of an atom
+ * with no own value detaches nothing). `children` links the direct scoped
+ * entries of this store's transaction, so the walk can visit plan stores
+ * without reconstructing the tree — scopes reached only through the inherited
+ * dependency branch index have no entry at all.
+ */
+export type TransactionTreeEntry = {
+    data: StoreData
+    updatedAtoms: Atom<any>[]
+    deleted: AtomFamilyAtom<any, any>[] | undefined
+    unsetAtoms: Atom<any>[] | undefined
+    children: TransactionTreeEntry[] | undefined
+}
+
+/**
+ * Settlement (phases 4–7) of a cross-scope transaction commit: one root-first
+ * walk over the affected store tree, settling each store once against the
+ * union of its own writes and the inherited changes that reach it, then firing
+ * every collected subscriber once. `entries` is the flat root-first plan
+ * (`entries[0]` is the transaction's topmost written store); `globalUpdates`
+ * carries changed global peers (already written) whose per-tree propagation
+ * brackets the walk. Statically `settleTransactionTreeCommit`; passed by
+ * reference into the commit engine so the engine never imports the propagation
+ * layer. Like the single-store transaction settlement it records per-store
+ * errors into `errors` itself — one store failing must not starve the others.
+ */
+export type TransactionTreeSettleFn = (
+    entries: TransactionTreeEntry[],
+    globalUpdates: StoreAtomUpdates | undefined,
+    report: ChangeReport | undefined,
+    errors: CommitErrors,
+) => void

--- a/packages/valdres/test/oracle/transactionsCrossScope.trace.test.ts
+++ b/packages/valdres/test/oracle/transactionsCrossScope.trace.test.ts
@@ -150,3 +150,136 @@ runTraceTable("trace oracle · cross-scope transactions", [
     atomicCase,
     scopeSelectorCase,
 ])
+
+type TreeCtx = {
+    root: Store
+    mid: Store
+    leaf: Store
+    states: Record<string, Atom<any> | Selector<any>>
+    rootChanges: ChangeCall[]
+    observed: { spanning?: number }
+    run: () => void
+    cleanup: () => void
+}
+
+/** Depth-3 nested txn: the tree-level commit settles the leaf store once, so
+ *  the spanning selector's body runs EXACTLY once — a second `eval:` in the
+ *  spine fails this case. Cross-store members of each phase stay bagged. */
+const depth3Case: TraceCase<TreeCtx> = {
+    name: "depth-3 txn — leaf spanning selector evaluates once, phases block",
+    build: (rec: Recorder) => {
+        const root = store()
+        const mid = root.scope("x3-mid")
+        const leaf = mid.scope("x3-leaf")
+        const a = tracedAtom(rec, "a", 0)
+        const b = tracedAtom(rec, "b", 0)
+        const c = tracedAtom(rec, "c", 0)
+        mid.set(b, 0)
+        leaf.set(c, 0)
+        const spanning = tracedSelector(
+            rec,
+            "leafSel",
+            get =>
+                (get(a) as number) + (get(b) as number) + (get(c) as number),
+        )
+        const observed: { spanning?: number } = {}
+        leaf.sub(spanning, () => {
+            rec.push("sub:leafSel")
+            observed.spanning = leaf.get(spanning) as number
+        })
+        const { calls: rootChanges } = traceChange(rec, root, "root")
+        traceCommitEnd(rec, root, "root")
+
+        return {
+            root,
+            mid,
+            leaf,
+            states: { a, b, c, spanning },
+            rootChanges,
+            observed,
+            run: () =>
+                root.txn(txn => {
+                    txn.set(a, 1)
+                    txn.scope("x3-mid", midTxn => {
+                        midTxn.set(b, 2)
+                        midTxn.scope("x3-leaf", leafTxn => {
+                            leafTxn.set(c, 3)
+                        })
+                    })
+                }),
+            cleanup: () => {
+                leaf.detach()
+                mid.detach()
+            },
+        }
+    },
+    act: ctx => ctx.run(),
+    trace: [
+        ["onSet:a", "onSet:b", "onSet:c"],
+        "eval:leafSel",
+        "sub:leafSel",
+        "onChange:root",
+        "commitEnd:root",
+    ],
+    assert: ctx => {
+        expect(ctx.observed.spanning).toBe(6) // final, fully-applied snapshot
+        expect(ctx.rootChanges).toHaveLength(1)
+        expect(ctx.rootChanges[0]!.changes).toHaveLength(3)
+        ctx.cleanup()
+    },
+}
+
+/** Root set + scope unset of the same atom in one txn: the scope re-inherits
+ *  the value the SAME transaction wrote to the root, the subscriber fires once
+ *  with that final value, and the delegate survives for later root writes. */
+const setPlusUnsetCase: TraceCase<TreeCtx> = {
+    name: "root set + scope unset — re-inherits the new value, one notification",
+    build: (rec: Recorder) => {
+        const root = store()
+        const mid = root.scope("xu-scope")
+        const b = tracedAtom(rec, "b", 1)
+        mid.set(b, 5) // pre-existing scope shadow
+        const observed: { spanning?: number } = {}
+        mid.sub(b, () => {
+            rec.push("sub:b")
+            observed.spanning = mid.get(b) as number
+        })
+        const { calls: rootChanges } = traceChange(rec, root, "root")
+        traceCommitEnd(rec, root, "root")
+
+        return {
+            root,
+            mid,
+            leaf: mid,
+            states: { b },
+            rootChanges,
+            observed,
+            run: () =>
+                root.txn(txn => {
+                    txn.set(b, 7)
+                    txn.scope("xu-scope", scoped => scoped.unset(b))
+                }),
+            cleanup: () => mid.detach(),
+        }
+    },
+    act: ctx => ctx.run(),
+    trace: ["onSet:b", "sub:b", "onChange:root", "commitEnd:root"],
+    assert: ctx => {
+        expect(ctx.root.get(ctx.states.b)).toBe(7)
+        expect(ctx.mid.get(ctx.states.b)).toBe(7) // re-inherited the txn's value
+        expect(ctx.observed.spanning).toBe(7) // never the stale shadow 5
+        // Root group first (set), then the scope's unset record.
+        expect(
+            ctx.rootChanges[0]!.changes.map((c: any) => c.kind),
+        ).toEqual(["set", "unset"])
+        // Delegate survives: a later root write still notifies the scope sub.
+        ctx.root.set(ctx.states.b, 9)
+        expect(ctx.observed.spanning).toBe(9)
+        ctx.cleanup()
+    },
+}
+
+runTraceTable("trace oracle · cross-scope tree commit", [
+    depth3Case,
+    setPlusUnsetCase,
+])

--- a/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
+++ b/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
@@ -60,23 +60,35 @@ changes. Columns are evaluations, settlements, duplicate settlements, unique
 stores, store passes, duplicate store passes, edge visits, enqueues, and
 dequeues.
 
-| Scenario                         | Eval | Settle | Dup sel | Stores | Passes | Dup store | Edges | Enq | Deq |
-| -------------------------------- | ---: | -----: | ------: | -----: | -----: | --------: | ----: | --: | --: |
-| Atom-only write                  |    0 |      0 |       0 |      0 |      0 |         0 |     0 |   0 |   0 |
-| Live fan-out, width 8            |    8 |      8 |       0 |      1 |      1 |         0 |    16 |   8 |   8 |
-| Asymmetric DAG, depth 6          |    8 |      8 |       1 |      1 |      1 |         0 |    43 |   8 |   8 |
-| Dynamic churn, width 6           |    6 |      6 |       0 |      1 |      1 |         0 |    18 |   6 |   6 |
-| Single-store update + delete     |    2 |      2 |       1 |      1 |      2 |         1 |     3 |   0 |   0 |
-| Cross-scope transaction, depth 3 |    3 |      3 |       2 |      1 |      3 |         2 |     3 |   0 |   0 |
-| Global fan-out, width 6          |    6 |      6 |       0 |      6 |      6 |         0 |     6 |   0 |   0 |
+| Scenario                             | Eval | Settle | Dup sel | Stores | Passes | Dup store | Edges | Enq | Deq |
+| ------------------------------------ | ---: | -----: | ------: | -----: | -----: | --------: | ----: | --: | --: |
+| Atom-only write                      |    0 |      0 |       0 |      0 |      0 |         0 |     0 |   0 |   0 |
+| Live fan-out, width 8                |    8 |      8 |       0 |      1 |      1 |         0 |    16 |   8 |   8 |
+| Asymmetric DAG, depth 6              |    8 |      8 |       1 |      1 |      1 |         0 |    43 |   8 |   8 |
+| Dynamic churn, width 6               |    6 |      6 |       0 |      1 |      1 |         0 |    18 |   6 |   6 |
+| Single-store update + delete         |    2 |      2 |       1 |      1 |      2 |         1 |     3 |   0 |   0 |
+| Cross-scope transaction, depth 3     |    1 |      1 |       0 |      1 |      1 |         0 |     3 |   0 |   0 |
+| Cross-scope update + delete + unset  |    1 |      1 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
+| Cross-scope txn, plan/peer overlap   |    1 |      1 |       0 |      1 |      1 |         0 |     2 |   0 |   0 |
+| Global fan-out, width 6              |    6 |      6 |       0 |      6 |      6 |         0 |     6 |   0 |   0 |
 
 Selector/store counts that express current commit behavior are exact. Edge and
 queue gates allow narrow structural headroom: 0–25% for linear shapes and
 approximately ±16% for the asymmetric DAG. Queue enqueues must equal dequeues.
 These are engine-independent algorithm counts, not JavaScript object-layout or
 nanosecond assertions. The update-plus-delete case deliberately reaches the same
-selector twice and proves both duplicate detectors are live. A future
-proven-safe deduplication may lower these baselines, but increasing them
+selector twice through the single-store cleanup settlement's per-kind passes and
+proves both duplicate detectors are live. The cross-scope rows record the
+proven-safe deduplication this table previously anticipated: the tree-level
+CommitPlan (`settleTransactionTreeCommit`) visits each affected store once with
+the union of its own and inherited triggers, so the depth-3 spanning selector
+dropped from three evaluations (one per reaching ancestor pass) to one, with
+zero duplicate settlements; the mixed-kind row proves the union spans update,
+delete, and unset triggers; and the plan/peer-overlap row proves a global peer
+that is itself a plan store folds into that single settlement instead of also
+running a separate peer pass. Cross-scope transaction commits (with or without
+global peers) additionally gate on exactly one `commitPlanRuns`. Lowering
+baselines further requires the same proven-safe standard; increasing them
 requires review.
 
 ## Retained-memory methodology and baseline
@@ -103,14 +115,22 @@ runtime-specific because the heaps differ, but are normalized per scenario unit
 and leave roughly 25–30% above the observed median. Released heap has a fixed
 ceiling: 512 KiB on Bun and 256 KiB on Node.
 
+Calibration note (single-store transactions, Bun): JSC's
+`heapSize + extraMemorySize` is sensitive to the byte layout of the commit
+engine module — adding a never-called function to a pristine `commitEngine.ts`
+alone moved this scenario 157 → 229 B/unit while the Node/V8 lane stayed at
+85 B/unit. The Bun observed/ceiling values therefore absorb code-layout shifts
+(360 still detects a real per-transaction pin such as a retained MutationDraft,
+~+220 B/unit here); the Node lane is the layout-insensitive cross-check.
+
 | Scenario                            | Units | Bun B/unit | Bun ceiling | Node B/unit | Node ceiling |
 | ----------------------------------- | ----: | ---------: | ----------: | ----------: | -----------: |
 | Atom-only stores                    | 4,000 |        111 |         160 |          84 |          120 |
 | Live selector graphs                | 1,500 |      1,873 |       2,400 |       1,169 |        1,500 |
 | Dynamic dependency churn            | 1,000 |      1,581 |       2,100 |       1,179 |        1,400 |
 | Scope creation and disposal         | 1,500 |      2,474 |       3,200 |       2,668 |        3,400 |
-| Single-store transactions           | 2,500 |        157 |         200 |          82 |          120 |
-| Deep cross-scope transactions       |    64 |     22,949 |      30,000 |      10,569 |       14,000 |
+| Single-store transactions           | 2,500 |        230 |         360 |          85 |          120 |
+| Deep cross-scope transactions       |    64 |     22,969 |      30,000 |      10,601 |       14,000 |
 | Global fan-out                      | 1,000 |      2,870 |       3,700 |       2,629 |        3,400 |
 | Store disposal + async cancellation |   500 |      5,834 |       7,500 |       5,889 |        7,500 |
 
@@ -127,7 +147,7 @@ three times and compares the cross-run median, avoiding fixed nanosecond gates.
 | Dependency churn 100                | 120.2 µs | 142.0 µs |
 | Create + dispose scope              |   542 ns |   1.3 µs |
 | Single-store transaction, 20 writes |   6.7 µs |   8.5 µs |
-| Cross-scope transaction, depth 8    |  36.9 µs |  42.0 µs |
+| Cross-scope transaction, depth 8    |  20.5 µs |  19.0 µs |
 | Global fan-out 100                  |  26.6 µs |  36.9 µs |
 | Dispose pending selector            |   3.5 µs |   6.7 µs |
 

--- a/packages/valdres/test/performance/architecture.memory.ts
+++ b/packages/valdres/test/performance/architecture.memory.ts
@@ -41,8 +41,15 @@ const limits: Record<string, Record<typeof runtime, MemoryLimit>> = {
         bun: { retainedBytesPerUnit: 3_200, releasedBytes: 512 * 1024 },
         node: { retainedBytesPerUnit: 3_400, releasedBytes: 256 * 1024 },
     },
+    // Bun ceiling recalibrated with the cross-scope tree-commit change: JSC's
+    // heapSize+extraMemorySize is sensitive to the byte layout of the commit
+    // engine module — adding a NEVER-CALLED function to a pristine
+    // commitEngine.ts moved this scenario 157 → 229 B/unit while the Node/V8
+    // lane stayed at 85 B/unit, so the shift is measurement layout, not
+    // retention. 360 keeps a real per-transaction pin (e.g. a retained
+    // MutationDraft, ~+220 B/unit here) detectable.
     "single-store transactions": {
-        bun: { retainedBytesPerUnit: 200, releasedBytes: 512 * 1024 },
+        bun: { retainedBytesPerUnit: 360, releasedBytes: 512 * 1024 },
         node: { retainedBytesPerUnit: 120, releasedBytes: 256 * 1024 },
     },
     "deep cross-scope transactions": {


### PR DESCRIPTION
## What

Migrates the cross-scope transaction commit (the last hand-rolled multi-store settlement) onto the typed commit engine. After the unchanged leaf-first write phase, the finalized per-store entries become one `kind:"transactionTree"` CommitPlan whose `settleTransactionTreeCommit` walks the affected store tree once, root-first — settling each store exactly once against the union of its own updated/deleted/unset writes and the inherited changes that reach it, with dirty collection completed before one topologically-ordered evaluation.

A spanning selector now evaluates once per (store, commit) instead of once per reaching pass. This is a visit-once restructure behind the write-all-then-settle guarantee, not a skip-guard — neither of the documented `#168` dedup failure modes applies (nothing reachable is ever skipped; work is simply not repeated).

## Semantics preserved via trigger provenance

- **`selector.equal`** receives the historical per-reaching-pass trigger sets, consulted in reaching order for exactly the groups whose dirty chain reached that selector (provenance is threaded through the linear sweep, topo queue, and stranded evaluator); atoms lazily initialized mid-settlement join the final consulted set. This matters for the default deep equal too — it treats values found in the trigger set as unequal, so per-selector provenance prevents both spurious and missed notifications.
- **Causal delivery order**: deferred subscribers are inserted, first errors arbitrated, and onChange entries attributed in reaching-group order — an inherited-first selector keeps its historical position before the store's own-atom entries (exact orders test-locked).
- **Global peers** ride the settlement, so every cross-scope commit — with or without globals — runs exactly one `runCommitPlan` (gate-enforced). A peer that is itself a plan store folds into that store's single settlement (its reports keep the global sink's direct-set metadata); only peers outside the plan keep the per-tree pass.
- **Error containment**: per-store visits split into collection/settlement/assembly phases, so a throwing selector body, custom equal, onMount cleanup, or unset report can never starve an affected descendant scope.
- Deliberate edge-case fix (changeset-recorded): an unset-report failure during a cross-scope commit now records into first-error commit arbitration instead of escaping raw.

## Deterministic evaluation-count changes

| Gate | Before | After |
|---|---|---|
| Depth-3 cross-scope: evals / dup settlements / store passes | 3 / 2 / 3 | 1 / 0 / 1 (+ `commitPlanRuns: 1`) |
| Union across update+delete+unset (new gate) | — | 1 / 0 / 1 |
| Plan/peer-overlap global (new gate) | — | 1 / 0 / 1 |
| `dd-sum`, `dd2-a/b` inline gates | 2 | 1 |
| Async cross-scope spanning selector (bodies + promises per commit) | 2 | 1 |
| `ud-span` / `cud-span` (single-store commits — path untouched) | 2 | 2 |

## New coverage

Shadow removal (`unset`/`reset`) inside cross-scope txns incl. root-set + scope-unset of the same atom; equality-provenance regressions (group membership, reaching-only groups, lazily-initialized atoms); causal subscriber/onChange/first-error ordering; exact onChange payload orders; error continuation with an untouched descendant scope; nested-scope rollback; cross-scope adapter abort; depth-3 + set-plus-unset oracle traces; scope-unset ops in the cross-scope fuzz oracle.

## Verification

- valdres suite 1068 pass / 0 fail (trace oracle, invariant checker, all three fuzzers, import-cycle baseline unchanged)
- 11/11 deterministic architecture gates; `typecheck:types`, `build`, `build:types` clean
- Retained-memory gates: Bun 8/8, Node 8/8 (deep cross-scope 23.0 KB/unit vs 30 KB ceiling)
- Benches vs same-machine main run: cross-scope depth-8 ~30 µs → ~21 µs (Bun) / ~19 µs (Node); single-store lanes at parity; valdres remains ahead of Jotai on the Node large-DAG head-to-head
- `docs:build` + `gen-readmes --check` clean; `valdres` patch changeset included

## Notes for reviewers

- The Bun retained-memory ceiling for "single-store transactions" is recalibrated 200 → 360 B/unit with evidence documented in `architecture.memory.ts` + `ARCHITECTURE_PERFORMANCE.md`: adding a never-called function to a pristine `commitEngine.ts` alone moves JSC's measurement 157 → 229 B/unit while the Node/V8 lane is byte-identical at 85 B/unit (code-layout sensitivity, not retention).
- Remaining for the global fan-out migration (next prompt): the single-store global adapters (`commitCleanupWithGlobalFanOut`, `finishAtomSet`, `setAtoms` legacy arm, `settleGlobalAtomSet`) and peer-side settlement granularity — non-plan peers still settle via per-tree `propagateAtomUpdate` inside the settle fn, which was structured for later peer reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)