### PR TITLE
refactor(valdres): own dependency-graph mutation behind an internal GraphRuntime boundary

### DIFF
--- a/.changeset/graph-runtime-boundary.md
+++ b/.changeset/graph-runtime-boundary.md
@@ -1,0 +1,19 @@
+---
+"valdres": patch
+---
+
+Move every write to the dependency-graph tables behind an internal
+GraphRuntime boundary (`src/lib/graph/`): forward/reverse edges and
+dependency replacement, scope-branch registration, liveness counters and
+mount reachability, cycle metadata, orphan-edge cleanup, and the
+installation of dependencies discovered by async evaluation. Selector
+evaluators no longer mutate graph state — they report discovered
+dependencies through a pooled evaluation-outcome carrier and the dispatcher
+that ran them installs the result, so evaluation and graph bookkeeping are
+now separable phases with documented invariants at each boundary.
+
+Internal-only: no public API, semantics, or ordering changes. The core
+write-path import cycle shrinks from 24 modules to 9 and the
+`mountAtom ↔ storeFromStoreData` cycle is gone, guarded by a new
+type-checker-based table-ownership scan and stricter import-boundary tests
+alongside the existing cycle ratchet.

--- a/packages/valdres/src/lib/asyncDependencyTracking.ts
+++ b/packages/valdres/src/lib/asyncDependencyTracking.ts
@@ -1,17 +1,5 @@
-import type { Atom } from "../types/Atom"
 import type { Selector } from "../types/Selector"
-import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
-import { getState } from "./getState"
-import { addStateDependent } from "./inheritedDependencyBranches"
-import {
-    activateSelectorGraph,
-    isLive,
-    mountTransitiveDeps,
-    noteDependencyAdded,
-    onLiveDependencyAdded,
-} from "./mountAtom"
-import { noteDependencyGraphChanged } from "./noteDependencyGraphChanged"
 import { noteStateValueChanged } from "./stateRevisions"
 
 export class SuspendAndWaitForResolveError extends Error {
@@ -28,59 +16,6 @@ export const isSuspendError = (
     e: unknown,
 ): e is { promise: Promise<any> } => {
     return e instanceof SuspendAndWaitForResolveError
-}
-
-/**
- * Handle a deferred `get` call — one that runs after the synchronous
- * evaluation of the selector has already completed (e.g. inside a
- * setTimeout or after an await). Registers the dependency, mounts it
- * if the selector is transitively subscribed, and returns the value.
- */
-export const lateGet = (
-    state: State,
-    selector: Selector,
-    data: StoreData,
-) => {
-    // Register dependency
-    let deps = data.stateDependencies.get(selector)
-    if (!deps) {
-        deps = new Set()
-        data.stateDependencies.set(selector, deps)
-    }
-    const isNewDep = !deps.has(state)
-    if (isNewDep) {
-        deps.add(state)
-        if (data.selectorGraphActive.has(selector)) {
-            noteDependencyGraphChanged(selector, data)
-            addStateDependent(state, selector, data)
-            // New edge: keep the mount-closure marker's no-false-negative invariant.
-            noteDependencyAdded(selector, state, data)
-        } else {
-            // The dependency list no longer aligns with the cold cache's
-            // revision array. Force validation/re-evaluation on the next read.
-            const cache = data.coldSelectorCaches.get(selector)
-            if (cache) cache.validatedAt = -1
-        }
-    }
-
-    // Get the value (may throw for error-throwing selectors).
-    // Atoms lazily initialized here are first-time accesses — no other
-    // selector depends on them yet, so propagation is unnecessary.
-    const lateInitSet = new Set<Atom>()
-    try {
-        return getState(state, data, lateInitSet)
-    } finally {
-        // Validate/read a cold selector before promoting its dependency graph;
-        // promotion deliberately bypasses cold-cache validation thereafter.
-        if (isNewDep && data.selectorGraphActive.has(selector)) {
-            activateSelectorGraph(state, data)
-            // Mount new dependencies if the selector is live.
-            if (isLive(selector, data)) {
-                onLiveDependencyAdded(state, data)
-                mountTransitiveDeps(state, data)
-            }
-        }
-    }
 }
 
 export const cleanUpRejectedPromise = <Value>(

--- a/packages/valdres/src/lib/disposeStoreData.ts
+++ b/packages/valdres/src/lib/disposeStoreData.ts
@@ -1,12 +1,16 @@
 import type { InternalGlobalAtom } from "../types/InternalGlobalAtom"
 import type { StoreData } from "../types/StoreData"
-import { detachInheritedDependencyBranches } from "./inheritedDependencyBranches"
-import { unmountAtom } from "./mountAtom"
+import {
+    detachInheritedDependencyBranches,
+    dropQueuedOrphanWork,
+    resetLivenessScratch,
+    sealGraphForDisposal,
+    unmountAtom,
+} from "./graph"
 import { commitEndRegistry } from "./onCommitEnd"
 import { changeListenerRegistry } from "./notifyChangeListeners"
 import { unsubscribe } from "./unsubscribe"
 import {
-    DISPOSED_STORE_PENDING,
     getStoreDisposedErrorToken,
     getTouchedGlobals,
     markStoreDisposed,
@@ -40,9 +44,7 @@ export const disposeStoreData = (data: StoreData): void => {
         const touched = getTouchedGlobals(current)
         if (touched?.size) globalsByStore.push([current, [...touched]])
         markStoreDisposed(current, disposalToken)
-        // Reuse the existing public-operation orphan guard as the terminal
-        // facade marker. This also replaces and releases any queued roots.
-        current.pendingOrphanCleanup = DISPOSED_STORE_PENDING
+        sealGraphForDisposal(current)
 
         // Unlink scopes while their scopeIndexKeys are still available. This is
         // also what the ref-counted ScopedStore.detach() path needs to release.
@@ -91,7 +93,7 @@ export const disposeStoreData = (data: StoreData): void => {
         // roots now; the already-enqueued microtask observes the terminal marker
         // and becomes a no-op. Batched transactions, maxAge timers, onChange,
         // and onCommitEnd own tracked cleanup entries below.
-        current.orphanCleanupScheduled = false
+        dropQueuedOrphanWork(current)
 
         const transactions = takeStoreTransactions(current)
         if (transactions) {
@@ -170,12 +172,7 @@ export const disposeStoreData = (data: StoreData): void => {
             }
         }
 
-        // These are transient scratch owners rather than external resources,
-        // but clearing them releases any strong states immediately.
-        current.livenessPassActive = false
-        current.livenessSeeds = undefined
-        current.livenessRemovalArmed = false
-        current.livenessLazyArmed = false
+        resetLivenessScratch(current)
     }
 
     // Defensive counter repair for lifecycle entries created by raw internal

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -12,6 +12,9 @@ import { isSelector } from "../utils/isSelector"
 import { createScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_SKIP_FAMILY_INDEX } from "./commitIntents"
+import {
+    clearStaleSelectorActivation,
+} from "./graph"
 import { hasAtomCommitObservers } from "./hasAtomCommitObservers"
 import { initAtom } from "./initAtom"
 import { initSelector } from "./initSelector"
@@ -364,13 +367,13 @@ export function getState<
         return data.values.get(state)
     }
     if (isSelector<Value>(state)) {
-        // Orphan cleanup may leave the weak active marker behind to keep
-        // teardown cheap. With no forward graph this is a fresh read, not a
-        // live re-evaluation, so clear the stale marker before selecting the
-        // evaluation mode. Fresh live subscriptions bypass this path and call
-        // initFreshActiveSelector directly.
+        // Fresh live subscriptions bypass this path and call
+        // initFreshActiveSelector directly; a graph-less read must first shed
+        // any stale active marker left behind by cheap orphan teardown. The
+        // presence CHECK is a plain read (unrestricted); only the rare stale
+        // path crosses into the graph runtime to write.
         if (!data.stateDependencies.has(state)) {
-            data.selectorGraphActive.delete(state)
+            clearStaleSelectorActivation(state, data)
         }
         initSelector<Value>(
             state,

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -10,7 +10,11 @@ import type { StoreData } from "./../types/StoreData"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors, recordCommitError } from "./commitErrors"
 import { globalOnSetMarker } from "./globalOnSetMarker"
-import { isLive, mountAtom, unmountAtom } from "./mountAtom"
+import {
+    isLive,
+    mountAtom,
+    unmountAtom,
+} from "./graph"
 import { settleCommitForest } from "./propagateUpdatedAtoms"
 import { installMaxAgeTimer } from "./subscribe"
 import { detachOwnValue } from "./unsetValue"

--- a/packages/valdres/src/lib/graph/cleanupOrphanedDeps.ts
+++ b/packages/valdres/src/lib/graph/cleanupOrphanedDeps.ts
@@ -1,10 +1,10 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
-import type { Selector } from "../types/Selector"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+import type { Selector } from "../../types/Selector"
 import { removeStateDependent } from "./inheritedDependencyBranches"
 import { isLive } from "./mountAtom"
-import { noteStateValueChanged } from "./stateRevisions"
-import { untrackAbortController } from "./storeLifecycle"
+import { noteStateValueChanged } from "../stateRevisions"
+import { untrackAbortController } from "../storeLifecycle"
 
 /**
  * Remove non-live states from the dependency graph, clear selector caches, and

--- a/packages/valdres/src/lib/graph/evaluationOutcome.ts
+++ b/packages/valdres/src/lib/graph/evaluationOutcome.ts
@@ -1,0 +1,69 @@
+import type { State } from "../../types/State"
+
+/**
+ * What one selector evaluation discovered, handed from the evaluator to the
+ * graph installer by the dispatcher that ran it. Evaluators fill every field
+ * exactly once, immediately before returning — never during dependency
+ * capture — and never touch graph tables themselves; whoever ran the
+ * evaluator installs the outcome (or skips the call when `needsInstall` is
+ * false) and releases the carrier.
+ */
+export type EvaluationOutcome = {
+    /** Deduped deps read this evaluation. Escapes into stateDependencies on
+     *  sync installs, so it is allocated per evaluation (status quo). */
+    deps: Set<State> | undefined
+    /** Dependency set observed at evaluation start (committed table or the
+     *  transaction overlay map). Undefined = first materialization. */
+    prevDeps: Set<State> | undefined
+    depsChanged: boolean
+    /** Result was promise-like or a suspension — install merges prevDeps
+     *  forward instead of removing them (reconciled on resolve). */
+    isAsync: boolean
+    /** = depsChanged || !prevDeps. False on the no-churn steady state, which
+     *  therefore makes zero graph-runtime calls. */
+    needsInstall: boolean
+}
+
+export const createEvaluationOutcome = (): EvaluationOutcome => ({
+    deps: undefined,
+    prevDeps: undefined,
+    depsChanged: false,
+    isAsync: false,
+    needsInstall: false,
+})
+
+/**
+ * Depth-indexed carrier pool for the dispatcher paths, where evaluations
+ * recurse (a selector body reading a fresh child selector re-enters the
+ * dispatcher mid-capture): each frame takes its own slot, and allocation
+ * happens only at the high-water depth mark. Callers MUST release in a
+ * `finally` so a throwing evaluation or install unwinds the depth, and must
+ * consume the outcome before running anything that could evaluate another
+ * selector (release does both: it clears the dep references so the pool
+ * retains no states, and pops the frame).
+ *
+ * The propagation loops instead own one plain carrier per PASS (like their
+ * reusable DepsChange) via `createEvaluationOutcome` — no pool traffic on the
+ * re-evaluation hot path.
+ */
+const pool: EvaluationOutcome[] = []
+let depth = 0
+
+export const acquireEvaluationOutcome = (): EvaluationOutcome => {
+    let outcome = pool[depth]
+    if (!outcome) {
+        outcome = createEvaluationOutcome()
+        pool[depth] = outcome
+    }
+    depth++
+    // An evaluator that throws never writes the carrier; the dispatcher's
+    // install gate must then read a definite false, not a stale true.
+    outcome.needsInstall = false
+    return outcome
+}
+
+export const releaseEvaluationOutcome = (outcome: EvaluationOutcome): void => {
+    outcome.deps = undefined
+    outcome.prevDeps = undefined
+    depth--
+}

--- a/packages/valdres/src/lib/graph/flushPendingOrphanCleanup.ts
+++ b/packages/valdres/src/lib/graph/flushPendingOrphanCleanup.ts
@@ -1,7 +1,7 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
 import { cleanupOrphanedDeps } from "./cleanupOrphanedDeps"
-import { DISPOSED_STORE_PENDING } from "./storeLifecycle"
+import { DISPOSED_STORE_PENDING } from "../storeLifecycle"
 
 /**
  * Drain this store's queued orphan roots synchronously. Public store operations

--- a/packages/valdres/src/lib/graph/index.ts
+++ b/packages/valdres/src/lib/graph/index.ts
@@ -1,0 +1,98 @@
+/**
+ * The dependency-graph runtime: the single owner of every WRITE to the graph
+ * tables on StoreData —
+ *
+ *   stateDependencies / stateDependents      forward/reverse edges + replacement
+ *   selectorGraphActive                      cold→live promotion markers
+ *   inheritedDependencyBranches(+Keys)       scope-branch registration
+ *   liveDependentCount / mounts /            liveness + mount reachability, and
+ *     mountInClosure, livenessPassActive/      the liveness-pass scratch
+ *     livenessSeeds/livenessRemovalArmed/
+ *     livenessLazyArmed
+ *   dependencyOrder / nextDependencyOrder /  cycle metadata: stable order,
+ *     dependencyGraphVersion /                 topology generation, risk marker,
+ *     cycleRiskInClosure /                     memoized acyclic proofs
+ *     acyclicDependencyVersion
+ *   orphanCleanupVersion /                   orphan-edge cleanup plane
+ *     pendingOrphanCleanup /
+ *     orphanCleanupScheduled
+ *
+ * Non-graph modules may READ these tables freely (hot paths depend on it) and
+ * may compare `pendingOrphanCleanup` against DISPOSED_STORE_PENDING, but every
+ * write goes through a function exported from this facade — enforced by
+ * test/import-cycles/graphBoundary.test.ts, which also pins that graph modules
+ * import only graph siblings plus a fixed leaf allowlist, keeping this cluster
+ * outside every import cycle (the commitEngine "leaf by injection" pattern).
+ * The one deliberate carve-out is the transaction overlay
+ * (SelectorEvaluationRuntime): its private forward map mirrors this shape but
+ * is evaluation-session state owned by the draft, never the committed graph.
+ *
+ * Invariants owned here:
+ * - Edge CONSTRUCTION bumps dependencyGraphVersion (noteDependencyGraphChanged);
+ *   orphan-teardown edge DELETION deliberately does not, preserving memoized
+ *   acyclic proofs across an unsubscribe burst. Do not "fix" the asymmetry.
+ *   (The async-deps reconcile bumps once per reconcile — existing behavior.)
+ * - Phase model for consumers: after an install* call the edge TOPOLOGY
+ *   (symmetric edges, order, scope branches) is consistent, but liveness and
+ *   mounts may still be pending until applyLiveDependencyDiff or the owning
+ *   liveness pass (endLivenessPass + reconcileLivenessAfterChurn) settles
+ *   them; full store invariants hold at those settled boundaries, after
+ *   reconcileAsyncDeps, and after completed disposal.
+ *
+ * Sanctioned cross-plane effects (the boundary is "one writing owner for
+ * graph tables", not "graph code touches nothing else"):
+ * - activateSelectorGraph deletes coldSelectorCaches entries — cold→live
+ *   promotion consumes the cold plane.
+ * - installLateDependency invalidates a cold cache (validatedAt = -1) when a
+ *   new async edge desynchronizes it.
+ * - cleanupOrphanedDeps deletes orphaned states' entries from values,
+ *   coldSelectorCaches, and latestEvalContext, and aborts + untracks their
+ *   controllers: delete-only teardown of the planes it orphans, never inserts.
+ * - The store facade for user onMount hooks resolves through the leaf
+ *   getStoreRuntime slot; iterable mount ledgers go through storeLifecycle.
+ *
+ * A follow-up may split StoreData into a read-only view for ordinary modules
+ * and a mutable graph-only type; today the static boundary test carries that
+ * guarantee without retyping every module.
+ */
+
+export {
+    beginLivenessPass,
+    endLivenessPass,
+    isLive,
+    mountAtom,
+    mountTransitiveDeps,
+    onFirstDirectSubscriber,
+    onLastDirectSubscriber,
+    reconcileLivenessAfterChurn,
+    regionHasCycle,
+    unmountAtom,
+    unmountOrphanedDeps,
+} from "./mountAtom"
+export {
+    detachInheritedDependencyBranches,
+    hasInheritedDependencyBranches,
+    refreshInheritedDependencyBranch,
+} from "./inheritedDependencyBranches"
+export { queueOrphanCleanup } from "./queueOrphanCleanup"
+export { flushPendingOrphanCleanup } from "./flushPendingOrphanCleanup"
+export {
+    acquireEvaluationOutcome,
+    createEvaluationOutcome,
+    releaseEvaluationOutcome,
+    type EvaluationOutcome,
+} from "./evaluationOutcome"
+export {
+    applyLiveDependencyDiff,
+    clearStaleSelectorActivation,
+    dropQueuedOrphanWork,
+    installEvaluationDeps,
+    installEvaluationDepsLiveOnly,
+    installLateDependency,
+    markSelectorGraphActive,
+    reconcileAsyncDeps,
+    resetLivenessScratch,
+    rollbackSelectorActivation,
+    sealGraphForDisposal,
+    settleLateDependency,
+} from "./runtime"

--- a/packages/valdres/src/lib/graph/inheritedDependencyBranches.ts
+++ b/packages/valdres/src/lib/graph/inheritedDependencyBranches.ts
@@ -1,7 +1,7 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
-import { isAtom } from "../utils/isAtom"
-import { isAtomFamily } from "../utils/isAtomFamily"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+import { isAtom } from "../../utils/isAtom"
+import { isAtomFamily } from "../../utils/isAtomFamily"
 
 /** Only atoms and atom families read through a scope boundary. Selectors are
  * evaluated per store, so their reverse edges never belong in the branch index. */

--- a/packages/valdres/src/lib/graph/mountAtom.ts
+++ b/packages/valdres/src/lib/graph/mountAtom.ts
@@ -1,14 +1,14 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
-import { isSelector } from "../utils/isSelector"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+import { isSelector } from "../../utils/isSelector"
 import { addStateDependent } from "./inheritedDependencyBranches"
 import { noteDependencyGraphChanged } from "./noteDependencyGraphChanged"
-import { storeFromStoreData } from "./storeFromStoreData"
+import { getStoreRuntime } from "../getStoreRuntime"
 import {
     isStoreDisposed,
     trackStoreMount,
     untrackStoreMount,
-} from "./storeLifecycle"
+} from "../storeLifecycle"
 
 // Shared immutable empty set — a missing stateDependencies entry (atoms and
 // atom-family members are graph sinks) yields a zero-length iterator without
@@ -546,7 +546,7 @@ export const mountAtom = (state: State, data: StoreData) => {
         data.mounts.delete(state)
         return
     }
-    const store = storeFromStoreData(data)
+    const store = getStoreRuntime(data)
     try {
         const result = onMountFn(store, state)
         if (typeof result === "function") {

--- a/packages/valdres/src/lib/graph/noteDependencyGraphChanged.ts
+++ b/packages/valdres/src/lib/graph/noteDependencyGraphChanged.ts
@@ -1,5 +1,5 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
 
 /**
  * Invalidate topology-sensitive teardown caches after graph construction or

--- a/packages/valdres/src/lib/graph/queueOrphanCleanup.ts
+++ b/packages/valdres/src/lib/graph/queueOrphanCleanup.ts
@@ -1,7 +1,7 @@
-import type { State } from "../types/State"
-import type { StoreData } from "../types/StoreData"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
 import { flushPendingOrphanCleanup } from "./flushPendingOrphanCleanup"
-import { isStoreDisposed } from "./storeLifecycle"
+import { isStoreDisposed } from "../storeLifecycle"
 
 /**
  * Batch orphan graph/value cleanup across a synchronous unsubscribe burst.

--- a/packages/valdres/src/lib/graph/runtime.test.ts
+++ b/packages/valdres/src/lib/graph/runtime.test.ts
@@ -1,0 +1,528 @@
+import { describe, expect, test } from "bun:test"
+import { atom } from "../../atom"
+import { selector } from "../../selector"
+import { store } from "../../store"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+import type { DepsChange } from "../../types/DepsChange"
+import { checkStoreInvariants } from "../../../test/invariants/checkStoreInvariants"
+import { getStoreData } from "../getStoreData"
+import {
+    acquireEvaluationOutcome,
+    releaseEvaluationOutcome,
+} from "./evaluationOutcome"
+import { addStateDependent } from "./inheritedDependencyBranches"
+import { beginLivenessPass, endLivenessPass } from "./mountAtom"
+import {
+    applyLiveDependencyDiff,
+    installEvaluationDeps,
+    installEvaluationDepsLiveOnly,
+} from "./runtime"
+
+const names = new Map<State, string>()
+const label = (state: State) => names.get(state) ?? "?"
+
+const makeStates = () => {
+    const a = atom(1)
+    const b = atom(2)
+    const c = atom(3)
+    const sel = selector(get => get(a) + get(b))
+    names.set(a, "a").set(b, "b").set(c, "c").set(sel, "sel")
+    return { a, b, c, sel }
+}
+
+/** Raw graph-table snapshot for the states under test, for twin comparison. */
+const snapshot = (data: StoreData, states: State[]) => ({
+    deps: states.map(
+        state =>
+            `${label(state)}:${[...(data.stateDependencies.get(state) ?? [])]
+                .map(label)
+                .sort()
+                .join(",")}`,
+    ),
+    dependents: states.map(
+        state =>
+            `${label(state)}:${[...(data.stateDependents.get(state) ?? [])]
+                .map(label)
+                .sort()
+                .join(",")}`,
+    ),
+    seeds: [...((data.livenessSeeds as Set<State>) ?? [])].map(label).sort(),
+    lazyArmed: !!data.livenessLazyArmed,
+    removalArmed: !!data.livenessRemovalArmed,
+})
+
+describe("installer twin parity", () => {
+    // installEvaluationDepsLiveOnly is a monomorphic twin of
+    // installEvaluationDeps with tracksReverseEdges=true on a store that has
+    // never built a cold cache. The two must produce identical graph tables
+    // for every shape, or the twins have semantically drifted.
+    const shapes: {
+        name: string
+        prev?: (states: ReturnType<typeof makeStates>) => State[]
+        next: (states: ReturnType<typeof makeStates>) => State[]
+        isAsync: boolean
+        livenessPass?: boolean
+    }[] = [
+        { name: "first materialization", next: s => [s.a, s.b], isAsync: false },
+        {
+            name: "re-eval add+remove",
+            prev: s => [s.a, s.b],
+            next: s => [s.b, s.c],
+            isAsync: false,
+            livenessPass: true,
+        },
+        {
+            name: "async merge-forward keeps previous deps",
+            prev: s => [s.a],
+            next: s => [s.b],
+            isAsync: true,
+            livenessPass: true,
+        },
+        {
+            name: "empty re-materialization",
+            prev: s => [s.a],
+            next: () => [],
+            isAsync: false,
+            livenessPass: true,
+        },
+    ]
+
+    for (const shape of shapes) {
+        test(shape.name, () => {
+            const states = makeStates()
+            const all = [states.a, states.b, states.c, states.sel]
+            const mixed = getStoreData(store())
+            const liveOnly = getStoreData(store())
+            for (const data of [mixed, liveOnly]) {
+                if (shape.prev) {
+                    const prev = new Set(shape.prev(states))
+                    data === mixed
+                        ? installEvaluationDeps(
+                              states.sel,
+                              data,
+                              prev,
+                              undefined,
+                              true,
+                              false,
+                              undefined,
+                          )
+                        : installEvaluationDepsLiveOnly(
+                              states.sel,
+                              data,
+                              prev,
+                              undefined,
+                              false,
+                          )
+                }
+                if (shape.livenessPass) beginLivenessPass(data)
+                const next = new Set(shape.next(states))
+                data === mixed
+                    ? installEvaluationDeps(
+                          states.sel,
+                          data,
+                          next,
+                          data.stateDependencies.get(states.sel),
+                          true,
+                          shape.isAsync,
+                          undefined,
+                      )
+                    : installEvaluationDepsLiveOnly(
+                          states.sel,
+                          data,
+                          next,
+                          data.stateDependencies.get(states.sel),
+                          shape.isAsync,
+                      )
+            }
+            expect(snapshot(mixed, all)).toEqual(snapshot(liveOnly, all))
+            if (shape.livenessPass) {
+                endLivenessPass(mixed)
+                endLivenessPass(liveOnly)
+            }
+        })
+    }
+
+    test("first-materialization install merges an interval-created forward set", () => {
+        // A deferred `get` running between capture and install (then-getter)
+        // creates the selector's forward set through installLateDependency.
+        // Both installer twins must merge it rather than overwrite it.
+        const runFor = (liveOnly: boolean) => {
+            const states = makeStates()
+            const data = getStoreData(store())
+            data.stateDependencies.set(states.sel, new Set([states.c]))
+            addStateDependent(states.c, states.sel, data)
+            liveOnly
+                ? installEvaluationDepsLiveOnly(
+                      states.sel,
+                      data,
+                      new Set([states.a]),
+                      undefined,
+                      true,
+                  )
+                : installEvaluationDeps(
+                      states.sel,
+                      data,
+                      new Set([states.a]),
+                      undefined,
+                      true,
+                      true,
+                      undefined,
+                  )
+            const forward = [...data.stateDependencies.get(states.sel)!]
+                .map(label)
+                .sort()
+            expect(forward).toEqual(["a", "c"])
+            expect(data.stateDependents.get(states.c)?.has(states.sel)).toBe(
+                true,
+            )
+            expect(data.stateDependents.get(states.a)?.has(states.sel)).toBe(
+                true,
+            )
+        }
+        runFor(false)
+        runFor(true)
+    })
+
+    test("the propagation diff suppresses the lazy arm; its absence arms it", () => {
+        const states = makeStates()
+        const data = getStoreData(store())
+        installEvaluationDeps(
+            states.sel,
+            data,
+            new Set([states.a]),
+            undefined,
+            true,
+            false,
+            undefined,
+        )
+        beginLivenessPass(data)
+        const depsChange: DepsChange = {}
+        installEvaluationDeps(
+            states.sel,
+            data,
+            new Set([states.b]),
+            data.stateDependencies.get(states.sel),
+            true,
+            false,
+            depsChange,
+        )
+        // Loop-driven re-eval: the diff is exported, the lazy arm stays off.
+        expect([...depsChange.added!].map(label)).toEqual(["b"])
+        expect([...depsChange.removed!].map(label)).toEqual(["a"])
+        expect(data.livenessLazyArmed).toBe(false)
+        // Removed selector deps would arm removal; a removed ATOM must not.
+        expect(data.livenessRemovalArmed).toBe(false)
+        endLivenessPass(data)
+
+        beginLivenessPass(data)
+        installEvaluationDeps(
+            states.sel,
+            data,
+            new Set([states.c]),
+            data.stateDependencies.get(states.sel),
+            true,
+            false,
+            undefined,
+        )
+        // Lazy re-init (no diff consumer): the reconcile must arm.
+        expect(data.livenessLazyArmed).toBe(true)
+        endLivenessPass(data)
+    })
+})
+
+describe("evaluation outcome pool", () => {
+    test("nested acquires get distinct slots; release restores depth", () => {
+        const outer = acquireEvaluationOutcome()
+        const inner = acquireEvaluationOutcome()
+        expect(inner).not.toBe(outer)
+        releaseEvaluationOutcome(inner)
+        const innerAgain = acquireEvaluationOutcome()
+        expect(innerAgain).toBe(inner)
+        releaseEvaluationOutcome(innerAgain)
+        releaseEvaluationOutcome(outer)
+        const outerAgain = acquireEvaluationOutcome()
+        expect(outerAgain).toBe(outer)
+        releaseEvaluationOutcome(outerAgain)
+    })
+
+    test("release clears dep references; acquire resets the install gate", () => {
+        const outcome = acquireEvaluationOutcome()
+        outcome.deps = new Set([atom(1)])
+        outcome.prevDeps = new Set([atom(2)])
+        outcome.needsInstall = true
+        releaseEvaluationOutcome(outcome)
+        // The pooled slot must not pin any state after release (retention).
+        expect(outcome.deps).toBeUndefined()
+        expect(outcome.prevDeps).toBeUndefined()
+        // A throwing evaluator never writes the carrier — the next acquire
+        // must present a definite false to the dispatcher's install gate.
+        const again = acquireEvaluationOutcome()
+        expect(again.needsInstall).toBe(false)
+        releaseEvaluationOutcome(again)
+    })
+
+    test("deep fresh-selector recursion evaluates through nested carriers", () => {
+        const base = atom(1)
+        const chain = [selector(get => get(base) + 1)]
+        for (let i = 1; i < 24; i++) {
+            const previous = chain[i - 1]!
+            chain.push(selector(get => get(previous) + 1))
+        }
+        const s = store()
+        const top = chain[chain.length - 1]!
+        const seen: number[] = []
+        s.sub(top, () => seen.push(s.get(top)))
+        expect(s.get(top)).toBe(25)
+        s.set(base, 2)
+        expect(seen).toEqual([26])
+        expect(checkStoreInvariants(s, { states: [base, ...chain] })).toEqual(
+            [],
+        )
+    })
+
+    test("a throwing evaluator releases its carrier for the next evaluation", () => {
+        const flag = atom(true)
+        const boom = selector(get => {
+            if (get(flag)) throw new Error("boom")
+            return "ok"
+        })
+        const s = store()
+        expect(() => s.get(boom)).toThrow()
+        expect(() => s.get(boom)).toThrow()
+        s.set(flag, false)
+        expect(s.get(boom)).toBe("ok")
+        expect(checkStoreInvariants(s, { states: [flag, boom] })).toEqual([])
+    })
+
+    test("steady-state re-evaluation installs nothing", () => {
+        const a = atom(1)
+        const b = atom(2)
+        const sum = selector(get => get(a) + get(b))
+        const s = store()
+        const data = getStoreData(s)
+        s.sub(sum, () => {})
+        expect(s.get(sum)).toBe(3)
+        const versionAfterInit = data.dependencyGraphVersion
+        s.set(a, 10)
+        expect(s.get(sum)).toBe(12)
+        // Same dep set → needsInstall false → no graph-runtime call, so the
+        // topology generation is untouched.
+        expect(data.dependencyGraphVersion).toBe(versionAfterInit)
+    })
+
+    test("consecutive stores keep independent graphs through one pool", () => {
+        const a = atom(1)
+        const sel = selector(get => get(a) * 2)
+        const s1 = store()
+        const s2 = store()
+        s1.sub(sel, () => {})
+        expect(s1.get(sel)).toBe(2)
+        s2.set(a, 5)
+        expect(s2.get(sel)).toBe(10)
+        expect(s1.get(sel)).toBe(2)
+        const d1 = getStoreData(s1)
+        const d2 = getStoreData(s2)
+        expect(d1.stateDependents.get(a)?.has(sel)).toBe(true)
+        expect([...(d2.stateDependencies.get(sel) ?? [])]).toEqual([a])
+    })
+
+    test("transaction overlay evaluation leaves the committed graph untouched", () => {
+        const a = atom(1)
+        const doubled = selector(get => get(a) * 2)
+        const s = store()
+        const data = getStoreData(s)
+        s.txn(tx => {
+            tx.set(a, 21)
+            expect(tx.get(doubled)).toBe(42)
+        })
+        // The overlay's private forward map carried the txn read; the
+        // committed reverse graph never saw the selector.
+        expect(data.stateDependents.get(a)?.has(doubled) ?? false).toBe(false)
+        expect(s.get(doubled)).toBe(42)
+    })
+})
+
+describe("late dependency install", () => {
+    test("a dependency read twice after await settles liveness exactly once", async () => {
+        const dep = atom(2)
+        const sel = selector(get =>
+            (async () => {
+                await Promise.resolve()
+                const first = get(dep)
+                await Promise.resolve()
+                const second = get(dep)
+                return first + second
+            })(),
+        )
+        const s = store()
+        const data = getStoreData(s)
+        s.sub(sel, () => {})
+        await s.get(sel)
+        // Second read is an existing edge: install returns false and the
+        // settle half must not run again — a double settle would count the
+        // same edge twice.
+        expect(data.liveDependentCount.get(dep)).toBe(1)
+        expect(checkStoreInvariants(s, { quiescent: true })).toEqual([])
+    })
+
+    test("a genuinely new post-await dependency mounts and counts once", async () => {
+        let mounts = 0
+        let cleanups = 0
+        const dep = atom(7, {
+            onMount: () => {
+                mounts++
+                return () => {
+                    cleanups++
+                }
+            },
+        })
+        const sel = selector(get =>
+            (async () => {
+                await Promise.resolve()
+                return get(dep) * 3
+            })(),
+        )
+        const s = store()
+        const data = getStoreData(s)
+        const unsub = s.sub(sel, () => {})
+        expect(await s.get(sel)).toBe(21)
+        expect(data.liveDependentCount.get(dep)).toBe(1)
+        expect(mounts).toBe(1)
+        unsub()
+        await Promise.resolve()
+        expect(cleanups).toBe(1)
+        expect(
+            checkStoreInvariants(s, { states: [dep, sel], quiescent: true }),
+        ).toEqual([])
+    })
+
+    test("a then-getter's deferred get cannot strand asymmetric edges", async () => {
+        // A returned promise's user-visible `then` is probed on the way to
+        // settlement. A getter there can run the captured `get` in the
+        // capture-to-install window; the installed dependency set must not
+        // overwrite (and thereby orphan) the reverse edge lateGet created.
+        const dep = atom(1)
+        let capturedGet: ((state: State) => unknown) | undefined
+        let thenReads = 0
+        const sel = selector((get: any) => {
+            capturedGet = get
+            const promise = Promise.resolve(41)
+            const realThen = promise.then.bind(promise)
+            Object.defineProperty(promise, "then", {
+                get() {
+                    thenReads++
+                    if (thenReads === 2) capturedGet!(dep)
+                    return realThen
+                },
+            })
+            return promise
+        })
+        const s = store()
+        const data = getStoreData(s)
+        const unsub = s.sub(sel, () => {})
+        await s.get(sel)
+        await Promise.resolve()
+        expect(thenReads).toBeGreaterThanOrEqual(2)
+        // Symmetry: any reverse edge must have its forward twin.
+        const forward = data.stateDependencies.get(sel)
+        const reverse = data.stateDependents.get(dep)
+        if (reverse?.has(sel)) {
+            expect(forward?.has(dep)).toBe(true)
+        }
+        expect(
+            checkStoreInvariants(s, { states: [dep, sel], quiescent: true }),
+        ).toEqual([])
+        unsub()
+        await Promise.resolve()
+        expect(data.stateDependents.get(dep)?.has(sel) ?? false).toBe(false)
+        expect(
+            checkStoreInvariants(s, { quiescent: true }),
+        ).toEqual([])
+    })
+
+    test("a throwing dependency read still records the new edge", async () => {
+        const boom = selector((): number => {
+            throw new Error("late boom")
+        })
+        const sel = selector(get =>
+            (async () => {
+                await Promise.resolve()
+                return get(boom)
+            })(),
+        )
+        const s = store()
+        const data = getStoreData(s)
+        s.sub(sel, () => {})
+        await expect(s.get(sel)).rejects.toThrow()
+        expect(data.stateDependencies.get(sel)?.has(boom)).toBe(true)
+    })
+})
+
+describe("invariant phase boundaries", () => {
+    test("topology-only install settles fully after the dependency diff", () => {
+        const a = atom(1)
+        const b = atom(2)
+        const sum = selector(get => get(a) + get(b))
+        const s = store()
+        const data = getStoreData(s)
+        s.sub(sum, () => {})
+        expect(s.get(sum)).toBe(3)
+
+        // Simulate a propagation-loop re-evaluation that discovered a new
+        // dependency: install the topology first, exactly as the dispatcher
+        // does, with the liveness diff still pending.
+        const c = atom(5)
+        beginLivenessPass(data)
+        const depsChange: DepsChange = {}
+        installEvaluationDeps(
+            sum,
+            data,
+            new Set<State>([a, b, c]),
+            data.stateDependencies.get(sum),
+            true,
+            false,
+            depsChange,
+        )
+
+        // Phase 2 — topology installed: symmetric edges and ownership hold;
+        // liveness settlement is honestly still pending.
+        const topologyOnly = checkStoreInvariants(s, {
+            states: [a, b, c, sum],
+            skip: ["liveness-counts", "mount-state"],
+        })
+        expect(topologyOnly).toEqual([])
+        const beforeDiff = checkStoreInvariants(s, { states: [a, b, c, sum] })
+        expect(
+            beforeDiff.some(violation =>
+                violation.startsWith("[liveness-counts]"),
+            ),
+        ).toBe(true)
+
+        // Phase 3 — the diff is applied: full invariants hold again.
+        applyLiveDependencyDiff(
+            sum,
+            depsChange.added,
+            depsChange.removed,
+            data,
+        )
+        endLivenessPass(data)
+        expect(checkStoreInvariants(s, { states: [a, b, c, sum] })).toEqual([])
+        expect(s.get(sum)).toBe(3)
+        s.set(c, 6)
+        expect(s.get(sum)).toBe(3)
+    })
+
+    test("full invariants hold after disposal", () => {
+        const a = atom(1)
+        const sel = selector(get => get(a) + 1)
+        const s = store()
+        s.sub(sel, () => {})
+        expect(s.get(sel)).toBe(2)
+        s.dispose()
+        // No explicit `states` seed: disposal deliberately leaves weak graph
+        // entries to be collected with the store; the checker audits the
+        // terminal state through the store's own iterable anchors.
+        expect(checkStoreInvariants(s)).toEqual([])
+    })
+})

--- a/packages/valdres/src/lib/graph/runtime.ts
+++ b/packages/valdres/src/lib/graph/runtime.ts
@@ -1,0 +1,405 @@
+import type { DepsChange } from "../../types/DepsChange"
+import type { Selector } from "../../types/Selector"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+import { isSelector } from "../../utils/isSelector"
+import { DISPOSED_STORE_PENDING } from "../storeLifecycle"
+import { cleanupOrphanedDeps } from "./cleanupOrphanedDeps"
+import {
+    addStateDependent,
+    removeStateDependent,
+} from "./inheritedDependencyBranches"
+import {
+    activateSelectorGraph,
+    isLive,
+    mountTransitiveDeps,
+    noteDependencyAdded,
+    onLiveDependencyAdded,
+    onLiveDependencyRemoved,
+    unmountOrphanedDeps,
+} from "./mountAtom"
+import {
+    noteDependencyGraphChanged,
+    noteDependencyMaterialized,
+} from "./noteDependencyGraphChanged"
+
+/**
+ * Graph-runtime installers: the write API evaluation and settlement code use
+ * to commit discovered dependencies into the graph tables. Evaluators never
+ * mutate graph state themselves — they fill an EvaluationOutcome and their
+ * dispatcher hands it here. Immediately after an install the edge TOPOLOGY
+ * (symmetric forward/reverse edges, order, scope branches) is consistent;
+ * liveness and mounts may still be pending until the caller applies the
+ * dependency diff (`applyLiveDependencyDiff`) or the owning liveness pass
+ * reconciles — see graph/index.ts for the full phase model.
+ */
+
+/**
+ * Commit a full dependency-set replacement discovered by one evaluation of
+ * `selector` against the committed store. Verbatim semantics of the historical
+ * in-evaluator install: version/order notes, liveness-pass seeding, async
+ * merge-forward, add/remove edge diff, then the forward-set write — in that
+ * order. Call only when the dep set actually changed (`outcome.needsInstall`).
+ */
+export const installEvaluationDeps = (
+    selector: Selector,
+    data: StoreData,
+    updatedDeps: Set<State>,
+    currentDependencies: Set<State> | undefined,
+    tracksReverseEdges: boolean,
+    isAsyncResult: boolean,
+    depsChangeOut?: DepsChange,
+): void => {
+    // Invalidate topology-sensitive teardown caches once for this
+    // dependency-set materialization or change (including an empty
+    // selector re-materialized after cleanup).
+    if (tracksReverseEdges) {
+        noteDependencyGraphChanged(selector, data)
+    } else {
+        noteDependencyMaterialized(selector, data)
+    }
+    // Seed the active selector-update pass's liveness reconcile with this
+    // selector whenever its dep SET changed — covering BOTH the
+    // propagation-loop path and lazy re-inits through `get`. Added deps
+    // are covered via this selector's downward closure; removed deps are
+    // seeded individually below to cover torn-down subtrees. Only when an
+    // EXISTING selector changed — a first init is reached (and seeded)
+    // through whatever live selector just read it.
+    if (tracksReverseEdges && data.livenessPassActive && currentDependencies) {
+        // Allocate the collector lazily on first seed — a no-churn pass
+        // never reaches here, so it stays allocation-free.
+        ;(data.livenessSeeds ??= new Set<State>()).add(selector)
+        // A lazy re-init (no depsChangeOut) commits these edges without
+        // going through the propagation loop's onLiveDependency* calls,
+        // so the incremental count never sees them — arm the reconcile
+        // UNCONDITIONALLY (it can mis-count even an acyclic graph because
+        // the incremental path never ran for it).
+        if (!depsChangeOut) data.livenessLazyArmed = true
+    }
+    // Sync selectors store the freshly-read dep set directly — no copy.
+    // Async selectors need a separate set so previous deps can be merged
+    // in (below) without mutating `updatedDeps`, which the evaluator still
+    // reads as the promise-tracking seed (`asyncDeps`).
+    const updatedDependencies = isAsyncResult
+        ? new Set<State>(updatedDeps)
+        : updatedDeps
+    // For async selectors, retain all previous deps so they aren't
+    // prematurely removed (and unmounted) before the continuation runs.
+    // Stale deps are cleaned up when the promise resolves (see
+    // reconcileAsyncDeps).
+    if (isAsyncResult && currentDependencies) {
+        for (const dep of currentDependencies) {
+            updatedDependencies.add(dep)
+        }
+    }
+    // First materialization: user code probed between capture and install
+    // (e.g. a `then` accessor running a deferred `get`) may have created a
+    // forward set through installLateDependency. Overwriting it would strand
+    // its reverse edges — merge instead. The edge loop below is idempotent
+    // for already-installed members. Re-evals need no merge: their late adds
+    // land in `currentDependencies` itself and the removal diff below tears
+    // them down symmetrically.
+    if (!currentDependencies) {
+        const interval = data.stateDependencies.get(selector)
+        if (interval) {
+            for (const dep of interval) {
+                updatedDependencies.add(dep)
+            }
+        }
+    }
+    const prev = currentDependencies ?? new Set<State>()
+    for (const state of updatedDependencies) {
+        if (!prev.has(state)) {
+            if (tracksReverseEdges) {
+                addStateDependent(state, selector, data)
+                // New edge: propagate the mount-closure marker up so the
+                // mount/unmount walk-skip stays free of false negatives.
+                noteDependencyAdded(selector, state, data)
+                // A newly-read selector may itself have been only cold-
+                // cached. Promote its closure before liveness bookkeeping
+                // treats it as a live dependency. Stores that have never
+                // built a cold cache have nothing to promote; keep that
+                // dominant live-only path to one scalar branch rather
+                // than a helper call plus a state-shape check per edge.
+                if (data.coldSelectorCachesEnabled) {
+                    activateSelectorGraph(state, data)
+                }
+                if (depsChangeOut) {
+                    if (!depsChangeOut.added)
+                        depsChangeOut.added = new Set<State>()
+                    depsChangeOut.added.add(state)
+                }
+            }
+        }
+    }
+    if (!isAsyncResult) {
+        for (const state of prev) {
+            if (!updatedDependencies.has(state)) {
+                if (tracksReverseEdges) {
+                    removeStateDependent(state, selector, data)
+                    if (depsChangeOut) {
+                        if (!depsChangeOut.removed)
+                            depsChangeOut.removed = new Set<State>()
+                        depsChangeOut.removed.add(state)
+                    }
+                }
+                // Removed dep: arm the removal path only when the dropped
+                // dep is a SELECTOR. A directed cycle is selector-only —
+                // only selectors are keyed in stateDependencies; atoms and
+                // atom-family members are graph sinks (no out-edges), so
+                // removing one can be on no cycle and the incremental
+                // teardown is already exact. (selectorFamily members ARE
+                // selectors — isSelector is true for them, so they take
+                // this gated path.) For a selector dep we seed its
+                // torn-down subtree and arm; the end-of-pass reconcile is
+                // then still gated on regionHasCycle, so an acyclic selector
+                // removal also stays on the incremental path.
+                if (
+                    tracksReverseEdges &&
+                    data.livenessPassActive &&
+                    isSelector(state)
+                ) {
+                    ;(data.livenessSeeds ??= new Set<State>()).add(state)
+                    data.livenessRemovalArmed = true
+                }
+            }
+        }
+    }
+    data.stateDependencies.set(selector, updatedDependencies)
+}
+
+/**
+ * Twin of `installEvaluationDeps` for the dominant live-only store shape
+ * (see evaluateLiveOnlySelector): reverse edges always tracked, no cold
+ * caches to promote, no propagation-loop diff to mirror. Kept as a second
+ * monomorphic entry so the pre-cold-cache path pays no per-edge mode
+ * branches; the semantic core is identical and pinned by a parity test.
+ */
+export const installEvaluationDepsLiveOnly = (
+    selector: Selector,
+    data: StoreData,
+    updatedDeps: Set<State>,
+    currentDependencies: Set<State> | undefined,
+    isAsyncResult: boolean,
+): void => {
+    noteDependencyGraphChanged(selector, data)
+    if (data.livenessPassActive && currentDependencies) {
+        ;(data.livenessSeeds ??= new Set<State>()).add(selector)
+        data.livenessLazyArmed = true
+    }
+    const updatedDependencies = isAsyncResult
+        ? new Set<State>(updatedDeps)
+        : updatedDeps
+    if (isAsyncResult && currentDependencies) {
+        for (const dep of currentDependencies) {
+            updatedDependencies.add(dep)
+        }
+    }
+    // See installEvaluationDeps: merge a forward set created by a deferred
+    // `get` in the capture-to-install window rather than overwriting it.
+    if (!currentDependencies) {
+        const interval = data.stateDependencies.get(selector)
+        if (interval) {
+            for (const dep of interval) {
+                updatedDependencies.add(dep)
+            }
+        }
+    }
+    const prev = currentDependencies ?? new Set<State>()
+    for (const state of updatedDependencies) {
+        if (!prev.has(state)) {
+            addStateDependent(state, selector, data)
+            noteDependencyAdded(selector, state, data)
+        }
+    }
+    if (!isAsyncResult) {
+        for (const state of prev) {
+            if (!updatedDependencies.has(state)) {
+                removeStateDependent(state, selector, data)
+                if (data.livenessPassActive && isSelector(state)) {
+                    ;(data.livenessSeeds ??= new Set<State>()).add(state)
+                    data.livenessRemovalArmed = true
+                }
+            }
+        }
+    }
+    data.stateDependencies.set(selector, updatedDependencies)
+}
+
+/**
+ * Register one dependency discovered by a deferred `get` (after an await or
+ * timeout) — the pre-read half. Returns whether the edge is genuinely new;
+ * the caller reads the dependency's value in between and MUST gate
+ * `settleLateDependency` on that result: settling an existing edge would
+ * double-increment liveDependentCount and remount an already-mounted dep.
+ */
+export const installLateDependency = (
+    selector: Selector,
+    state: State,
+    data: StoreData,
+): boolean => {
+    let deps = data.stateDependencies.get(selector)
+    if (!deps) {
+        deps = new Set()
+        data.stateDependencies.set(selector, deps)
+    }
+    const isNewDep = !deps.has(state)
+    if (isNewDep) {
+        deps.add(state)
+        if (data.selectorGraphActive.has(selector)) {
+            noteDependencyGraphChanged(selector, data)
+            addStateDependent(state, selector, data)
+            // New edge: keep the mount-closure marker's no-false-negative invariant.
+            noteDependencyAdded(selector, state, data)
+        } else {
+            // The dependency list no longer aligns with the cold cache's
+            // revision array. Force validation/re-evaluation on the next read.
+            const cache = data.coldSelectorCaches.get(selector)
+            if (cache) cache.validatedAt = -1
+        }
+    }
+    return isNewDep
+}
+
+/**
+ * Post-read half of a late dependency install: promote and mount the newly
+ * added edge. `selectorGraphActive` is deliberately re-checked — the value
+ * read between the two halves can change it (a cold selector is validated/
+ * read before its graph is promoted; promotion bypasses cold-cache
+ * validation thereafter).
+ */
+export const settleLateDependency = (
+    selector: Selector,
+    state: State,
+    data: StoreData,
+): void => {
+    if (data.selectorGraphActive.has(selector)) {
+        activateSelectorGraph(state, data)
+        // Mount new dependencies if the selector is live.
+        if (isLive(selector, data)) {
+            onLiveDependencyAdded(state, data)
+            mountTransitiveDeps(state, data)
+        }
+    }
+}
+
+/**
+ * Reconcile a resolved async selector's committed dependencies: remove any
+ * that were carried forward from a previous evaluation but not read by the
+ * evaluation that produced this resolution. `evalDeps` is the kept set.
+ * Liveness is snapshotted ONCE before the loop — an unmount cleanup running
+ * mid-loop may unsubscribe this selector, and re-checking per dep would
+ * change which removals propagate.
+ */
+export const reconcileAsyncDeps = (
+    selector: Selector,
+    evalDeps: Set<State>,
+    data: StoreData,
+): void => {
+    const currentDeps = data.stateDependencies.get(selector)
+    if (!currentDeps) return
+    const tracksReverseEdges = data.selectorGraphActive.has(selector)
+    const selectorIsLive = isLive(selector, data)
+    let graphChangeNoted = false
+    for (const dep of currentDeps) {
+        if (!evalDeps.has(dep)) {
+            if (tracksReverseEdges && !graphChangeNoted) {
+                noteDependencyGraphChanged(selector, data)
+                graphChangeNoted = true
+            }
+            currentDeps.delete(dep)
+            if (tracksReverseEdges) {
+                removeStateDependent(dep, selector, data)
+                if (selectorIsLive) {
+                    onLiveDependencyRemoved(dep, data)
+                }
+                unmountOrphanedDeps(dep, data)
+            }
+        }
+    }
+}
+
+/** Speculatively mark a fresh selector as part of the live reverse graph
+ * before its first evaluation (a selector discovered below a live selector is
+ * itself live by construction). Balanced by `rollbackSelectorActivation` when
+ * that evaluation throws. */
+export const markSelectorGraphActive = (
+    selector: Selector,
+    data: StoreData,
+): void => {
+    data.selectorGraphActive.add(selector)
+}
+
+/** Undo a speculative activation after the activating evaluation threw. */
+export const rollbackSelectorActivation = (
+    selector: Selector,
+    data: StoreData,
+): void => {
+    cleanupOrphanedDeps(selector, data)
+    // A selector that threw before committing its dependency set has no graph
+    // for cleanupOrphanedDeps to remove, but the active marker is still owned
+    // by the evaluation that speculatively added it.
+    if (!isLive(selector, data)) data.selectorGraphActive.delete(selector)
+}
+
+/** Orphan cleanup may leave the weak active marker behind to keep teardown
+ * cheap. With no forward graph a read is fresh, not a live re-evaluation —
+ * clear the stale marker before selecting the evaluation mode. */
+export const clearStaleSelectorActivation = (
+    selector: Selector,
+    data: StoreData,
+): void => {
+    if (!data.stateDependencies.has(selector)) {
+        data.selectorGraphActive.delete(selector)
+    }
+}
+
+/**
+ * Apply an installed dependency diff to the incremental liveness/mount
+ * bookkeeping. Runs user onMount/cleanup, so callers must invoke it OUTSIDE
+ * any error-swallowing re-evaluation guard — a throwing onMount must
+ * propagate — and only after the selector's settled value is committed.
+ */
+export const applyLiveDependencyDiff = (
+    selector: Selector,
+    added: Set<State> | undefined,
+    removed: Set<State> | undefined,
+    data: StoreData,
+): void => {
+    if (!isLive(selector, data)) return
+    if (added) {
+        for (const dep of added) {
+            onLiveDependencyAdded(dep, data)
+            mountTransitiveDeps(dep, data)
+        }
+    }
+    if (removed) {
+        for (const dep of removed) {
+            onLiveDependencyRemoved(dep, data)
+            unmountOrphanedDeps(dep, data)
+        }
+    }
+}
+
+/** Mark a store's graph terminal for disposal. Reuses the public-operation
+ * orphan guard as the terminal facade marker; this also replaces and releases
+ * any queued orphan roots. */
+export const sealGraphForDisposal = (data: StoreData): void => {
+    data.pendingOrphanCleanup = DISPOSED_STORE_PENDING
+}
+
+/** Drop a queued orphan sweep's roots during disposal. The already-enqueued
+ * microtask observes the terminal marker and becomes a no-op. */
+export const dropQueuedOrphanWork = (data: StoreData): void => {
+    data.orphanCleanupScheduled = false
+}
+
+/** Release the liveness-pass scratch during disposal. These are transient
+ * scratch owners rather than external resources, but clearing them releases
+ * any strong states immediately. */
+export const resetLivenessScratch = (data: StoreData): void => {
+    data.livenessPassActive = false
+    data.livenessSeeds = undefined
+    data.livenessRemovalArmed = false
+    data.livenessLazyArmed = false
+}

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -11,25 +11,20 @@ import { isSelector } from "../utils/isSelector"
 import {
     SuspendAndWaitForResolveError,
     cleanUpRejectedPromise,
-    lateGet,
 } from "./asyncDependencyTracking"
 import { getState } from "./getState"
 import {
-    addStateDependent,
-    removeStateDependent,
-} from "./inheritedDependencyBranches"
-import {
-    activateSelectorGraph,
-    isLive,
-    noteDependencyAdded,
-    onLiveDependencyRemoved,
-    unmountOrphanedDeps,
-} from "./mountAtom"
-import {
-    noteDependencyGraphChanged,
-    noteDependencyMaterialized,
-} from "./noteDependencyGraphChanged"
-import { cleanupOrphanedDeps } from "./cleanupOrphanedDeps"
+    type EvaluationOutcome,
+    acquireEvaluationOutcome,
+    installEvaluationDeps,
+    installEvaluationDepsLiveOnly,
+    installLateDependency,
+    markSelectorGraphActive,
+    reconcileAsyncDeps,
+    releaseEvaluationOutcome,
+    rollbackSelectorActivation,
+    settleLateDependency,
+} from "./graph"
 import { createGuardedScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
@@ -206,24 +201,13 @@ class SelectorEvaluation implements SelectorEvaluationContext {
     }
 }
 
-const rollbackFreshSelectorActivation = (
-    selector: Selector,
-    data: StoreData,
-) => {
-    cleanupOrphanedDeps(selector, data)
-    // A selector that threw before committing its dependency set has no graph
-    // for cleanupOrphanedDeps to remove, but the active marker is still owned
-    // by the evaluation that speculatively added it.
-    if (!isLive(selector, data)) data.selectorGraphActive.delete(selector)
-}
-
 export const initFreshActiveSelector = <V>(
     selector: Selector<V>,
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     circularDependencySet: WeakSet<Selector>,
 ): V => {
-    data.selectorGraphActive.add(selector)
+    markSelectorGraphActive(selector, data)
     try {
         initSelector(
             selector,
@@ -234,7 +218,7 @@ export const initFreshActiveSelector = <V>(
         )
         return data.values.get(selector)
     } catch (error) {
-        rollbackFreshSelectorActivation(selector, data)
+        rollbackSelectorActivation(selector, data)
         throw error
     }
 }
@@ -245,11 +229,32 @@ const rollbackFreshSelectorActivations = (
 ) => {
     if (!selectors) return
     if (!Array.isArray(selectors)) {
-        rollbackFreshSelectorActivation(selectors, data)
+        rollbackSelectorActivation(selectors, data)
         return
     }
     for (let i = selectors.length - 1; i >= 0; i--) {
-        rollbackFreshSelectorActivation(selectors[i], data)
+        rollbackSelectorActivation(selectors[i], data)
+    }
+}
+
+/**
+ * Handle a deferred `get` call — one that runs after the synchronous
+ * evaluation of the selector has already completed (e.g. inside a
+ * setTimeout or after an await). Registers the dependency through the graph
+ * runtime, reads the value, and settles (promotes/mounts) ONLY a genuinely
+ * new edge — settling an existing one would double-count its liveness.
+ * The read stays sandwiched between the two graph calls: a cold selector is
+ * validated/read before its dependency graph is promoted.
+ */
+const lateGet = (state: State, selector: Selector, data: StoreData) => {
+    const added = installLateDependency(selector, state, data)
+    // Atoms lazily initialized here are first-time accesses — no other
+    // selector depends on them yet, so propagation is unnecessary.
+    const lateInitSet = new Set<Atom>()
+    try {
+        return getState(state, data, lateInitSet)
+    } finally {
+        if (added) settleLateDependency(selector, state, data)
     }
 }
 
@@ -271,17 +276,6 @@ const lateGetWithRevisionSnapshot = (
             revisions.set(state, getStateRevision(state, data))
         }
     }
-}
-
-/**
- * Holder for dep-change tracking during propagation. The Sets inside are
- * allocated lazily by `evaluateSelector` only when deps actually changed —
- * the steady-state case (same deps re-evaluated) does no allocation here.
- * Callers should clear `added` / `removed` to `undefined` before reuse.
- */
-export type DepsChange = {
-    added?: Set<State>
-    removed?: Set<State>
 }
 
 /** Selector bookkeeping owned by a read overlay rather than the committed
@@ -306,6 +300,7 @@ const evaluateLiveOnlySelector = <V>(
     data: StoreData,
     initializedAtomsSet: Set<Atom>,
     circularDependencySet: WeakSet<Selector>,
+    outcome: EvaluationOutcome,
 ) => {
     if (!IS_PROD && data.architectureInstrumentation)
         recordSelectorEvaluation(data)
@@ -397,9 +392,14 @@ const evaluateLiveOnlySelector = <V>(
         }
 
         evaluationComplete = true
+        // Probe the user-visible `then` exactly once: a getter there can run
+        // a deferred `get` (installing edges through lateGet), so no second
+        // probe may happen between capture and the dispatcher's install —
+        // that window would let the install overwrite the late edge's
+        // forward set and strand its reverse edge.
+        const isPromiseResult = isPromiseLike(result)
         const isAsyncResult =
-            result instanceof SuspendAndWaitForResolveError ||
-            isPromiseLike(result)
+            result instanceof SuspendAndWaitForResolveError || isPromiseResult
 
         if (
             !isAsyncResult &&
@@ -410,44 +410,13 @@ const evaluateLiveOnlySelector = <V>(
             depsChanged = true
         }
 
-        if (depsChanged || !currentDependencies) {
-            noteDependencyGraphChanged(selector, data)
-            if (data.livenessPassActive && currentDependencies) {
-                ;(data.livenessSeeds ??= new Set<State>()).add(selector)
-                data.livenessLazyArmed = true
-            }
-            const updatedDependencies = isAsyncResult
-                ? new Set<State<any>>(updatedDeps)
-                : updatedDeps
-            if (isAsyncResult && currentDependencies) {
-                for (const dep of currentDependencies) {
-                    updatedDependencies.add(dep)
-                }
-            }
-            const prev = currentDependencies ?? new Set<State<any>>()
-            for (const state of updatedDependencies) {
-                if (!prev.has(state)) {
-                    addStateDependent(state, selector, data)
-                    noteDependencyAdded(selector, state, data)
-                }
-            }
-            if (!isAsyncResult) {
-                for (const state of prev) {
-                    if (!updatedDependencies.has(state)) {
-                        removeStateDependent(state, selector, data)
-                        if (data.livenessPassActive && isSelector(state)) {
-                            ;(data.livenessSeeds ??= new Set<State>()).add(
-                                state,
-                            )
-                            data.livenessRemovalArmed = true
-                        }
-                    }
-                }
-            }
-            data.stateDependencies.set(selector, updatedDependencies)
-        }
+        outcome.deps = updatedDeps
+        outcome.prevDeps = currentDependencies
+        outcome.depsChanged = depsChanged
+        outcome.isAsync = isAsyncResult
+        outcome.needsInstall = depsChanged || !currentDependencies
 
-        if (isPromiseLike(result)) {
+        if (isPromiseResult) {
             evalCtx.asyncDeps = new Set<State>(updatedDeps)
         }
         return result
@@ -462,7 +431,7 @@ export const evaluateSelector = <V>(
     initializedAtomsSet: Set<Atom>,
     circularDependencySet: WeakSet<Selector> = data.circularDepSet,
     selectorGraphActive: boolean = false,
-    depsChangeOut?: DepsChange,
+    outcome: EvaluationOutcome,
     readOverlay?: GetValue,
     runtime?: SelectorEvaluationRuntime,
 ) => {
@@ -656,9 +625,12 @@ export const evaluateSelector = <V>(
 
         evaluationComplete = true
 
+        // Probe the user-visible `then` exactly once — see the identical note
+        // in evaluateLiveOnlySelector: a second probe before the dispatcher
+        // installs would let a `then`-getter's deferred `get` be overwritten.
+        const isPromiseResult = isPromiseLike(result)
         const isAsyncResult =
-            result instanceof SuspendAndWaitForResolveError ||
-            isPromiseLike(result)
+            result instanceof SuspendAndWaitForResolveError || isPromiseResult
 
         // For sync selectors, check if dep count changed (handles removed deps).
         // For async selectors, skip — the dep count is incomplete until the
@@ -672,129 +644,15 @@ export const evaluateSelector = <V>(
             depsChanged = true
         }
 
-        if (runtime && (depsChanged || !currentDependencies)) {
-            // The overlay graph tracks async dependencies and re-evaluations,
-            // but deliberately has no committed reverse edges or liveness.
-            const updatedDependencies = isAsyncResult
-                ? new Set<State<any>>(updatedDeps)
-                : updatedDeps
-            if (isAsyncResult && currentDependencies) {
-                for (const dep of currentDependencies) {
-                    updatedDependencies.add(dep)
-                }
-            }
-            stateDependencies.set(selector, updatedDependencies)
-        }
-
-        if (!runtime && (depsChanged || !currentDependencies)) {
-            // Invalidate topology-sensitive teardown caches once for this
-            // dependency-set materialization or change (including an empty
-            // selector re-materialized after cleanup).
-            if (tracksReverseEdges) {
-                noteDependencyGraphChanged(selector, data)
-            } else {
-                noteDependencyMaterialized(selector, data)
-            }
-            // Seed the active selector-update pass's liveness reconcile with this
-            // selector whenever its dep SET changed — covering BOTH the
-            // propagation-loop path and lazy re-inits through `get`. Added deps
-            // are covered via this selector's downward closure; removed deps are
-            // seeded individually below to cover torn-down subtrees. Only when an
-            // EXISTING selector changed — a first init is reached (and seeded)
-            // through whatever live selector just read it.
-            if (
-                tracksReverseEdges &&
-                data.livenessPassActive &&
-                currentDependencies
-            ) {
-                // Allocate the collector lazily on first seed — a no-churn pass
-                // never reaches here, so it stays allocation-free.
-                ;(data.livenessSeeds ??= new Set<State>()).add(selector)
-                // A lazy re-init (no depsChangeOut) commits these edges without
-                // going through the propagation loop's onLiveDependency* calls,
-                // so the incremental count never sees them — arm the reconcile
-                // UNCONDITIONALLY (it can mis-count even an acyclic graph because
-                // the incremental path never ran for it).
-                if (!depsChangeOut) data.livenessLazyArmed = true
-            }
-            // Sync selectors store the freshly-read dep set directly — no copy.
-            // Async selectors need a separate set so previous deps can be merged
-            // in (below) without mutating `updatedDeps`, which is still read as
-            // the promise-tracking seed (`allDepsThisEval`) further down.
-            const updatedDependencies = isAsyncResult
-                ? new Set<State<any>>(updatedDeps)
-                : updatedDeps
-            // For async selectors, retain all previous deps so they aren't
-            // prematurely removed (and unmounted) before the continuation runs.
-            // Stale deps are cleaned up when the promise resolves (see
-            // the reconciliation logic in handleSelectorResult).
-            if (isAsyncResult && currentDependencies) {
-                for (const dep of currentDependencies) {
-                    updatedDependencies.add(dep)
-                }
-            }
-            const prev = currentDependencies ?? new Set<State<any>>()
-            for (const state of updatedDependencies) {
-                if (!prev.has(state)) {
-                    if (tracksReverseEdges) {
-                        addStateDependent(state, selector, data)
-                        // New edge: propagate the mount-closure marker up so the
-                        // mount/unmount walk-skip stays free of false negatives.
-                        noteDependencyAdded(selector, state, data)
-                        // A newly-read selector may itself have been only cold-
-                        // cached. Promote its closure before liveness bookkeeping
-                        // treats it as a live dependency. Stores that have never
-                        // built a cold cache have nothing to promote; keep that
-                        // dominant live-only path to one scalar branch rather
-                        // than a helper call plus a state-shape check per edge.
-                        if (data.coldSelectorCachesEnabled) {
-                            activateSelectorGraph(state, data)
-                        }
-                        if (depsChangeOut) {
-                            if (!depsChangeOut.added)
-                                depsChangeOut.added = new Set<State>()
-                            depsChangeOut.added.add(state)
-                        }
-                    }
-                }
-            }
-            if (!isAsyncResult) {
-                for (const state of prev) {
-                    if (!updatedDependencies.has(state)) {
-                        if (tracksReverseEdges) {
-                            removeStateDependent(state, selector, data)
-                            if (depsChangeOut) {
-                                if (!depsChangeOut.removed)
-                                    depsChangeOut.removed = new Set<State>()
-                                depsChangeOut.removed.add(state)
-                            }
-                        }
-                        // Removed dep: arm the removal path only when the dropped
-                        // dep is a SELECTOR. A directed cycle is selector-only —
-                        // only selectors are keyed in stateDependencies; atoms and
-                        // atom-family members are graph sinks (no out-edges), so
-                        // removing one can be on no cycle and the incremental
-                        // teardown is already exact. (selectorFamily members ARE
-                        // selectors — isSelector is true for them, so they take
-                        // this gated path.) For a selector dep we seed its
-                        // torn-down subtree and arm; the end-of-pass reconcile is
-                        // then still gated on regionHasCycle, so an acyclic selector
-                        // removal also stays on the incremental path.
-                        if (
-                            tracksReverseEdges &&
-                            data.livenessPassActive &&
-                            isSelector(state)
-                        ) {
-                            ;(data.livenessSeeds ??= new Set<State>()).add(
-                                state,
-                            )
-                            data.livenessRemovalArmed = true
-                        }
-                    }
-                }
-            }
-            data.stateDependencies.set(selector, updatedDependencies)
-        }
+        // Hand the discovered dep set to the dispatcher, which installs it
+        // through the graph runtime (overlay or committed) after this
+        // evaluator returns. The evaluator itself no longer writes any graph
+        // table.
+        outcome.deps = updatedDeps
+        outcome.prevDeps = currentDependencies
+        outcome.depsChanged = depsChanged
+        outcome.isAsync = isAsyncResult
+        outcome.needsInstall = depsChanged || !currentDependencies
 
         // Store the tracking set on this evaluation's identity so
         // handleSelectorResult can reconcile when the promise resolves. A
@@ -802,7 +660,7 @@ export const evaluateSelector = <V>(
         // not a safe owner for this data. Only needed for native-promise
         // selectors — SuspendAndWaitForResolveError re-evaluates via
         // initSelector instead.
-        if (isPromiseLike(result)) {
+        if (isPromiseResult) {
             // Build the tracking set from sync deps discovered so far. Late
             // `get` calls (after await) will add to this set dynamically.
             evalCtx.asyncDeps = new Set<State>(updatedDeps)
@@ -986,29 +844,7 @@ export const handleSelectorResult = <Value>(
                 // Reconcile deps: remove any that were carried forward from a
                 // previous evaluation but not read in this one.
                 if (evalDeps) {
-                    const currentDeps = data.stateDependencies.get(selector)
-                    if (currentDeps) {
-                        const tracksReverseEdges =
-                            data.selectorGraphActive.has(selector)
-                        const selectorIsLive = isLive(selector, data)
-                        let graphChangeNoted = false
-                        for (const dep of currentDeps) {
-                            if (!evalDeps.has(dep)) {
-                                if (tracksReverseEdges && !graphChangeNoted) {
-                                    noteDependencyGraphChanged(selector, data)
-                                    graphChangeNoted = true
-                                }
-                                currentDeps.delete(dep)
-                                if (tracksReverseEdges) {
-                                    removeStateDependent(dep, selector, data)
-                                    if (selectorIsLive) {
-                                        onLiveDependencyRemoved(dep, data)
-                                    }
-                                    unmountOrphanedDeps(dep, data)
-                                }
-                            }
-                        }
-                    }
+                    reconcileAsyncDeps(selector, evalDeps, data)
                 }
 
                 // Async validation can't throw to a caller; on failure it's
@@ -1144,10 +980,81 @@ export const handleSelectorResult = <Value>(
     }
 }
 
+/** Install a transaction overlay evaluation into the draft's private forward
+ * map. The overlay graph tracks async dependencies and re-evaluations, but
+ * deliberately has no committed reverse edges or liveness — it never touches
+ * the committed graph tables, so it lives with the evaluator, not the graph
+ * runtime. */
+const installOverlayDeps = (
+    selector: Selector,
+    runtime: SelectorEvaluationRuntime,
+    outcome: EvaluationOutcome,
+) => {
+    const updatedDeps = outcome.deps!
+    const currentDependencies = outcome.prevDeps
+    const updatedDependencies = outcome.isAsync
+        ? new Set<State<any>>(updatedDeps)
+        : updatedDeps
+    if (outcome.isAsync && currentDependencies) {
+        for (const dep of currentDependencies) {
+            updatedDependencies.add(dep)
+        }
+    }
+    runtime.stateDependencies.set(selector, updatedDependencies)
+}
+
+/** Out-of-line installer choice for the committed dispatcher. Uses the SAME
+ * predicate value that selected the evaluator, so the twin evaluator and twin
+ * installer can never diverge. Kept out of the dispatcher body so the
+ * no-churn hot path stays small enough for V8 to inline. */
+const installCommittedOutcome = (
+    selector: Selector,
+    data: StoreData,
+    selectorGraphActive: boolean,
+    liveOnly: boolean,
+    outcome: EvaluationOutcome,
+) => {
+    if (liveOnly) {
+        installEvaluationDepsLiveOnly(
+            selector,
+            data,
+            outcome.deps!,
+            outcome.prevDeps,
+            outcome.isAsync,
+        )
+    } else {
+        installEvaluationDeps(
+            selector,
+            data,
+            outcome.deps!,
+            outcome.prevDeps,
+            selectorGraphActive,
+            outcome.isAsync,
+            undefined,
+        )
+    }
+}
+
+/** Cold path of the dispatcher's catch: keep the carrier release and error
+ * tracking out of the hot body. Returns the error to rethrow. */
+const releaseAfterEvaluationThrow = (
+    selector: Selector,
+    outcome: EvaluationOutcome,
+    error: unknown,
+): unknown => {
+    // Release here rather than in a wrapping finally: the extra exception
+    // scope measurably hurt V8's re-init hot path, and the installers run no
+    // user code, so the throw paths end at the evaluator.
+    releaseEvaluationOutcome(outcome)
+    if (error instanceof SelectorEvaluationError) error.track(selector)
+    return error
+}
+
 // Keep the committed call shape monomorphic: passing unused overlay/runtime
 // arguments measurably deoptimizes Bun's ordinary selector hot path. This is a
 // thin boundary only; both committed and transactional reads still delegate to
-// the same evaluator and result handler below.
+// the same evaluator and result handler below. The dispatcher — not the
+// evaluator — commits discovered dependencies into the graph.
 const evaluateCommittedSelectorValue = <V>(
     selector: Selector<V>,
     data: StoreData,
@@ -1155,27 +1062,39 @@ const evaluateCommittedSelectorValue = <V>(
     circularDependencySet: WeakSet<Selector>,
     selectorGraphActive: boolean,
 ) => {
+    const liveOnly = selectorGraphActive && !data.coldSelectorCachesEnabled
+    const outcome = acquireEvaluationOutcome()
     let value
     try {
-        value =
-            selectorGraphActive && !data.coldSelectorCachesEnabled
-                ? evaluateLiveOnlySelector(
-                      selector,
-                      data,
-                      initializedAtomsSet,
-                      circularDependencySet,
-                  )
-                : evaluateSelector(
-                      selector,
-                      data,
-                      initializedAtomsSet,
-                      circularDependencySet,
-                      selectorGraphActive,
-                  )
+        value = liveOnly
+            ? evaluateLiveOnlySelector(
+                  selector,
+                  data,
+                  initializedAtomsSet,
+                  circularDependencySet,
+                  outcome,
+              )
+            : evaluateSelector(
+                  selector,
+                  data,
+                  initializedAtomsSet,
+                  circularDependencySet,
+                  selectorGraphActive,
+                  outcome,
+              )
     } catch (error) {
-        if (error instanceof SelectorEvaluationError) error.track(selector)
-        throw error
+        throw releaseAfterEvaluationThrow(selector, outcome, error)
     }
+    if (outcome.needsInstall) {
+        installCommittedOutcome(
+            selector,
+            data,
+            selectorGraphActive,
+            liveOnly,
+            outcome,
+        )
+    }
+    releaseEvaluationOutcome(outcome)
     return handleSelectorResult(
         value,
         selector,
@@ -1236,6 +1155,7 @@ export const evaluateSelectorValue = <V>(
 ) => {
     const selectorGraphActive =
         !runtime && data.selectorGraphActive.has(selector)
+    const outcome = acquireEvaluationOutcome()
     let value
     try {
         value = evaluateSelector(
@@ -1244,13 +1164,26 @@ export const evaluateSelectorValue = <V>(
             initializedAtomsSet,
             circularDependencySet,
             selectorGraphActive,
-            undefined,
+            outcome,
             readOverlay,
             runtime,
         )
     } catch (error) {
-        if (error instanceof SelectorEvaluationError) error.track(selector)
-        throw error
+        throw releaseAfterEvaluationThrow(selector, outcome, error)
     }
+    if (outcome.needsInstall) {
+        if (runtime) {
+            installOverlayDeps(selector, runtime, outcome)
+        } else {
+            installCommittedOutcome(
+                selector,
+                data,
+                selectorGraphActive,
+                false,
+                outcome,
+            )
+        }
+    }
+    releaseEvaluationOutcome(outcome)
     return handleSelectorResult(value, selector, data, runtime)
 }

--- a/packages/valdres/src/lib/livenessReconciliation.test.ts
+++ b/packages/valdres/src/lib/livenessReconciliation.test.ts
@@ -5,7 +5,7 @@ import { atomFamily } from "../atomFamily"
 import { selector } from "../selector"
 import { selectorFamily } from "../selectorFamily"
 import { store } from "../store"
-import { isLive, reconcileLivenessAfterChurn } from "./mountAtom"
+import { isLive, reconcileLivenessAfterChurn } from "./graph/mountAtom"
 
 // Regression coverage for the `liveDependentCount` desync fixed by
 // `reconcileLivenessAfterChurn`: a selector transitively read by a live

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -13,18 +13,19 @@ import {
     deleteFamilyAtomsFromSet,
     recursivelyUpdateIndexes,
 } from "./atomFamilyIndex"
-import type { DepsChange } from "./initSelector"
+import type { DepsChange } from "../types/DepsChange"
 import { evaluateSelector, handleSelectorResult } from "./initSelector"
 import {
+    applyLiveDependencyDiff,
     beginLivenessPass,
+    createEvaluationOutcome,
     endLivenessPass,
+    hasInheritedDependencyBranches,
+    installEvaluationDeps,
     isLive,
-    mountTransitiveDeps,
-    onLiveDependencyAdded,
-    onLiveDependencyRemoved,
     reconcileLivenessAfterChurn,
-    unmountOrphanedDeps,
-} from "./mountAtom"
+    type EvaluationOutcome,
+} from "./graph"
 import { recordCommitError, type CommitErrors } from "./commitErrors"
 import {
     changeListenerRegistry,
@@ -55,7 +56,6 @@ import {
     commitRootOf,
     endCommit,
 } from "./onCommitEnd"
-import { hasInheritedDependencyBranches } from "./inheritedDependencyBranches"
 import { setValueInData } from "./setValueInData"
 import { noteStateValueChanged } from "./stateRevisions"
 import {
@@ -257,6 +257,7 @@ const reEvaluateSelector = (
     data: StoreData,
     updatedAtoms: Set<Atom>,
     depsChange: DepsChange,
+    outcome: EvaluationOutcome,
     existingValue: unknown,
     treeCtx?: TreeSettleContext,
 ): boolean => {
@@ -269,8 +270,25 @@ const reEvaluateSelector = (
             updatedAtoms,
             undefined,
             true,
-            depsChange,
+            outcome,
         )
+        // The carrier is owned per PASS (like the reusable depsChange), not
+        // per re-eval: the evaluator overwrites every field before returning
+        // and the install consumes them immediately, so the steady-state loop
+        // pays no pool traffic. Passing the loop's depsChange keeps the
+        // lazy-arm OFF for loop-driven re-evals: their dependency diff is
+        // applied incrementally by the caller via applyLiveDependencyDiff.
+        if (outcome.needsInstall) {
+            installEvaluationDeps(
+                selector,
+                data,
+                outcome.deps!,
+                outcome.prevDeps,
+                true,
+                outcome.isAsync,
+                depsChange,
+            )
+        }
         // This evaluator is reached from the committed reverse graph; cold
         // selectors are deliberately absent from that graph. Passing the known
         // mode avoids a second WeakSet lookup for every propagated selector.
@@ -2087,8 +2105,10 @@ const propagateDownstreamTopo = (
     // writes that side-effect into peer selectors during eval depend on it.
     // Reused across every re-evaluated selector. evaluateSelector only
     // allocates the inner Sets when deps actually changed, so steady-state
-    // settling does zero allocation here.
+    // settling does zero allocation here. The outcome carrier is likewise
+    // owned per pass: each re-eval overwrites and consumes it in place.
     const depsChange: DepsChange = {}
+    const outcome = createEvaluationOutcome()
     let head = 0
     while (head < ready.length) {
         const selector = ready[head++]
@@ -2135,6 +2155,7 @@ const propagateDownstreamTopo = (
             data,
             updatedInitializedAtoms,
             depsChange,
+            outcome,
             currentValue,
             treeCtx,
         )
@@ -2145,20 +2166,7 @@ const propagateDownstreamTopo = (
         if (added || removed) {
             // The graph changed under the walk — a node may now be stranded.
             graphMutated = true
-            if (isLive(selector, data)) {
-                if (added) {
-                    for (const dep of added) {
-                        onLiveDependencyAdded(dep, data)
-                        mountTransitiveDeps(dep, data)
-                    }
-                }
-                if (removed) {
-                    for (const dep of removed) {
-                        onLiveDependencyRemoved(dep, data)
-                        unmountOrphanedDeps(dep, data)
-                    }
-                }
-            }
+            applyLiveDependencyDiff(selector, added, removed, data)
         }
 
         pending.delete(selector)
@@ -2246,24 +2254,14 @@ const propagateDownstreamTopo = (
             data,
             updatedInitializedAtoms,
             depsChange,
+            outcome,
             currentValue,
             treeCtx,
         )
         const added = depsChange.added as Set<State> | undefined
         const removed = depsChange.removed as Set<State> | undefined
-        if ((added || removed) && isLive(selector, data)) {
-            if (added) {
-                for (const dep of added) {
-                    onLiveDependencyAdded(dep, data)
-                    mountTransitiveDeps(dep, data)
-                }
-            }
-            if (removed) {
-                for (const dep of removed) {
-                    onLiveDependencyRemoved(dep, data)
-                    unmountOrphanedDeps(dep, data)
-                }
-            }
+        if (added || removed) {
+            applyLiveDependencyDiff(selector, added, removed, data)
         }
         if (wasValueUpdated) {
             if (changedSelectors) changedSelectors.add(selector)
@@ -2376,6 +2374,7 @@ const propagateSelectorUpdatesLinearFirst = (
     const processedInitialSelectors = new Set<Selector>()
     // Reused across every re-evaluated selector — see propagateDownstreamTopo.
     const depsChange: DepsChange = {}
+    const outcome = createEvaluationOutcome()
     for (const selector of orderedSelectors) {
         const currentValue = data.values.get(selector)
         if (isPromiseLike(currentValue) && isInitOnly) {
@@ -2403,6 +2402,7 @@ const propagateSelectorUpdatesLinearFirst = (
             data,
             updatedInitializedAtoms,
             depsChange,
+            outcome,
             currentValue,
             treeCtx,
         )
@@ -2410,19 +2410,8 @@ const propagateSelectorUpdatesLinearFirst = (
         // property accesses lose their narrowing after a function call.
         const added = depsChange.added as Set<State> | undefined
         const removed = depsChange.removed as Set<State> | undefined
-        if ((added || removed) && isLive(selector, data)) {
-            if (added) {
-                for (const dep of added) {
-                    onLiveDependencyAdded(dep, data)
-                    mountTransitiveDeps(dep, data)
-                }
-            }
-            if (removed) {
-                for (const dep of removed) {
-                    onLiveDependencyRemoved(dep, data)
-                    unmountOrphanedDeps(dep, data)
-                }
-            }
+        if (added || removed) {
+            applyLiveDependencyDiff(selector, added, removed, data)
         }
         processedInitialSelectors.add(selector)
         if (!wasValueUpdated) continue

--- a/packages/valdres/src/lib/setValueInData.ts
+++ b/packages/valdres/src/lib/setValueInData.ts
@@ -4,7 +4,9 @@ import type { StoreData } from "../types/StoreData"
 import { deepFreeze } from "../utils/deepFreeze"
 import { isAtomFamily } from "../utils/isAtomFamily"
 import { ensureFamilyAncestorChain } from "./atomFamilyIndex"
-import { refreshInheritedDependencyBranch } from "./inheritedDependencyBranches"
+import {
+    refreshInheritedDependencyBranch,
+} from "./graph"
 import { IS_PROD } from "./IS_PROD"
 import { trackScopeValue } from "./trackScopeValue"
 

--- a/packages/valdres/src/lib/storeFromStoreData.ts
+++ b/packages/valdres/src/lib/storeFromStoreData.ts
@@ -14,13 +14,13 @@ import { unsetValue } from "./unsetValue"
 import { createStoreData } from "./createStoreData"
 import { deleteFamilyAtom } from "./deleteFamilyAtom"
 import { disposeStoreData } from "./disposeStoreData"
-import { flushPendingOrphanCleanup } from "./flushPendingOrphanCleanup"
-import { getState } from "./getState"
 import {
     beginLivenessPass,
     endLivenessPass,
+    flushPendingOrphanCleanup,
     reconcileLivenessAfterChurn,
-} from "./mountAtom"
+} from "./graph"
+import { getState } from "./getState"
 import { onCommitEnd } from "./onCommitEnd"
 import { onStoreChange } from "./onStoreChange"
 import { SETTLE_INIT_ONLY } from "./commitIntents"

--- a/packages/valdres/src/lib/subscribe.ts
+++ b/packages/valdres/src/lib/subscribe.ts
@@ -21,7 +21,10 @@ import { getState } from "./getState"
 import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
 import { setValueInData } from "./setValueInData"
 import { setMaxAgeCleanup } from "./maxAgeCleanups"
-import { mountTransitiveDeps, onFirstDirectSubscriber } from "./mountAtom"
+import {
+    mountTransitiveDeps,
+    onFirstDirectSubscriber,
+} from "./graph"
 import {
     createStoreDisposedError,
     DISPOSED_STORE_PENDING,

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -5,7 +5,9 @@ import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_INIT_ONLY, SETTLE_UNSET } from "./commitIntents"
 import { getState } from "./getState"
-import { refreshInheritedDependencyBranch } from "./inheritedDependencyBranches"
+import {
+    refreshInheritedDependencyBranch,
+} from "./graph"
 import {
     createChangeSink,
     flushChangeSink,

--- a/packages/valdres/src/lib/unsubscribe.ts
+++ b/packages/valdres/src/lib/unsubscribe.ts
@@ -6,11 +6,11 @@ import { getMaxAgeCleanup, deleteMaxAgeCleanup } from "./maxAgeCleanups"
 import {
     isLive,
     onLastDirectSubscriber,
+    queueOrphanCleanup,
     reconcileLivenessAfterChurn,
     regionHasCycle,
     unmountOrphanedDeps,
-} from "./mountAtom"
-import { queueOrphanCleanup } from "./queueOrphanCleanup"
+} from "./graph"
 
 const equalCheckCount = Symbol()
 type CountedSubscriptions = Set<Subscription> & {

--- a/packages/valdres/src/types/DepsChange.ts
+++ b/packages/valdres/src/types/DepsChange.ts
@@ -1,0 +1,12 @@
+import type { State } from "./State"
+
+/**
+ * Holder for dep-change tracking during propagation. The Sets inside are
+ * allocated lazily by the graph installer only when deps actually changed —
+ * the steady-state case (same deps re-evaluated) does no allocation here.
+ * Callers should clear `added` / `removed` to `undefined` before reuse.
+ */
+export type DepsChange = {
+    added?: Set<State>
+    removed?: Set<State>
+}

--- a/packages/valdres/test/build.test.ts
+++ b/packages/valdres/test/build.test.ts
@@ -52,7 +52,13 @@ describe("build output", () => {
                 code.includes('Symbol("valdres.storeDataAccess")'),
             ),
         ).toHaveLength(1)
-        expect(outputs[index]).not.toContain("Transaction")
+        // The single runtime must live in a shared chunk, not be duplicated
+        // into (or defined by) either entry. The public entry may still
+        // reference it by name: since the graph runtime stopped importing the
+        // store constructor, the adapter graph no longer reaches
+        // storeFromStoreData, which is therefore bundled index-only and imports
+        // TransactionContext from the chunk under its real name.
+        expect(outputs[index]).not.toContain("class TransactionContext")
         expect(outputs[adapterInternals]).toContain("Transaction")
     })
 

--- a/packages/valdres/test/import-cycles/graphBoundary.test.ts
+++ b/packages/valdres/test/import-cycles/graphBoundary.test.ts
@@ -244,6 +244,47 @@ describe("mutation-scan fixtures", () => {
         ).toEqual(["stateDependents"])
     })
 
+    test("catches writes through bracket access", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: object) => {
+                data["stateDependents"].set(s, new Set())
+                data[\`liveDependentCount\`].set(s, 1)
+            }`),
+        ).toEqual(["stateDependents", "liveDependentCount"])
+        // A computed non-literal string key on a StoreData receiver cannot be
+        // proven safe — flagged conservatively in mutating positions.
+        expect(
+            flagged(`export const f = (
+                data: StoreData,
+                key: "stateDependents" | "stateDependencies",
+                s: object,
+            ) => {
+                data[key].set(s, new Set())
+            }`),
+        ).toEqual(["<computed>"])
+        // Bracket-keyed destructuring records the alias like dot access does.
+        expect(
+            flagged(`export const f = (data: StoreData, s: object) => {
+                const { ["mountInClosure"]: table } = data
+                table.delete(s)
+            }`),
+        ).toEqual(["mountInClosure"])
+    })
+
+    test("ignores symbol-keyed slots and unowned bracket planes", () => {
+        expect(
+            flagged(`declare const SLOT: unique symbol
+            export const f = (
+                data: StoreData & { [SLOT]?: number },
+                s: object,
+                v: unknown,
+            ) => {
+                data[SLOT] = 1
+                data["values"].set(s, v)
+            }`),
+        ).toEqual([])
+    })
+
     test("catches writes through a generic StoreData-constrained receiver", () => {
         expect(
             flagged(`export const f = <T extends StoreData>(data: T, s: State) => {

--- a/packages/valdres/test/import-cycles/graphBoundary.test.ts
+++ b/packages/valdres/test/import-cycles/graphBoundary.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test"
+import { resolve } from "node:path"
+import { buildImportGraph, computeSccs, PACKAGE_ROOT } from "./importGraph"
+import {
+    createProductionProgram,
+    scanFixture,
+    scanSourceFileForGraphMutations,
+} from "./graphTableMutationScan"
+
+/**
+ * GraphRuntime boundary guard (see src/lib/graph/index.ts for the contract):
+ *
+ * 1. Import structure — the graph cluster is a LEAF layer: none of its files
+ *    participates in any import cycle, its full transitive runtime-import
+ *    closure stays inside graph/ plus a fixed leaf allowlist, and non-graph
+ *    production code enters only through the facade. The historical core SCC
+ *    is pinned to (a subset of) its current nine members so the 24→9
+ *    reduction cannot silently regress — this asserts the TARGET, unlike the
+ *    baseline ratchet, which a regeneration could otherwise re-bless.
+ *
+ * 2. Table ownership — no production module outside src/lib/graph/ writes a
+ *    graph table on StoreData. Enforced with the TypeScript checker (receiver
+ *    TYPE resolution + local alias tracking), not receiver regexes; fixture
+ *    tests below prove the guard catches the real mutation shapes and ignores
+ *    the sanctioned ones.
+ */
+
+const GRAPH_DIR = "src/lib/graph/"
+
+/** The exact members of the one remaining core write-path SCC. Shrinking is
+ *  welcome (subset allowed); growing or re-merging freed modules fails. */
+const CORE_SCC_MEMBERS = new Set([
+    "src/lib/coordinateAsyncWrite.ts",
+    "src/lib/getState.ts",
+    "src/lib/globalAtomFanOut.ts",
+    "src/lib/initAtom.ts",
+    "src/lib/initSelector.ts",
+    "src/lib/propagateUpdatedAtoms.ts",
+    "src/lib/resolveAtomDefaultValue.ts",
+    "src/lib/setAtom.ts",
+    "src/lib/unsetValue.ts",
+])
+
+/** Every module the graph cluster may reach at runtime, transitively. Adding
+ *  an import that escapes this set risks re-entering the write-path cycle —
+ *  extend it only for genuine leaves, consciously. */
+const GRAPH_LEAF_ALLOWLIST = new Set([
+    "src/lib/storeLifecycle.ts",
+    "src/lib/stateRevisions.ts",
+    "src/lib/getStoreRuntime.ts",
+    "src/lib/storeRuntimeKey.ts",
+    "src/utils/isSelector.ts",
+    "src/utils/isAtom.ts",
+    "src/utils/isAtomFamily.ts",
+    "src/errors/StoreDisposedError.ts",
+])
+
+/** Production files allowed to write graph-table fields directly. */
+const MUTATION_ALLOWLIST = new Set([
+    // Constructor-owned field initialization (fixes the hidden class); the
+    // store is not observable while createStoreData runs.
+    "src/lib/createStoreData.ts",
+])
+
+describe("graph import structure", () => {
+    const graph = buildImportGraph()
+    const sccs = computeSccs(graph)
+
+    test("no graph module participates in any import cycle", () => {
+        const inCycles = sccs
+            .flat()
+            .filter(module => module.startsWith(GRAPH_DIR))
+        expect(inCycles).toEqual([])
+    })
+
+    test("every SCC is a subset of the verified nine-module core", () => {
+        for (const scc of sccs) {
+            const escapees = scc.filter(
+                module => !CORE_SCC_MEMBERS.has(module),
+            )
+            expect(escapees).toEqual([])
+        }
+        expect(Math.max(0, ...sccs.map(scc => scc.length))).toBeLessThanOrEqual(
+            CORE_SCC_MEMBERS.size,
+        )
+    })
+
+    test("graph cluster's transitive runtime closure stays on leaves", () => {
+        const roots = [...graph.keys()].filter(module =>
+            module.startsWith(GRAPH_DIR),
+        )
+        expect(roots.length).toBeGreaterThanOrEqual(9)
+        const closure = new Set(roots)
+        const queue = [...roots]
+        while (queue.length > 0) {
+            for (const target of graph.get(queue.pop()!) ?? []) {
+                if (!closure.has(target)) {
+                    closure.add(target)
+                    queue.push(target)
+                }
+            }
+        }
+        const escapees = [...closure]
+            .filter(module => !module.startsWith(GRAPH_DIR))
+            .filter(module => !GRAPH_LEAF_ALLOWLIST.has(module))
+            .sort()
+        expect(escapees).toEqual([])
+    })
+
+    test("non-graph production code imports only the graph facade", () => {
+        const offenders: string[] = []
+        for (const [module, edges] of graph) {
+            if (module.startsWith(GRAPH_DIR)) continue
+            for (const target of edges) {
+                if (
+                    target.startsWith(GRAPH_DIR) &&
+                    target !== "src/lib/graph/index.ts"
+                ) {
+                    offenders.push(`${module} -> ${target}`)
+                }
+            }
+        }
+        expect(offenders).toEqual([])
+    })
+})
+
+describe("graph table ownership", () => {
+    const modules = [...buildImportGraph().keys()]
+    const program = createProductionProgram(modules)
+    const checker = program.getTypeChecker()
+
+    const violationsFor = (predicate: (module: string) => boolean) => {
+        const found: string[] = []
+        for (const module of modules) {
+            if (!predicate(module)) continue
+            const sourceFile = program.getSourceFile(
+                resolve(PACKAGE_ROOT, module),
+            )
+            if (!sourceFile) continue
+            for (const violation of scanSourceFileForGraphMutations(
+                sourceFile,
+                checker,
+            )) {
+                found.push(
+                    `${module}:${violation.line} [${violation.property}] ${violation.text}`,
+                )
+            }
+        }
+        return found.sort()
+    }
+
+    test("no module outside src/lib/graph/ mutates a graph table", () => {
+        const offenders = violationsFor(
+            module =>
+                !module.startsWith(GRAPH_DIR) &&
+                !MUTATION_ALLOWLIST.has(module),
+        )
+        expect(offenders).toEqual([])
+    })
+
+    test("non-vacuity: the scan sees the graph runtime's own writes", () => {
+        // If the table list, the type resolution, or module discovery silently
+        // broke, the ownership test above would pass trivially. The graph
+        // cluster performs dozens of these writes by design — require the
+        // scanner to find them.
+        const inGraph = violationsFor(module => module.startsWith(GRAPH_DIR))
+        expect(inGraph.length).toBeGreaterThanOrEqual(30)
+        // And the allowlisted constructor initializes most tables directly.
+        const inConstructor = violationsFor(module =>
+            MUTATION_ALLOWLIST.has(module),
+        )
+        expect(inConstructor.length).toBeGreaterThanOrEqual(3)
+    })
+})
+
+describe("mutation-scan fixtures", () => {
+    const flagged = (code: string) => scanFixture(code).map(v => v.property)
+
+    test("catches direct table method calls", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: State) => {
+                data.stateDependents.set(s, new Set())
+            }`),
+        ).toEqual(["stateDependents"])
+    })
+
+    test("catches scalar assignments and increments", () => {
+        expect(
+            flagged(`export const f = (data: StoreData) => {
+                data.dependencyGraphVersion++
+                data.livenessLazyArmed = true
+                data.livenessSeeds ??= new Set()
+            }`),
+        ).toEqual([
+            "dependencyGraphVersion",
+            "livenessLazyArmed",
+            "livenessSeeds",
+        ])
+    })
+
+    test("catches nested Set mutation through a value alias", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: object, d: State) => {
+                const deps = data.stateDependencies.get(s)
+                deps!.add(d)
+            }`),
+        ).toEqual(["stateDependencies"])
+    })
+
+    test("catches chained value mutation without an alias", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: object, d: State) => {
+                data.stateDependents.get(s)?.add(d)
+            }`),
+        ).toEqual(["stateDependents"])
+    })
+
+    test("catches destructured and renamed receivers", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: object) => {
+                const { liveDependentCount } = data
+                liveDependentCount.set(s, 1)
+            }`),
+        ).toEqual(["liveDependentCount"])
+        expect(
+            flagged(`export const f = (data: StoreData, s: object) => {
+                const runtime = data
+                runtime.selectorGraphActive.delete(s)
+            }`),
+        ).toEqual(["selectorGraphActive"])
+        expect(
+            flagged(`export const f = (data: StoreData, s: object) => {
+                const table = data.mountInClosure
+                table.delete(s)
+            }`),
+        ).toEqual(["mountInClosure"])
+    })
+
+    test("catches writes through an untyped receiver", () => {
+        expect(
+            flagged(`export const f = (data: any, s: object) => {
+                data.stateDependents.delete(s)
+            }`),
+        ).toEqual(["stateDependents"])
+    })
+
+    test("catches writes through a generic StoreData-constrained receiver", () => {
+        expect(
+            flagged(`export const f = <T extends StoreData>(data: T, s: State) => {
+                data.stateDependents.set(s, new Set())
+            }`),
+        ).toEqual(["stateDependents"])
+        // Indirect constraint chains resolve too.
+        expect(
+            flagged(`export const f = <
+                T extends StoreData,
+                U extends T,
+            >(data: U, s: object) => {
+                data.liveDependentCount.set(s, 1)
+            }`),
+        ).toEqual(["liveDependentCount"])
+    })
+
+    test("ignores reads, sentinels, comments, and strings", () => {
+        expect(
+            flagged(`declare const DISPOSED: Set<State>
+            export const f = (data: StoreData, s: object) => {
+                // data.stateDependents.set(s, new Set())
+                const label = "data.stateDependents.set"
+                const deps = data.stateDependencies.get(s)
+                const terminal = data.pendingOrphanCleanup === DISPOSED
+                return [label, deps?.size, terminal, data.mounts.has(s)]
+            }`),
+        ).toEqual([])
+    })
+
+    test("exempts the transaction overlay and the resource ledger by type", () => {
+        expect(
+            flagged(`export const f = (
+                runtime: SelectorEvaluationRuntime,
+                resources: StoreResources,
+                s: object,
+                d: State,
+            ) => {
+                runtime.stateDependencies.set(s, new Set())
+                runtime.stateDependencies.get(s)?.add(d)
+                resources.mounts.add(d)
+                resources.mounts.delete(d)
+            }`),
+        ).toEqual([])
+    })
+
+    test("does not flag unowned StoreData planes", () => {
+        expect(
+            flagged(`export const f = (data: StoreData, s: object, v: unknown) => {
+                data.values.set(s, v)
+                data.subscriptions.get(s)?.delete(s as any)
+            }`),
+        ).toEqual([])
+    })
+})

--- a/packages/valdres/test/import-cycles/graphTableMutationScan.ts
+++ b/packages/valdres/test/import-cycles/graphTableMutationScan.ts
@@ -1,0 +1,399 @@
+import ts from "typescript"
+import { resolve } from "node:path"
+import { PACKAGE_ROOT } from "./importGraph"
+
+/**
+ * TypeScript-checker-based scan for writes to the dependency-graph tables on
+ * `StoreData` (see src/lib/graph/index.ts for the ownership contract). Powers
+ * graphBoundary.test.ts.
+ *
+ * A regex over receivers cannot carry this guarantee: real mutation shapes in
+ * the codebase flow through aliased Sets/Maps (`deps.add(...)` where `deps`
+ * came from `data.stateDependencies.get(...)`), destructuring, renamed
+ * receivers, and optional chains. This scan instead resolves the RECEIVER'S
+ * TYPE with the compiler — any expression whose type is `StoreData` counts,
+ * however it is named — and tracks local aliases of graph tables and of their
+ * contained Sets syntactically. The transaction overlay
+ * (`SelectorEvaluationRuntime`) and the lifecycle ledgers (`StoreResources`)
+ * are exempt BY TYPE, not by variable name, so renaming a receiver cannot
+ * smuggle a write past the guard, and `StoreData.mounts` is distinguished
+ * from the ledger's `mounts` Set. An `any`/`unknown`-typed receiver with an
+ * owned property name is flagged conservatively — an untyped escape hatch
+ * must not become a mutation side door.
+ */
+
+/** Container-valued graph tables: mutated through set/add/delete/clear, on the
+ *  table itself or on a Set retrieved from it. */
+export const GRAPH_TABLES = new Set([
+    "stateDependencies",
+    "stateDependents",
+    "selectorGraphActive",
+    "inheritedDependencyBranches",
+    "inheritedDependencyKeys",
+    "liveDependentCount",
+    "mounts",
+    "mountInClosure",
+    "livenessSeeds",
+    "dependencyOrder",
+    "cycleRiskInClosure",
+    "acyclicDependencyVersion",
+    "orphanCleanupVersion",
+    "pendingOrphanCleanup",
+])
+
+/** Scalar/replaceable graph fields: mutated by assignment or ++/--. */
+export const GRAPH_SCALARS = new Set([
+    "dependencyGraphVersion",
+    "nextDependencyOrder",
+    "orphanCleanupScheduled",
+    "livenessPassActive",
+    "livenessSeeds",
+    "livenessRemovalArmed",
+    "livenessLazyArmed",
+    "pendingOrphanCleanup",
+])
+
+const MUTATING_METHODS = new Set(["set", "add", "delete", "clear"])
+
+const ASSIGNMENT_OPS = new Set<ts.SyntaxKind>([
+    ts.SyntaxKind.EqualsToken,
+    ts.SyntaxKind.PlusEqualsToken,
+    ts.SyntaxKind.MinusEqualsToken,
+    ts.SyntaxKind.QuestionQuestionEqualsToken,
+    ts.SyntaxKind.BarBarEqualsToken,
+    ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+])
+
+export type MutationViolation = {
+    file: string
+    line: number
+    property: string
+    text: string
+}
+
+const stripWrappers = (node: ts.Expression): ts.Expression => {
+    while (
+        ts.isParenthesizedExpression(node) ||
+        ts.isAsExpression(node) ||
+        ts.isNonNullExpression(node) ||
+        ts.isSatisfiesExpression(node)
+    ) {
+        node = node.expression
+    }
+    return node
+}
+
+const typeMatches = (
+    checker: ts.TypeChecker,
+    type: ts.Type,
+    name: string,
+): boolean => {
+    if (type.aliasSymbol?.name === name) return true
+    if (type.getSymbol()?.name === name) return true
+    if (type.isUnionOrIntersection()) {
+        return type.types.some(t => typeMatches(checker, t, name))
+    }
+    // Follow generic constraints: a `<T extends StoreData>(data: T)` receiver
+    // is a StoreData for mutation purposes and must not slip the guard.
+    if (type.isTypeParameter()) {
+        const constraint = checker.getBaseConstraintOfType(type)
+        if (constraint && constraint !== type) {
+            return typeMatches(checker, constraint, name)
+        }
+    }
+    return false
+}
+
+const isAnyOrUnknown = (type: ts.Type): boolean =>
+    (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0
+
+/** Alias kinds a local variable can hold: a graph table itself, or a Set
+ *  value retrieved from one. Carries the underlying table for reporting. */
+type AliasKind = "table" | "value"
+type AliasInfo = { kind: AliasKind; property: string }
+
+export const scanSourceFileForGraphMutations = (
+    sourceFile: ts.SourceFile,
+    checker: ts.TypeChecker,
+): MutationViolation[] => {
+    const violations: MutationViolation[] = []
+    const aliases = new Map<string, AliasInfo>()
+
+    const report = (node: ts.Node, property: string) => {
+        const { line } = sourceFile.getLineAndCharacterOfPosition(
+            node.getStart(sourceFile),
+        )
+        violations.push({
+            file: sourceFile.fileName,
+            line: line + 1,
+            property,
+            text: node.getText(sourceFile).split("\n")[0]!.slice(0, 120),
+        })
+    }
+
+    /** `expr.prop` where prop is an owned name and expr resolves to StoreData
+     *  (or is untyped). Returns the property name, else undefined. */
+    const graphTableAccess = (
+        node: ts.Expression,
+        names: Set<string>,
+    ): string | undefined => {
+        const expr = stripWrappers(node)
+        if (!ts.isPropertyAccessExpression(expr)) return undefined
+        const property = expr.name.text
+        if (!names.has(property)) return undefined
+        const base = stripWrappers(expr.expression)
+        const baseType = checker.getTypeAtLocation(base)
+        if (
+            typeMatches(checker, baseType, "StoreData") ||
+            isAnyOrUnknown(baseType)
+        ) {
+            return property
+        }
+        return undefined
+    }
+
+    /** `T.get(...)` (possibly optional-chained) where T is a graph table. */
+    const tableValueRetrieval = (node: ts.Expression): string | undefined => {
+        const expr = stripWrappers(node)
+        if (!ts.isCallExpression(expr)) return undefined
+        const callee = stripWrappers(expr.expression)
+        if (!ts.isPropertyAccessExpression(callee)) return undefined
+        if (callee.name.text !== "get") return undefined
+        const table = graphTableAccess(callee.expression, GRAPH_TABLES)
+        if (table) return table
+        // Alias-of-alias: `tableAlias.get(...)`.
+        const receiver = stripWrappers(callee.expression)
+        if (ts.isIdentifier(receiver)) {
+            const alias = aliases.get(receiver.text)
+            if (alias?.kind === "table") return alias.property
+        }
+        return undefined
+    }
+
+    /** Initializers that produce a table or contained-Set alias, including
+     *  `expr ?? new Set()` / `expr || fallback` shapes. */
+    const aliasKindOfInitializer = (
+        init: ts.Expression,
+    ): AliasInfo | undefined => {
+        const expr = stripWrappers(init)
+        const table = graphTableAccess(expr, GRAPH_TABLES)
+        if (table) return { kind: "table", property: table }
+        const value = tableValueRetrieval(expr)
+        if (value) return { kind: "value", property: value }
+        if (ts.isBinaryExpression(expr)) {
+            const op = expr.operatorToken.kind
+            if (
+                op === ts.SyntaxKind.QuestionQuestionToken ||
+                op === ts.SyntaxKind.BarBarToken
+            ) {
+                return (
+                    aliasKindOfInitializer(expr.left) ??
+                    aliasKindOfInitializer(expr.right)
+                )
+            }
+        }
+        if (ts.isIdentifier(expr)) return aliases.get(expr.text)
+        return undefined
+    }
+
+    const recordDeclarationAliases = (declaration: ts.VariableDeclaration) => {
+        const init = declaration.initializer
+        if (!init) return
+        if (ts.isIdentifier(declaration.name)) {
+            const alias = aliasKindOfInitializer(init)
+            // A non-alias initializer SHADOWS any earlier same-named alias —
+            // the map is file-scoped, so "most recent declaration wins" keeps
+            // an unrelated local (`const downstream = new Map()`) from
+            // inheriting an alias recorded in a previous function.
+            if (alias) aliases.set(declaration.name.text, alias)
+            else aliases.delete(declaration.name.text)
+            return
+        }
+        // Destructuring a graph table straight off a StoreData-typed object:
+        // `const { stateDependents } = data`.
+        if (ts.isObjectBindingPattern(declaration.name)) {
+            const initType = checker.getTypeAtLocation(stripWrappers(init))
+            if (
+                !typeMatches(checker, initType, "StoreData") &&
+                !isAnyOrUnknown(initType)
+            )
+                return
+            for (const element of declaration.name.elements) {
+                const property = ts.isIdentifier(element.propertyName ?? element.name)
+                    ? (element.propertyName ?? element.name).getText(sourceFile)
+                    : undefined
+                if (
+                    property &&
+                    GRAPH_TABLES.has(property) &&
+                    ts.isIdentifier(element.name)
+                ) {
+                    aliases.set(element.name.text, {
+                        kind: "table",
+                        property,
+                    })
+                }
+            }
+        }
+    }
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isVariableDeclaration(node)) recordDeclarationAliases(node)
+
+        // Method-call mutations: X.set/add/delete/clear(...)
+        if (ts.isCallExpression(node)) {
+            const callee = stripWrappers(node.expression)
+            if (
+                ts.isPropertyAccessExpression(callee) &&
+                MUTATING_METHODS.has(callee.name.text)
+            ) {
+                const receiverRaw = callee.expression
+                const receiver = stripWrappers(receiverRaw)
+                const direct = graphTableAccess(receiverRaw, GRAPH_TABLES)
+                if (direct) {
+                    report(node, direct)
+                } else {
+                    const chained = tableValueRetrieval(receiverRaw)
+                    if (chained) {
+                        report(node, chained)
+                    } else if (ts.isIdentifier(receiver)) {
+                        const alias = aliases.get(receiver.text)
+                        if (alias) report(node, alias.property)
+                    }
+                }
+            }
+        }
+
+        // Assignment mutations: data.<field> = / ??= / ++ / --
+        if (
+            ts.isBinaryExpression(node) &&
+            ASSIGNMENT_OPS.has(node.operatorToken.kind)
+        ) {
+            const target = graphTableAccess(
+                node.left,
+                new Set([...GRAPH_TABLES, ...GRAPH_SCALARS]),
+            )
+            if (target) report(node, target)
+            // Track alias reassignment: `deps = data.stateDependencies.get(x)`.
+            if (
+                node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+                ts.isIdentifier(node.left)
+            ) {
+                const alias = aliasKindOfInitializer(node.right)
+                if (alias) aliases.set(node.left.text, alias)
+                else aliases.delete(node.left.text)
+            }
+        }
+        if (
+            (ts.isPrefixUnaryExpression(node) ||
+                ts.isPostfixUnaryExpression(node)) &&
+            (node.operator === ts.SyntaxKind.PlusPlusToken ||
+                node.operator === ts.SyntaxKind.MinusMinusToken)
+        ) {
+            const target = graphTableAccess(
+                node.operand,
+                new Set([...GRAPH_TABLES, ...GRAPH_SCALARS]),
+            )
+            if (target) report(node, target)
+        }
+
+        ts.forEachChild(node, visit)
+    }
+
+    visit(sourceFile)
+    return violations
+}
+
+/** Build one checker program over the package's production sources. */
+export const createProductionProgram = (rootRelPaths: string[]): ts.Program => {
+    const configPath = resolve(PACKAGE_ROOT, "tsconfig.json")
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile)
+    const parsed = ts.parseJsonConfigFileContent(
+        configFile.config,
+        ts.sys,
+        PACKAGE_ROOT,
+    )
+    return ts.createProgram({
+        rootNames: rootRelPaths.map(rel => resolve(PACKAGE_ROOT, rel)),
+        options: { ...parsed.options, noEmit: true, declaration: false },
+    })
+}
+
+/** Compile an inline fixture against stub graph types and scan it — used by
+ *  the guard's own positive/negative fixture tests. */
+export const scanFixture = (code: string): MutationViolation[] => {
+    const FIXTURE_TYPES = `
+export type State = { __state: true }
+export type StoreData = {
+    parent?: StoreData
+    stateDependencies: WeakMap<object, Set<State>>
+    stateDependents: WeakMap<object, Set<State>>
+    selectorGraphActive: WeakSet<object>
+    inheritedDependencyBranches: WeakMap<object, Set<StoreData>>
+    inheritedDependencyKeys?: Set<object>
+    liveDependentCount: WeakMap<object, number>
+    mounts: WeakMap<object, { cleanup?: () => void }>
+    mountInClosure: WeakMap<object, true>
+    livenessSeeds?: Set<State>
+    livenessPassActive?: boolean
+    livenessRemovalArmed?: boolean
+    livenessLazyArmed?: boolean
+    dependencyOrder: WeakMap<object, number>
+    nextDependencyOrder: number
+    dependencyGraphVersion: number
+    cycleRiskInClosure: WeakMap<object, true>
+    acyclicDependencyVersion: WeakMap<object, number>
+    orphanCleanupVersion: WeakMap<object, number>
+    pendingOrphanCleanup?: Set<State>
+    orphanCleanupScheduled: boolean
+    values: WeakMap<object, unknown>
+    subscriptions: WeakMap<object, Set<object>>
+}
+export type SelectorEvaluationRuntime = {
+    stateDependencies: Map<object, Set<State>>
+}
+export type StoreResources = {
+    mounts: Set<State>
+}
+`
+    const files = new Map<string, string>([
+        ["/fixture-types.ts", FIXTURE_TYPES],
+        [
+            "/fixture.ts",
+            `import type { State, StoreData, SelectorEvaluationRuntime, StoreResources } from "./fixture-types"\n${code}`,
+        ],
+    ])
+    const options: ts.CompilerOptions = {
+        target: ts.ScriptTarget.ES2022,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        strict: true,
+        noEmit: true,
+    }
+    const host = ts.createCompilerHost(options)
+    const realGetSourceFile = host.getSourceFile.bind(host)
+    host.getSourceFile = (fileName, languageVersion, ...rest) => {
+        const virtual = files.get(fileName)
+        if (virtual !== undefined) {
+            return ts.createSourceFile(
+                fileName,
+                virtual,
+                languageVersion,
+                true,
+            )
+        }
+        return realGetSourceFile(fileName, languageVersion, ...rest)
+    }
+    const realFileExists = host.fileExists.bind(host)
+    host.fileExists = fileName =>
+        files.has(fileName) || realFileExists(fileName)
+    const realReadFile = host.readFile.bind(host)
+    host.readFile = fileName => files.get(fileName) ?? realReadFile(fileName)
+
+    const program = ts.createProgram({
+        rootNames: ["/fixture.ts"],
+        options,
+        host,
+    })
+    const sourceFile = program.getSourceFile("/fixture.ts")!
+    return scanSourceFileForGraphMutations(sourceFile, program.getTypeChecker())
+}

--- a/packages/valdres/test/import-cycles/graphTableMutationScan.ts
+++ b/packages/valdres/test/import-cycles/graphTableMutationScan.ts
@@ -10,7 +10,9 @@ import { PACKAGE_ROOT } from "./importGraph"
  * A regex over receivers cannot carry this guarantee: real mutation shapes in
  * the codebase flow through aliased Sets/Maps (`deps.add(...)` where `deps`
  * came from `data.stateDependencies.get(...)`), destructuring, renamed
- * receivers, and optional chains. This scan instead resolves the RECEIVER'S
+ * receivers, bracket access (`data["stateDependents"]`, including computed
+ * string keys — flagged conservatively; symbol-keyed slots are exempt), and
+ * optional chains. This scan instead resolves the RECEIVER'S
  * TYPE with the compiler — any expression whose type is `StoreData` counts,
  * however it is named — and tracks local aliases of graph tables and of their
  * contained Sets syntactically. The transaction overlay
@@ -131,23 +133,53 @@ export const scanSourceFileForGraphMutations = (
         })
     }
 
-    /** `expr.prop` where prop is an owned name and expr resolves to StoreData
-     *  (or is untyped). Returns the property name, else undefined. */
+    /** `expr.prop` / `expr["prop"]` where prop is an owned name and expr
+     *  resolves to StoreData (or is untyped). Returns the property name, else
+     *  undefined. A computed access with a NON-literal key on a StoreData
+     *  receiver is flagged conservatively as `<computed>` when it appears in
+     *  a mutating position — the key cannot be proven safe statically, and
+     *  production code has no legitimate reason to mutate StoreData through
+     *  a dynamic key. */
     const graphTableAccess = (
         node: ts.Expression,
         names: Set<string>,
     ): string | undefined => {
         const expr = stripWrappers(node)
-        if (!ts.isPropertyAccessExpression(expr)) return undefined
-        const property = expr.name.text
-        if (!names.has(property)) return undefined
-        const base = stripWrappers(expr.expression)
+        let property: string | undefined
+        let baseNode: ts.Expression
+        if (ts.isPropertyAccessExpression(expr)) {
+            property = expr.name.text
+            baseNode = expr.expression
+        } else if (ts.isElementAccessExpression(expr)) {
+            const argument = stripWrappers(expr.argumentExpression)
+            if (ts.isStringLiteralLike(argument)) {
+                property = argument.text
+            } else {
+                // Symbol-keyed slots (e.g. the STORE_RUNTIME facade slot)
+                // cannot name a string-keyed graph table — exempt them.
+                const keyType = checker.getTypeAtLocation(argument)
+                if (
+                    (keyType.flags &
+                        (ts.TypeFlags.ESSymbol |
+                            ts.TypeFlags.UniqueESSymbol)) !==
+                    0
+                ) {
+                    return undefined
+                }
+                property = undefined
+            }
+            baseNode = expr.expression
+        } else {
+            return undefined
+        }
+        if (property !== undefined && !names.has(property)) return undefined
+        const base = stripWrappers(baseNode)
         const baseType = checker.getTypeAtLocation(base)
         if (
             typeMatches(checker, baseType, "StoreData") ||
             isAnyOrUnknown(baseType)
         ) {
-            return property
+            return property ?? "<computed>"
         }
         return undefined
     }
@@ -210,7 +242,8 @@ export const scanSourceFileForGraphMutations = (
             return
         }
         // Destructuring a graph table straight off a StoreData-typed object:
-        // `const { stateDependents } = data`.
+        // `const { stateDependents } = data`, including string-literal and
+        // computed-literal keys (`const { ["stateDependents"]: t } = data`).
         if (ts.isObjectBindingPattern(declaration.name)) {
             const initType = checker.getTypeAtLocation(stripWrappers(init))
             if (
@@ -219,9 +252,20 @@ export const scanSourceFileForGraphMutations = (
             )
                 return
             for (const element of declaration.name.elements) {
-                const property = ts.isIdentifier(element.propertyName ?? element.name)
-                    ? (element.propertyName ?? element.name).getText(sourceFile)
-                    : undefined
+                const key = element.propertyName ?? element.name
+                let property: string | undefined
+                if (ts.isIdentifier(key)) {
+                    property = key.text
+                } else if (ts.isStringLiteralLike(key)) {
+                    property = key.text
+                } else if (
+                    ts.isComputedPropertyName(key) &&
+                    ts.isStringLiteralLike(stripWrappers(key.expression))
+                ) {
+                    property = (
+                        stripWrappers(key.expression) as ts.StringLiteralLike
+                    ).text
+                }
                 if (
                     property &&
                     GRAPH_TABLES.has(property) &&

--- a/packages/valdres/test/import-cycles/importCycles.baseline.json
+++ b/packages/valdres/test/import-cycles/importCycles.baseline.json
@@ -1,33 +1,18 @@
 {
     "note": "Import-cycle baseline for valdres core production modules. Regenerate with UPDATE_CYCLE_BASELINE=1 bun test test/import-cycles/importCycles.test.ts. The guard fails only when a change introduces a NEW cycle or GROWS an existing SCC — see importCycles.test.ts. Existing cycles are recorded, not required to be eliminated.",
-    "moduleCount": 158,
-    "edgeCount": 395,
+    "moduleCount": 162,
+    "edgeCount": 400,
     "sccs": [
         [
-            "src/lib/asyncDependencyTracking.ts",
-            "src/lib/cleanupOrphanedDeps.ts",
             "src/lib/coordinateAsyncWrite.ts",
-            "src/lib/deleteFamilyAtom.ts",
-            "src/lib/disposeStoreData.ts",
-            "src/lib/flushPendingOrphanCleanup.ts",
             "src/lib/getState.ts",
             "src/lib/globalAtomFanOut.ts",
             "src/lib/initAtom.ts",
             "src/lib/initSelector.ts",
-            "src/lib/mountAtom.ts",
             "src/lib/propagateUpdatedAtoms.ts",
-            "src/lib/queueOrphanCleanup.ts",
-            "src/lib/resetAtom.ts",
             "src/lib/resolveAtomDefaultValue.ts",
             "src/lib/setAtom.ts",
-            "src/lib/setAtoms.ts",
-            "src/lib/storeFromStoreData.ts",
-            "src/lib/subscribe.ts",
-            "src/lib/transaction.ts",
-            "src/lib/unsetValue.ts",
-            "src/lib/unsubscribe.ts",
-            "src/lib/writeAtoms.ts",
-            "src/utils/resolveReactive.ts"
+            "src/lib/unsetValue.ts"
         ]
     ]
 }


### PR DESCRIPTION
## Summary

- create `src/lib/graph/` — an internal GraphRuntime that exclusively owns every write to the StoreData graph tables: forward/reverse edges and dependency replacement, scope-branch registration, liveness counters and mount reachability, cycle metadata, the orphan plane, and installation of dependencies discovered by async evaluation
- evaluators no longer mutate graph state: they fill an `EvaluationOutcome` carrier (depth-pooled in the dispatchers, pass-owned like the reusable `DepsChange` in the propagation loops) and the dispatcher that ran them installs it — one semantic install core with a parity-tested monomorphic live-only twin, a gated two-phase late-dependency install, resolve-time async reconcile, activation lifecycle, and disposal seams
- cut `mountAtom → storeFromStoreData` (store facade resolves through the leaf `getStoreRuntime` slot, the commitEngine onSet precedent) and `asyncDependencyTracking → getState` (`lateGet` moves to its only caller): the core write-path import SCC shrinks **24 → 9 modules** and the direct `mountAtom ↔ storeFromStoreData` cycle is eliminated
- enforce the boundary in `test/import-cycles/`: a TypeScript-checker-based table-ownership scan (alias-, destructuring-, rename-, and generic-constraint-proof; transaction overlay and lifecycle ledgers exempt by type) with positive/negative fixtures, an exact nine-member SCC gate, graph transitive-closure and facade-only import rules, and a regenerated cycle baseline
- document and test the invariant phase model (topology installed vs liveness settled), installer twin parity, carrier pooling, and the late-dependency matrix; harden the capture-to-install window (single `then` probe + first-materialization interval merge) against user-controlled `then` accessors running deferred `get`s
- no public API, semantics, or ordering changes; specialized evaluator fast paths preserved; patch changeset included

## Verification

- bun run build
- bun run build:types
- bun --filter valdres typecheck:types
- bun run test / test:ci (workspace-wide)
- Valdres: 1,111 passed, 1 todo, 0 failed across 100 files (35 new tests)
- import-cycle, graph-boundary, trace-oracle, invariant, fuzz, architecture (unchanged counters), Bun memory, and Node memory suites passed
- bun run docs:build + gen-readmes --check clean

## Benchmark checkpoint

Interleaved origin/main versus branch pairs (BENCH_VALDRES_ONLY, `delta ≤ max(2%, base spread)` rule) under Bun 1.3.14 and Node 24.16.0:

- Bun latency lane: 63 of 63 benchmarks within the noise band after two shape fixes (per-pass outcome carrier in the propagation loops; slim dispatcher bodies with release-in-catch)
- observed async settlement: within noise on both runtimes
- retained bytes: Bun and Node memory gates green — no growth on either runtime
- architecture counters byte-identical (edge visits, evaluations, settlements, scheduler ops) — the algorithmic work is unchanged
- Node latency could not be certified locally: the machine's own controls failed at the needed resolution (E-core scheduling of background runs, thermal ramp flipping same-code deltas ±20 points; a pure `Map.get` reference row swung 3×). The V8-targeted shape fixes were verified directionally in the cleanest controls-passing session (chain teardown +25% → +2-3%). The same-runner Bencher lanes on this PR are the authoritative latency verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)