### PR TITLE
perf(valdres): reuse graph scheduling and liveness worklists

### DIFF
--- a/.changeset/reuse-graph-worklists.md
+++ b/.changeset/reuse-graph-worklists.md
@@ -1,0 +1,10 @@
+---
+"valdres": patch
+---
+
+Reuse bounded, frame-local graph worklists for selector scheduling and exact
+cyclic-liveness reconciliation. A changed-seed closure scheduler evaluates
+ordinary acyclic selectors once against finalized upstream values while no-op
+multi-seed writes stop before downstream discovery. Dynamic dependency
+replacement, re-entrant writes, and convergent cyclic fallback behavior remain
+supported.

--- a/.github/workflows/bencher-pr.yml
+++ b/.github/workflows/bencher-pr.yml
@@ -67,8 +67,10 @@ jobs:
               run: |
                   git worktree add --detach /tmp/base '${{ github.event.pull_request.base.sha }}'
                   (cd /tmp/base && bun install --frozen-lockfile)
+                  cp "${GITHUB_WORKSPACE}/packages/valdres/test/performance/architecture.timing.ts" /tmp/base/packages/valdres/test/performance/architecture.timing.ts
                   cp "${GITHUB_WORKSPACE}/packages/valdres/test/performance/asyncSettlement.timing.ts" /tmp/base/packages/valdres/test/performance/asyncSettlement.timing.ts
                   cp "${GITHUB_WORKSPACE}/packages/valdres/test/performance/bench-utils.ts" /tmp/base/packages/valdres/test/performance/bench-utils.ts
+                  cp "${GITHUB_WORKSPACE}/packages/valdres/vitest.architecture-bench.config.ts" /tmp/base/packages/valdres/vitest.architecture-bench.config.ts
                   cp "${GITHUB_WORKSPACE}/packages/valdres/vitest.async-bench.config.ts" /tmp/base/packages/valdres/vitest.async-bench.config.ts
 
             # Run the same benchmark harness against both implementations. New

--- a/packages/valdres/src/lib/architectureInstrumentation.ts
+++ b/packages/valdres/src/lib/architectureInstrumentation.ts
@@ -16,6 +16,20 @@ export type ArchitectureCounters = {
     dependencyEdgeVisits: number
     schedulerQueueEnqueues: number
     schedulerQueueDequeues: number
+    /** Scheduler-owned Set/Map/Array work containers created in the window. */
+    schedulerWorkAllocations: number
+    /** Liveness/mount-owned Set/Map/Array work containers created in the window. */
+    livenessWorkAllocations: number
+    /** Selector regions that required the insertion-order cyclic fallback. */
+    schedulerCycleFallbacks: number
+    /** Dependency edges examined while propagating/reconciling liveness. */
+    livenessEdgeVisits: number
+    /** Dependency edges examined by mount/unmount closure walks. */
+    mountEdgeVisits: number
+    /** Successful absent -> mounted lifecycle transitions. */
+    mountTransitions: number
+    /** Successful mounted -> absent lifecycle transitions. */
+    unmountTransitions: number
     /** Admitted `runCommitPlan` executions — one per engine-sequenced commit. */
     commitPlanRuns: number
 }
@@ -38,6 +52,13 @@ export const createArchitectureInstrumentation =
             dependencyEdgeVisits: 0,
             schedulerQueueEnqueues: 0,
             schedulerQueueDequeues: 0,
+            schedulerWorkAllocations: 0,
+            livenessWorkAllocations: 0,
+            schedulerCycleFallbacks: 0,
+            livenessEdgeVisits: 0,
+            mountEdgeVisits: 0,
+            mountTransitions: 0,
+            unmountTransitions: 0,
             commitPlanRuns: 0,
         },
         settledSelectors: new WeakMap(),

--- a/packages/valdres/src/lib/architecturePerformance.test.ts
+++ b/packages/valdres/src/lib/architecturePerformance.test.ts
@@ -77,6 +77,13 @@ describe("deterministic architecture performance gates", () => {
             dependencyEdgeVisits: 0,
             schedulerQueueEnqueues: 0,
             schedulerQueueDequeues: 0,
+            schedulerWorkAllocations: 0,
+            livenessWorkAllocations: 0,
+            schedulerCycleFallbacks: 0,
+            livenessEdgeVisits: 0,
+            mountEdgeVisits: 0,
+            mountTransitions: 0,
+            unmountTransitions: 0,
             // A scalar direct write settles without an engine plan.
             commitPlanRuns: 0,
         })
@@ -90,6 +97,7 @@ describe("deterministic architecture performance gates", () => {
             selector(get => get(source) + offset),
         )
         const cleanups = selectors.map(derived => target.sub(derived, noop))
+        target.set(source, -1)
 
         const counts = measureArchitecture(target, () => target.set(source, 1))
         reportCounts("Live fan-out, width 8", counts)
@@ -100,13 +108,49 @@ describe("deterministic architecture performance gates", () => {
         expect(counts.affectedStoresSettled).toBe(1)
         expect(counts.storeSettlementPasses).toBe(1)
         expect(counts.duplicateStoreSettlements).toBe(0)
-        expectBetween(counts.dependencyEdgeVisits, width * 2, width * 2.5)
-        expectBetween(counts.schedulerQueueEnqueues, width, width + 2)
-        expect(counts.schedulerQueueDequeues).toBe(
-            counts.schedulerQueueEnqueues,
-        )
+        expectBetween(counts.dependencyEdgeVisits, width, width * 1.5)
+        expect(counts.schedulerQueueEnqueues).toBe(0)
+        expect(counts.schedulerQueueDequeues).toBe(0)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+        expect(counts.livenessWorkAllocations).toBe(0)
 
         for (const cleanup of cleanups) cleanup()
+    })
+
+    test("unchanged multi-seed writes do not discover downstream closure", () => {
+        const depth = 200
+        const target = store()
+        const source = atom(0)
+        const left = selector(get => {
+            get(source)
+            return 0
+        })
+        const right = selector(get => {
+            get(source)
+            return 0
+        })
+        let sink: any = left
+        for (let index = 0; index < depth; index++) {
+            const dependency = sink
+            sink = selector(get => get(dependency) + 1)
+        }
+        const cleanupSink = target.sub(sink, noop)
+        const cleanupRight = target.sub(right, noop)
+        target.set(source, -1)
+
+        const counts = measureArchitecture(target, () => target.set(source, 1))
+        reportCounts("Unchanged multi-seed closure", counts)
+
+        expect(counts.selectorEvaluations).toBe(2)
+        expect(counts.selectorSettlements).toBe(2)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
+        expectBetween(counts.dependencyEdgeVisits, 2, 8)
+        expect(counts.schedulerQueueEnqueues).toBe(0)
+        expect(counts.schedulerQueueDequeues).toBe(0)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+
+        cleanupRight()
+        cleanupSink()
     })
 
     test("asymmetric DAG queue and edge work remains bounded", () => {
@@ -124,21 +168,23 @@ describe("deterministic architecture performance gates", () => {
             chain.reduce((sum, derived) => sum + get(derived), get(source)),
         )
         const cleanup = target.sub(sink, noop)
+        target.set(source, -1)
 
         const counts = measureArchitecture(target, () => target.set(source, 1))
         reportCounts("Asymmetric DAG, depth 6", counts)
 
-        // The wide sink is reached in the initial sweep and once after its
-        // chain settles. That one repeat is the current correctness-preserving
-        // baseline; the gate prevents it from growing with path count.
-        expect(counts.selectorEvaluations).toBe(8)
-        expect(counts.selectorSettlements).toBe(8)
-        expect(counts.duplicateSelectorSettlements).toBe(1)
-        expectBetween(counts.dependencyEdgeVisits, 36, 50)
-        expectBetween(counts.schedulerQueueEnqueues, 7, 10)
+        // The closure scheduler waits for every in-closure dependency, so the
+        // wide sink settles once against the finalized six-link chain.
+        expect(counts.selectorEvaluations).toBe(7)
+        expect(counts.selectorSettlements).toBe(7)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
+        expectBetween(counts.dependencyEdgeVisits, 37, 42)
+        expect(counts.schedulerQueueEnqueues).toBe(8)
         expect(counts.schedulerQueueDequeues).toBe(
             counts.schedulerQueueEnqueues,
         )
+        expect(counts.schedulerWorkAllocations).toBe(0)
+        expect(counts.schedulerCycleFallbacks).toBe(0)
         cleanup()
     })
 
@@ -152,9 +198,10 @@ describe("deterministic architecture performance gates", () => {
             selector(get => (get(toggle) ? get(left) : get(right))),
         )
         const cleanups = selectors.map(derived => target.sub(derived, noop))
+        target.set(toggle, false)
 
         const counts = measureArchitecture(target, () =>
-            target.set(toggle, false),
+            target.set(toggle, true),
         )
         reportCounts("Dynamic churn, width 6", counts)
 
@@ -162,13 +209,144 @@ describe("deterministic architecture performance gates", () => {
         expect(counts.selectorSettlements).toBe(width)
         expect(counts.duplicateSelectorSettlements).toBe(0)
         expect(counts.affectedStoresSettled).toBe(1)
-        expectBetween(counts.dependencyEdgeVisits, width * 3, width * 4)
-        expectBetween(counts.schedulerQueueEnqueues, width, width + 2)
-        expect(counts.schedulerQueueDequeues).toBe(
-            counts.schedulerQueueEnqueues,
-        )
+        expectBetween(counts.dependencyEdgeVisits, width, width * 2)
+        expect(counts.schedulerQueueEnqueues).toBe(0)
+        expect(counts.schedulerQueueDequeues).toBe(0)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+        // The one-array count walks intentionally stay local: pooling them
+        // regresses subscribe/unsubscribe despite avoiding these two arrays.
+        expect(counts.livenessWorkAllocations).toBe(2)
 
         for (const cleanup of cleanups) cleanup()
+    })
+
+    test("dynamic mount churn keeps lifecycle transitions exact", () => {
+        let mounts = 0
+        let cleanups = 0
+        const target = store()
+        const toggle = atom(true)
+        const left = atom(1, {
+            onMount: () => {
+                mounts++
+                return () => {
+                    cleanups++
+                }
+            },
+        })
+        const right = atom(2, {
+            onMount: () => {
+                mounts++
+                return () => {
+                    cleanups++
+                }
+            },
+        })
+        const dynamic = selector(get => (get(toggle) ? get(left) : get(right)))
+        const cleanup = target.sub(dynamic, noop)
+        target.set(toggle, false)
+        const mountsBefore = mounts
+        const cleanupsBefore = cleanups
+
+        const counts = measureArchitecture(target, () =>
+            target.set(toggle, true),
+        )
+        reportCounts("Dynamic mount churn", counts)
+
+        expect(mounts - mountsBefore).toBe(1)
+        expect(cleanups - cleanupsBefore).toBe(1)
+        expect(counts.mountTransitions).toBe(1)
+        expect(counts.unmountTransitions).toBe(1)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+        // The measured-faster local count and mount walks keep their six
+        // short-lived containers; only multi-container reconciliation is pooled.
+        expect(counts.livenessWorkAllocations).toBe(6)
+        expect(counts.livenessEdgeVisits).toBe(0)
+        expect(counts.mountEdgeVisits).toBe(0)
+
+        cleanup()
+    })
+
+    test("re-entrant mount writes use a distinct warm scheduler frame", () => {
+        let mounts = 0
+        let cleanups = 0
+        const target = store()
+        const gate = atom(false)
+        const innerSource = atom(0)
+        const innerLeft = selector(get => get(innerSource) + 1)
+        const innerRight = selector(get => get(innerLeft) + 1)
+        const innerSink = selector(get => get(innerLeft) + get(innerRight))
+        const mounted = atom(10, {
+            onMount: () => {
+                mounts++
+                target.set(innerSource, mounts)
+                return () => {
+                    cleanups++
+                }
+            },
+        })
+        const dynamic = selector(get => (get(gate) ? get(mounted) : 0))
+        const peer = selector(get => get(dynamic) + (get(gate) ? 1 : 0))
+        const outerSink = selector(get => get(dynamic) + get(peer))
+        const cleanupInner = target.sub(innerSink, noop)
+        const cleanupOuter = target.sub(outerSink, noop)
+
+        // First pass creates the outer and nested frames; the false transition
+        // releases both before the measured warm re-entry.
+        target.set(gate, true)
+        target.set(gate, false)
+        const counts = measureArchitecture(target, () => target.set(gate, true))
+        reportCounts("Re-entrant mount write", counts)
+
+        expect(mounts).toBe(2)
+        expect(cleanups).toBe(1)
+        expect(target.get(dynamic)).toBe(10)
+        expect(target.get(peer)).toBe(11)
+        expect(target.get(innerLeft)).toBe(3)
+        expect(target.get(innerRight)).toBe(4)
+        expect(target.get(innerSink)).toBe(7)
+        expect(target.get(outerSink)).toBe(21)
+        expect(counts.selectorEvaluations).toBe(6)
+        expect(counts.duplicateSelectorSettlements).toBe(0)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+        expect(counts.livenessWorkAllocations).toBe(3)
+        expect(counts.mountTransitions).toBe(1)
+        expect(counts.unmountTransitions).toBe(0)
+
+        cleanupOuter()
+        cleanupInner()
+    })
+
+    test("cyclic closures iterate fallback waves to a stable fixpoint", () => {
+        const target = store()
+        const warmSource = atom(0)
+        const warmLeft = selector(get => get(warmSource))
+        const warmRight = selector(get => get(warmSource))
+        const warmSink = selector(get => get(warmLeft) + get(warmRight))
+        const cleanupWarm = target.sub(warmSink, noop)
+        target.set(warmSource, 1)
+
+        const drive = atom(0)
+        const entry = selector(get => get(drive))
+        let cyclicRight: any
+        const cyclicLeft = selector(get =>
+            get(entry) > 0 ? get(cyclicRight) : 0,
+        )
+        cyclicRight = selector(get => Math.min(get(cyclicLeft) + 1, 9))
+        const cleanupLeft = target.sub(cyclicLeft, noop)
+        const cleanupRight = target.sub(cyclicRight, noop)
+
+        const counts = measureArchitecture(target, () => target.set(drive, 1))
+        reportCounts("Cyclic closure fallback", counts)
+
+        expect(target.get(entry)).toBe(1)
+        expect(target.get(cyclicLeft)).toBe(9)
+        expect(target.get(cyclicRight)).toBe(9)
+        expect(counts.schedulerCycleFallbacks).toBeGreaterThan(0)
+        expect(counts.schedulerWorkAllocations).toBe(0)
+
+        cleanupRight()
+        cleanupLeft()
+        cleanupWarm()
     })
 
     test("single-store transactions execute exactly one commit plan per shape", () => {

--- a/packages/valdres/src/lib/graph/index.ts
+++ b/packages/valdres/src/lib/graph/index.ts
@@ -27,6 +27,12 @@
  * (SelectorEvaluationRuntime): its private forward map mirrors this shape but
  * is evaluation-session state owned by the draft, never the committed graph.
  *
+ * Scheduler and multi-container cyclic-liveness worklists live in the leaf
+ * `workspace` module, weakly keyed by StoreData rather than stored on it. At
+ * most four frames per store are pooled for re-entrant user code; every release
+ * clears strong state references and drops backing containers above 1,024
+ * entries. Measured-faster single-array count and mount walks remain local.
+ *
  * Invariants owned here:
  * - Edge CONSTRUCTION bumps dependencyGraphVersion (noteDependencyGraphChanged);
  *   orphan-teardown edge DELETION deliberately does not, preserving memoized
@@ -96,3 +102,8 @@ export {
     sealGraphForDisposal,
     settleLateDependency,
 } from "./runtime"
+export {
+    scheduleSelectors,
+    SCHEDULE_CHANGED,
+    SCHEDULE_GRAPH_CHANGED,
+} from "./scheduler"

--- a/packages/valdres/src/lib/graph/mountAtom.ts
+++ b/packages/valdres/src/lib/graph/mountAtom.ts
@@ -1,8 +1,20 @@
 import type { State } from "../../types/State"
 import type { StoreData } from "../../types/StoreData"
 import { isSelector } from "../../utils/isSelector"
+import { IS_PROD } from "../IS_PROD"
 import { addStateDependent } from "./inheritedDependencyBranches"
 import { noteDependencyGraphChanged } from "./noteDependencyGraphChanged"
+import {
+    acquireLivenessWorkspace,
+    ensureLive,
+    ensureMountVisited,
+    ensureOnPath,
+    ensureRegion,
+    ensureUnmountVisited,
+    ensureWasLive,
+    noteLivenessWorkspaceSize,
+    releaseLivenessWorkspace,
+} from "./workspace"
 import { getStoreRuntime } from "../getStoreRuntime"
 import {
     isStoreDisposed,
@@ -14,6 +26,21 @@ import {
 // atom-family members are graph sinks) yields a zero-length iterator without
 // allocating. Never mutated.
 const EMPTY: Set<State> = new Set()
+
+const recordLivenessEdge = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.livenessEdgeVisits++
+}
+
+const recordMount = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.mountTransitions++
+}
+
+const recordUnmount = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.unmountTransitions++
+}
 
 const hasDirectSubscribers = (state: State, data: StoreData): boolean => {
     const subs = data.subscriptions.get(state)
@@ -174,11 +201,16 @@ export const isLive = (state: State, data: StoreData): boolean => {
  */
 const propagateLive = (root: State, data: StoreData) => {
     const stack: State[] = [root]
+    const instrumentation = !IS_PROD
+        ? data.architectureInstrumentation
+        : undefined
+    if (instrumentation) instrumentation.counters.livenessWorkAllocations++
     while (stack.length > 0) {
         const current = stack.pop()!
         const deps = data.stateDependencies.get(current)
         if (!deps) continue
         for (const dep of deps) {
+            if (instrumentation) instrumentation.counters.livenessEdgeVisits++
             const prev = data.liveDependentCount.get(dep) ?? 0
             data.liveDependentCount.set(dep, prev + 1)
             if (prev === 0 && !hasDirectSubscribers(dep, data)) {
@@ -194,11 +226,16 @@ const propagateLive = (root: State, data: StoreData) => {
  */
 const propagateNotLive = (root: State, data: StoreData) => {
     const stack: State[] = [root]
+    const instrumentation = !IS_PROD
+        ? data.architectureInstrumentation
+        : undefined
+    if (instrumentation) instrumentation.counters.livenessWorkAllocations++
     while (stack.length > 0) {
         const current = stack.pop()!
         const deps = data.stateDependencies.get(current)
         if (!deps) continue
         for (const dep of deps) {
+            if (instrumentation) instrumentation.counters.livenessEdgeVisits++
             const prev = data.liveDependentCount.get(dep) ?? 0
             const next = prev - 1
             if (next <= 0) {
@@ -299,38 +336,44 @@ const seedClosureHasCycle = (
     // across every sibling unsubscribe in the burst.
     if (acyclicAtVersion.get(seed) === graphVersion) return false
 
-    const onPath = new Set<State>()
+    const workspace = acquireLivenessWorkspace(data)
+    const onPath = ensureOnPath(workspace, data)
+    const stack = workspace.dfs
     // Explicit stack of frames: { node, iterator over its deps }. A frame is
     // pushed onto `onPath` when entered. Once its deps are exhausted, its whole
     // closure is proven acyclic at this graph version. Encountering an `onPath`
     // node is a back-edge. Positive results are never cached because a later
     // teardown edge deletion could break the cycle without bumping the version.
-    const stack: { node: State; it: Iterator<State> }[] = [
-        {
-            node: seed,
-            it: (data.stateDependencies.get(seed) ?? EMPTY).values(),
-        },
-    ]
+    stack.push({
+        node: seed,
+        it: (data.stateDependencies.get(seed) ?? EMPTY).values(),
+    })
     onPath.add(seed)
-    while (stack.length > 0) {
-        const frame = stack[stack.length - 1]!
-        const next = frame.it.next()
-        if (next.done) {
-            onPath.delete(frame.node)
-            acyclicAtVersion.set(frame.node, graphVersion)
-            stack.pop()
-            continue
+    try {
+        while (stack.length > 0) {
+            const frame = stack[stack.length - 1]!
+            const next = frame.it.next()
+            if (next.done) {
+                onPath.delete(frame.node)
+                acyclicAtVersion.set(frame.node, graphVersion)
+                stack.pop()
+                continue
+            }
+            const dep = next.value as State
+            if (!IS_PROD) recordLivenessEdge(data)
+            if (onPath.has(dep)) return true // back-edge → cycle
+            if (acyclicAtVersion.get(dep) === graphVersion) continue
+            onPath.add(dep)
+            stack.push({
+                node: dep,
+                it: (data.stateDependencies.get(dep) ?? EMPTY).values(),
+            })
+            noteLivenessWorkspaceSize(workspace)
         }
-        const dep = next.value as State
-        if (onPath.has(dep)) return true // back-edge → cycle
-        if (acyclicAtVersion.get(dep) === graphVersion) continue
-        onPath.add(dep)
-        stack.push({
-            node: dep,
-            it: (data.stateDependencies.get(dep) ?? EMPTY).values(),
-        })
+        return false
+    } finally {
+        releaseLivenessWorkspace(workspace)
     }
-    return false
 }
 
 export const regionHasCycle = (
@@ -447,84 +490,100 @@ export const reconcileLivenessAfterChurn = (
     seeds: Set<State>,
     data: StoreData,
 ) => {
-    // 1. region = downward dependency closure of the seeds.
-    const region = new Set<State>()
-    const stack: State[] = [...seeds]
-    while (stack.length > 0) {
-        const s = stack.pop()!
-        if (region.has(s)) continue
-        region.add(s)
-        const deps = data.stateDependencies.get(s)
-        if (deps) for (const d of deps) if (!region.has(d)) stack.push(d)
-    }
+    const workspace = acquireLivenessWorkspace(data)
+    const region = ensureRegion(workspace, data)
+    const live = ensureLive(workspace, data)
+    const wasLive = ensureWasLive(workspace, data)
+    const mountVisited = ensureMountVisited(workspace, data)
+    const unmountVisited = ensureUnmountVisited(workspace, data)
+    const stack = workspace.stack
+    const work = workspace.ordered
+    try {
+        // 1. region = downward dependency closure of the seeds.
+        for (const seed of seeds) stack.push(seed)
+        noteLivenessWorkspaceSize(workspace)
+        while (stack.length > 0) {
+            const s = stack.pop()!
+            if (region.has(s)) continue
+            region.add(s)
+            const deps = data.stateDependencies.get(s)
+            if (deps)
+                for (const d of deps) {
+                    if (!IS_PROD) recordLivenessEdge(data)
+                    if (!region.has(d)) stack.push(d)
+                }
+            noteLivenessWorkspaceSize(workspace)
+        }
 
-    // 2. Ground-truth liveness for the region. Seed from direct subscribers and
-    //    from dependents OUTSIDE the region (their liveness is unaffected by
-    //    this churn, so the cached isLive() is authoritative). Then push
-    //    liveness DOWN: a live state's dependencies each gain a live dependent.
-    const live = new Set<State>()
-    const work: State[] = []
-    for (const D of region) {
-        let isit = hasDirectSubscribers(D, data)
-        if (!isit) {
-            const dependents = data.stateDependents.get(D)
-            if (dependents) {
-                for (const T of dependents) {
-                    if (!region.has(T) && isLive(T, data)) {
-                        isit = true
-                        break
+        // 2. Ground-truth liveness for the region. Seed from direct subscribers
+        //    and from dependents OUTSIDE the region (their liveness is unaffected
+        //    by this churn, so the cached isLive() is authoritative). Then push
+        //    liveness DOWN: a live state's dependencies gain a live dependent.
+        for (const D of region) {
+            let isit = hasDirectSubscribers(D, data)
+            if (!isit) {
+                const dependents = data.stateDependents.get(D)
+                if (dependents) {
+                    for (const T of dependents) {
+                        if (!IS_PROD) recordLivenessEdge(data)
+                        if (!region.has(T) && isLive(T, data)) {
+                            isit = true
+                            break
+                        }
                     }
                 }
             }
-        }
-        if (isit) {
-            live.add(D)
-            work.push(D)
-        }
-    }
-    while (work.length > 0) {
-        const T = work.pop()!
-        const deps = data.stateDependencies.get(T)
-        if (!deps) continue
-        for (const D of deps) {
-            if (region.has(D) && !live.has(D)) {
+            if (isit) {
                 live.add(D)
                 work.push(D)
+                noteLivenessWorkspaceSize(workspace)
             }
         }
-    }
+        while (work.length > 0) {
+            const T = work.pop()!
+            const deps = data.stateDependencies.get(T)
+            if (!deps) continue
+            for (const D of deps) {
+                if (!IS_PROD) recordLivenessEdge(data)
+                if (region.has(D) && !live.has(D)) {
+                    live.add(D)
+                    work.push(D)
+                    noteLivenessWorkspaceSize(workspace)
+                }
+            }
+        }
 
-    // 3. Recompute counts from ground truth, snapshotting prior liveness so we
-    //    can mount/unmount on genuine transitions afterwards (idempotent).
-    const wasLive = new Map<State, boolean>()
-    for (const D of region) wasLive.set(D, isLive(D, data))
-    for (const D of region) {
-        const dependents = data.stateDependents.get(D)
-        let count = 0
-        if (dependents) {
-            for (const T of dependents) {
-                if (region.has(T) ? live.has(T) : isLive(T, data)) count++
+        // 3. Recompute counts from ground truth, snapshotting prior liveness so
+        //    mount/unmount only run on genuine transitions (idempotent).
+        for (const D of region) wasLive.set(D, isLive(D, data))
+        for (const D of region) {
+            const dependents = data.stateDependents.get(D)
+            let count = 0
+            if (dependents) {
+                for (const T of dependents) {
+                    if (!IS_PROD) recordLivenessEdge(data)
+                    if (region.has(T) ? live.has(T) : isLive(T, data)) count++
+                }
             }
+            // liveDependentCount never stores 0 (entries are deleted at <= 0),
+            // so a missing entry IS count 0 — only touch on a genuine change.
+            const prev = data.liveDependentCount.get(D) ?? 0
+            if (count === prev) continue
+            if (count <= 0) data.liveDependentCount.delete(D)
+            else data.liveDependentCount.set(D, count)
         }
-        // liveDependentCount never stores 0 (entries are deleted at <= 0), so a
-        // missing entry IS count 0 — only touch the map on a genuine change.
-        const prev = data.liveDependentCount.get(D) ?? 0
-        if (count === prev) continue
-        if (count <= 0) data.liveDependentCount.delete(D)
-        else data.liveDependentCount.set(D, count)
-    }
-    // Share a visited set across all mount calls (and a separate one across all
-    // unmount calls) so overlapping transitive subtrees are walked once total, not
-    // once per transitioning region node — O(region + edges), not O(region *
-    // edges). Mount and unmount must NOT share a set: a node skipped by an unmount
-    // walk must still be reachable by a mount walk, and vice versa.
-    const mountVisited = new Set<State>()
-    const unmountVisited = new Set<State>()
-    for (const D of region) {
-        const now = live.has(D)
-        if (now && !wasLive.get(D)) mountTransitiveDeps(D, data, mountVisited)
-        else if (!now && wasLive.get(D))
-            unmountOrphanedDeps(D, data, unmountVisited)
+        // Share one visited set across all mounts and a different set across all
+        // unmounts. They cannot be shared with each other: a node skipped by one
+        // transition direction must remain reachable from the other.
+        for (const D of region) {
+            const now = live.has(D)
+            if (now && !wasLive.get(D))
+                mountTransitiveDeps(D, data, mountVisited)
+            else if (!now && wasLive.get(D))
+                unmountOrphanedDeps(D, data, unmountVisited)
+        }
+    } finally {
+        releaseLivenessWorkspace(workspace)
     }
 }
 
@@ -563,6 +622,13 @@ export const mountAtom = (state: State, data: StoreData) => {
                 mountEntry.cleanup = result
             }
         }
+        if (
+            !IS_PROD &&
+            data.architectureInstrumentation &&
+            data.mounts.get(state) === mountEntry
+        ) {
+            recordMount(data)
+        }
     } catch (error) {
         if (data.mounts.get(state) === mountEntry) data.mounts.delete(state)
         untrackStoreMount(data, state)
@@ -582,6 +648,7 @@ export const unmountAtom = (state: State, data: StoreData) => {
     }
     data.mounts.delete(state)
     untrackStoreMount(data, state)
+    if (!IS_PROD && data.architectureInstrumentation) recordUnmount(data)
     if (typeof mount.cleanup === "function") {
         mount.cleanup()
     }
@@ -615,6 +682,11 @@ export const mountTransitiveDeps = (
     const seen = visited ?? new Set<State>()
     let firstError: { value: unknown } | null = null
     const stack: State[] = [state]
+    const instrumentation = !IS_PROD
+        ? data.architectureInstrumentation
+        : undefined
+    if (instrumentation)
+        instrumentation.counters.livenessWorkAllocations += visited ? 1 : 2
     while (stack.length > 0) {
         const current = stack.pop()!
         if (seen.has(current)) continue
@@ -632,8 +704,11 @@ export const mountTransitiveDeps = (
             // Dependencies are recorded in read order. Push them in reverse so
             // the LIFO traversal mounts siblings in that same observable order.
             const orderedDeps = Array.from(deps) as State[]
+            if (instrumentation)
+                instrumentation.counters.livenessWorkAllocations++
             for (let i = orderedDeps.length - 1; i >= 0; i--) {
                 const dep = orderedDeps[i]!
+                if (instrumentation) instrumentation.counters.mountEdgeVisits++
                 if (!seen.has(dep)) stack.push(dep)
             }
         }
@@ -666,6 +741,11 @@ export const unmountOrphanedDeps = (
     const seen = visited ?? new Set<State>()
     let firstError: { value: unknown } | null = null
     const stack: State[] = [state]
+    const instrumentation = !IS_PROD
+        ? data.architectureInstrumentation
+        : undefined
+    if (instrumentation)
+        instrumentation.counters.livenessWorkAllocations += visited ? 1 : 2
     while (stack.length > 0) {
         const current = stack.pop()!
         if (seen.has(current)) continue
@@ -683,6 +763,7 @@ export const unmountOrphanedDeps = (
         const deps = data.stateDependencies.get(current)
         if (deps) {
             for (const dep of deps) {
+                if (instrumentation) instrumentation.counters.mountEdgeVisits++
                 if (!seen.has(dep)) stack.push(dep)
             }
         }

--- a/packages/valdres/src/lib/graph/runtime.ts
+++ b/packages/valdres/src/lib/graph/runtime.ts
@@ -22,6 +22,7 @@ import {
     noteDependencyGraphChanged,
     noteDependencyMaterialized,
 } from "./noteDependencyGraphChanged"
+import { dropGraphWorkspaces } from "./workspace"
 
 /**
  * Graph-runtime installers: the write API evaluation and settlement code use
@@ -402,4 +403,5 @@ export const resetLivenessScratch = (data: StoreData): void => {
     data.livenessSeeds = undefined
     data.livenessRemovalArmed = false
     data.livenessLazyArmed = false
+    dropGraphWorkspaces(data)
 }

--- a/packages/valdres/src/lib/graph/scheduler.ts
+++ b/packages/valdres/src/lib/graph/scheduler.ts
@@ -1,0 +1,825 @@
+import type { Selector } from "../../types/Selector"
+import type { StoreData } from "../../types/StoreData"
+import { IS_PROD } from "../IS_PROD"
+import {
+    acquireSchedulerWorkspace,
+    releaseSchedulerWorkspace,
+    type SchedulerWorkspace,
+} from "./workspace"
+
+export const SCHEDULE_CHANGED = 1
+export const SCHEDULE_GRAPH_CHANGED = 2
+
+const NEEDS_EVAL = 1
+const SETTLED = 2
+const RESWEEP = 4
+const ACTIVE = 8
+const SEARCHED = 16
+const SEARCH_ADDED = 32
+const FLAG_BASE = 64
+
+type SettleSelector<Context> = (
+    selector: Selector,
+    data: StoreData,
+    context: Context,
+) => number
+
+type PropagateSelector<Context> = (
+    parent: Selector,
+    child: Selector,
+    context: Context,
+) => void
+
+const flagsOf = (value: number): number => value % FLAG_BASE
+const pendingOf = (value: number): number => Math.floor(value / FLAG_BASE)
+const withFlags = (value: number, flags: number): number =>
+    pendingOf(value) * FLAG_BASE + flags
+const withPending = (value: number, pending: number): number =>
+    pending * FLAG_BASE + flagsOf(value)
+
+const recordEdge = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.dependencyEdgeVisits++
+}
+
+const recordEnqueue = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.schedulerQueueEnqueues++
+}
+
+const recordDequeue = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.schedulerQueueDequeues++
+}
+
+const recordCycleFallback = (data: StoreData) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.schedulerCycleFallbacks++
+}
+
+const markNeedsEval = (selector: Selector, frame: SchedulerWorkspace): void => {
+    const value = frame.meta.get(selector)
+    if (value === undefined) return
+    frame.meta.set(selector, withFlags(value, flagsOf(value) | NEEDS_EVAL))
+}
+
+const addClosureNode = (
+    selector: Selector,
+    needsEval: boolean,
+    frame: SchedulerWorkspace,
+): boolean => {
+    const value = frame.meta.get(selector)
+    if (value !== undefined) {
+        if (needsEval) markNeedsEval(selector, frame)
+        return false
+    }
+    frame.meta.set(selector, needsEval ? NEEDS_EVAL : 0)
+    frame.nodes.push(selector)
+    return true
+}
+
+const discoverClosure = (
+    initial: Iterable<Selector>,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+) => {
+    for (const selector of initial) addClosureNode(selector, true, frame)
+    for (let index = 0; index < frame.nodes.length; index++) {
+        const selector = frame.nodes[index]!
+        const downstream = data.stateDependents.get(selector)
+        if (!downstream) continue
+        for (const child of downstream) {
+            if (!IS_PROD) recordEdge(data)
+            addClosureNode(child as Selector, false, frame)
+        }
+    }
+}
+
+const initializeReadyQueue = (frame: SchedulerWorkspace, data: StoreData) => {
+    for (const selector of frame.nodes) {
+        let pending = 0
+        const deps = data.stateDependencies.get(selector)
+        if (deps) {
+            for (const dep of deps) {
+                if (!IS_PROD) recordEdge(data)
+                if (frame.meta.has(dep as Selector)) pending++
+            }
+        }
+        const value = frame.meta.get(selector)!
+        frame.meta.set(selector, withPending(value, pending))
+        if (pending === 0) {
+            frame.ready.push(selector)
+            if (!IS_PROD) recordEnqueue(data)
+        }
+    }
+}
+
+const markForResweep = (
+    selector: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+) => {
+    const value = frame.meta.get(selector)
+    if (value !== undefined && (flagsOf(value) & RESWEEP) !== 0) return
+    if (value === undefined) frame.meta.set(selector, NEEDS_EVAL | RESWEEP)
+    else
+        frame.meta.set(
+            selector,
+            withFlags(value, flagsOf(value) | NEEDS_EVAL | RESWEEP),
+        )
+    frame.resweep.push(selector)
+    if (!IS_PROD) recordEnqueue(data)
+
+    // `resweep` doubles as the traversal queue. Every descendant is marked
+    // once, so appending while iterating remains linear and allocation-free.
+    for (let index = frame.resweep.length - 1; index < frame.resweep.length; ) {
+        const current = frame.resweep[index++]!
+        const downstream = data.stateDependents.get(current)
+        if (!downstream) continue
+        for (const childState of downstream) {
+            if (!IS_PROD) recordEdge(data)
+            const child = childState as Selector
+            const childValue = frame.meta.get(child)
+            if (
+                childValue !== undefined &&
+                (flagsOf(childValue) & RESWEEP) !== 0
+            ) {
+                continue
+            }
+            if (childValue === undefined) {
+                frame.meta.set(child, NEEDS_EVAL | RESWEEP)
+            } else {
+                frame.meta.set(
+                    child,
+                    withFlags(
+                        childValue,
+                        flagsOf(childValue) | NEEDS_EVAL | RESWEEP,
+                    ),
+                )
+            }
+            frame.resweep.push(child)
+            if (!IS_PROD) recordEnqueue(data)
+        }
+    }
+}
+
+const advance = <Context>(
+    selector: Selector,
+    changed: boolean,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    propagate: PropagateSelector<Context> | undefined,
+): boolean => {
+    let closureExpanded = false
+    const downstream = data.stateDependents.get(selector)
+    if (!downstream) return closureExpanded
+    for (const childState of downstream) {
+        if (!IS_PROD) recordEdge(data)
+        const child = childState as Selector
+        if (changed && propagate) propagate(selector, child, context)
+        let childValue = frame.meta.get(child)
+        if (childValue === undefined) {
+            if (changed) {
+                frame.meta.set(child, NEEDS_EVAL)
+                frame.nodes.push(child)
+                frame.ready.push(child)
+                if (!IS_PROD) recordEnqueue(data)
+                closureExpanded = true
+            }
+            continue
+        }
+        const flags = flagsOf(childValue)
+        if ((flags & SETTLED) !== 0) {
+            if (changed) markForResweep(child, frame, data)
+            continue
+        }
+        const pending = Math.max(0, pendingOf(childValue) - 1)
+        let nextFlags = flags
+        if (changed) nextFlags |= NEEDS_EVAL
+        childValue = pending * FLAG_BASE + nextFlags
+        frame.meta.set(child, childValue)
+        if (pending <= 0) {
+            frame.ready.push(child)
+            if (!IS_PROD) recordEnqueue(data)
+        }
+    }
+    return closureExpanded
+}
+
+const settleReady = <Context>(
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+): boolean => {
+    let graphMutated = false
+    let head = 0
+    while (head < frame.ready.length) {
+        const selector = frame.ready[head++]!
+        if (!IS_PROD) recordDequeue(data)
+        const value = frame.meta.get(selector)
+        if (value === undefined) continue
+        const flags = flagsOf(value)
+        if ((flags & (SETTLED | RESWEEP)) !== 0) continue
+
+        let result = 0
+        if ((flags & NEEDS_EVAL) !== 0) {
+            result = settle(selector, data, context)
+            if ((result & SCHEDULE_GRAPH_CHANGED) !== 0) graphMutated = true
+        }
+        frame.meta.set(selector, withFlags(value, flags | SETTLED))
+        if (
+            advance(
+                selector,
+                (result & SCHEDULE_CHANGED) !== 0,
+                frame,
+                data,
+                context,
+                propagate,
+            )
+        ) {
+            graphMutated = true
+        }
+    }
+    return graphMutated
+}
+
+const activateStrandedWork = (
+    frame: SchedulerWorkspace,
+    graphMutated: boolean,
+    data: StoreData,
+) => {
+    frame.ready.length = 0
+    // Match the historical cycle boundary: a pre-existing stalled cycle does
+    // not start a new fixpoint by itself. Only dependency replacement or an
+    // out-of-closure materialization can invalidate the Kahn snapshot and arm
+    // the stranded-region fallback.
+    if (!graphMutated) return
+    for (const selector of frame.nodes) {
+        const value = frame.meta.get(selector)
+        if (value === undefined) continue
+        const flags = flagsOf(value)
+        if (
+            (flags & NEEDS_EVAL) !== 0 &&
+            (flags & SETTLED) === 0 &&
+            pendingOf(value) > 0
+        ) {
+            markForResweep(selector, frame, data)
+        }
+    }
+    for (const selector of frame.resweep) {
+        const value = frame.meta.get(selector)!
+        frame.meta.set(selector, withFlags(value, flagsOf(value) | ACTIVE))
+        frame.ready.push(selector)
+    }
+}
+
+const hasActiveDependency = (
+    selector: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+): boolean => {
+    const deps = data.stateDependencies.get(selector)
+    if (!deps) return false
+    for (const dep of deps) {
+        if (!IS_PROD) recordEdge(data)
+        if (dep === selector) continue
+        const value = frame.meta.get(dep as Selector)
+        if (value !== undefined && (flagsOf(value) & ACTIVE) !== 0) {
+            return true
+        }
+    }
+    return false
+}
+
+const signalClosesCycle = (
+    parent: Selector,
+    child: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+): boolean => {
+    if (parent === child) return true
+
+    // Reuse the tail of `nodes` as frame-local search storage. This guard is
+    // armed only after the fallback has spent a bounded settlement budget:
+    // practical convergent cycles reach their fixpoint normally, while a
+    // value-divergent cycle cannot keep the synchronous scheduler alive forever.
+    const start = frame.nodes.length
+    const mark = (selector: Selector) => {
+        const value = frame.meta.get(selector)
+        if (value === undefined) {
+            frame.meta.set(selector, SEARCHED | SEARCH_ADDED)
+        } else {
+            frame.meta.set(
+                selector,
+                withFlags(value, flagsOf(value) | SEARCHED),
+            )
+        }
+        frame.nodes.push(selector)
+    }
+    mark(parent)
+    let closesCycle = false
+    for (
+        let index = start;
+        index < frame.nodes.length && !closesCycle;
+        index++
+    ) {
+        const selector = frame.nodes[index]!
+        const deps = data.stateDependencies.get(selector)
+        if (!deps) continue
+        for (const depState of deps) {
+            if (!IS_PROD) recordEdge(data)
+            const dep = depState as Selector
+            if (dep === child) {
+                closesCycle = true
+                break
+            }
+            const value = frame.meta.get(dep)
+            if (value !== undefined && (flagsOf(value) & SEARCHED) !== 0) {
+                continue
+            }
+            mark(dep)
+        }
+    }
+    for (let index = start; index < frame.nodes.length; index++) {
+        const selector = frame.nodes[index]!
+        const value = frame.meta.get(selector)
+        if (value === undefined) continue
+        const flags = flagsOf(value)
+        if ((flags & SEARCH_ADDED) !== 0) {
+            frame.meta.delete(selector)
+        } else {
+            frame.meta.set(selector, withFlags(value, flags & ~SEARCHED))
+        }
+    }
+    frame.nodes.length = start
+    return closesCycle
+}
+
+const enqueueFallbackDownstream = <Context>(
+    selector: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    propagate: PropagateSelector<Context> | undefined,
+    suppressClosingCycle: boolean,
+) => {
+    const downstream = data.stateDependents.get(selector)
+    if (!downstream) return
+    for (const childState of downstream) {
+        if (!IS_PROD) recordEdge(data)
+        const child = childState as Selector
+        if (propagate) propagate(selector, child, context)
+        const value = frame.meta.get(child) ?? 0
+        const flags = flagsOf(value)
+        if ((flags & ACTIVE) !== 0) continue
+        if (
+            suppressClosingCycle &&
+            signalClosesCycle(selector, child, frame, data)
+        ) {
+            continue
+        }
+        frame.meta.set(
+            child,
+            withFlags(value, flags | NEEDS_EVAL | RESWEEP | ACTIVE),
+        )
+        if ((flags & RESWEEP) === 0) frame.resweep.push(child)
+        frame.ready.push(child)
+        if (!IS_PROD) recordEnqueue(data)
+    }
+}
+
+const settleFallbackSelector = <Context>(
+    selector: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+    suppressClosingCycles: boolean,
+) => {
+    const value = frame.meta.get(selector) ?? 0
+    frame.meta.set(selector, withFlags(value, flagsOf(value) & ~ACTIVE))
+    if (!IS_PROD) recordDequeue(data)
+    const result = settle(selector, data, context)
+    if ((result & SCHEDULE_CHANGED) !== 0) {
+        enqueueFallbackDownstream(
+            selector,
+            frame,
+            data,
+            context,
+            propagate,
+            suppressClosingCycles,
+        )
+    }
+}
+
+const settleStranded = <Context>(
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    let readyHead = 0
+    let fallbackSettlements = 0
+    const shouldSuppressClosingCycles = () =>
+        fallbackSettlements >= Math.max(32, frame.resweep.length * 16)
+    while (true) {
+        frame.batch.length = 0
+        while (readyHead < frame.ready.length) {
+            const selector = frame.ready[readyHead++]!
+            const value = frame.meta.get(selector)
+            if (value !== undefined && (flagsOf(value) & ACTIVE) !== 0) {
+                frame.batch.push(selector)
+            }
+        }
+        frame.ready.length = 0
+        readyHead = 0
+        if (frame.batch.length === 0) return
+
+        let progressed = false
+        for (const selector of frame.batch) {
+            const value = frame.meta.get(selector)
+            if (value === undefined || (flagsOf(value) & ACTIVE) === 0) continue
+            if (hasActiveDependency(selector, frame, data)) continue
+            progressed = true
+            settleFallbackSelector(
+                selector,
+                frame,
+                data,
+                context,
+                settle,
+                propagate,
+                shouldSuppressClosingCycles(),
+            )
+            fallbackSettlements++
+        }
+        if (progressed) {
+            for (const selector of frame.batch) {
+                const value = frame.meta.get(selector)
+                if (value !== undefined && (flagsOf(value) & ACTIVE) !== 0) {
+                    frame.ready.push(selector)
+                }
+            }
+            continue
+        }
+
+        // The remaining active region has no dependency-free node. Evaluate one
+        // isolated insertion-order wave, matching the historical handling for
+        // cyclic work. Clear current membership before evaluating the fixed
+        // batch so changed edges enqueue into the next reusable queue, matching
+        // the historical Set-based fixpoint behavior for convergent cycles.
+        if (!IS_PROD) recordCycleFallback(data)
+        for (const selector of frame.batch) {
+            const value = frame.meta.get(selector)
+            if (value !== undefined) {
+                frame.meta.set(
+                    selector,
+                    withFlags(value, flagsOf(value) & ~ACTIVE),
+                )
+            }
+        }
+        for (const selector of frame.batch) {
+            if (!IS_PROD) recordDequeue(data)
+            const result = settle(selector, data, context)
+            fallbackSettlements++
+            if ((result & SCHEDULE_CHANGED) !== 0) {
+                enqueueFallbackDownstream(
+                    selector,
+                    frame,
+                    data,
+                    context,
+                    propagate,
+                    shouldSuppressClosingCycles(),
+                )
+            }
+        }
+    }
+}
+
+const orderInitialSelectors = (
+    selectors: Set<Selector>,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+) => {
+    for (const selector of selectors) addClosureNode(selector, true, frame)
+    for (const selector of frame.nodes) {
+        frame.meta.set(selector, withPending(frame.meta.get(selector)!, 0))
+    }
+    for (const selector of frame.nodes) {
+        const downstream = data.stateDependents.get(selector)
+        if (!downstream) continue
+        for (const childState of downstream) {
+            if (!IS_PROD) recordEdge(data)
+            const child = childState as Selector
+            const value = frame.meta.get(child)
+            if (value === undefined) continue
+            frame.meta.set(child, withPending(value, pendingOf(value) + 1))
+        }
+    }
+    for (const selector of frame.nodes) {
+        if (pendingOf(frame.meta.get(selector)!) !== 0) continue
+        frame.ready.push(selector)
+        if (!IS_PROD) recordEnqueue(data)
+    }
+
+    let head = 0
+    while (head < frame.ready.length) {
+        const selector = frame.ready[head++]!
+        if (!IS_PROD) recordDequeue(data)
+        frame.batch.push(selector)
+        const downstream = data.stateDependents.get(selector)
+        if (!downstream) continue
+        for (const childState of downstream) {
+            const child = childState as Selector
+            const value = frame.meta.get(child)
+            if (value === undefined) continue
+            if (!IS_PROD) recordEdge(data)
+            const pending = Math.max(0, pendingOf(value) - 1)
+            frame.meta.set(child, withPending(value, pending))
+            if (pending === 0) {
+                frame.ready.push(child)
+                if (!IS_PROD) recordEnqueue(data)
+            }
+        }
+    }
+
+    // Preserve the historical insertion-order treatment when the initial set
+    // itself is cyclic. Any changed edge below is still handed to the isolated
+    // closure fixpoint.
+    if (frame.batch.length !== frame.nodes.length) {
+        frame.batch.length = 0
+        for (const selector of frame.nodes) frame.batch.push(selector)
+    }
+}
+
+const addChangedClosureNode = (
+    selector: Selector,
+    needsEval: boolean,
+    frame: SchedulerWorkspace,
+): boolean => {
+    const value = frame.meta.get(selector) ?? 0
+    const flags = flagsOf(value)
+    if ((flags & RESWEEP) !== 0) {
+        if (needsEval) {
+            frame.meta.set(selector, withFlags(value, flags | NEEDS_EVAL))
+        }
+        return false
+    }
+    // Reset any seed-order pending count; the finalized closure takes a fresh
+    // dependency snapshot after every changed seed has been settled or deferred.
+    frame.meta.set(
+        selector,
+        RESWEEP | (flags & NEEDS_EVAL) | (needsEval ? NEEDS_EVAL : 0),
+    )
+    frame.resweep.push(selector)
+    return true
+}
+
+const discoverClosureFrom = (
+    start: number,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+) => {
+    for (let index = start; index < frame.resweep.length; index++) {
+        const selector = frame.resweep[index]!
+        const children = data.stateDependents.get(selector)
+        if (!children) continue
+        for (const childState of children) {
+            if (!IS_PROD) recordEdge(data)
+            addChangedClosureNode(childState as Selector, false, frame)
+        }
+    }
+}
+
+const discoverChangedClosure = <Context>(
+    parent: Selector,
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    const start = frame.resweep.length
+    const downstream = data.stateDependents.get(parent)
+    if (downstream) {
+        for (const childState of downstream) {
+            if (!IS_PROD) recordEdge(data)
+            const child = childState as Selector
+            if (propagate) propagate(parent, child, context)
+            addChangedClosureNode(child, true, frame)
+        }
+    }
+
+    // Discover the union only after a seed actually changes. Initial selectors
+    // reached by this traversal are marked RESWEEP and skipped by the seed pass,
+    // so a wide sink is evaluated once after every reached upstream finalizes.
+    discoverClosureFrom(start, frame, data)
+}
+
+const prepareChangedClosure = (frame: SchedulerWorkspace) => {
+    for (const selector of frame.nodes) {
+        const value = frame.meta.get(selector)
+        if (value !== undefined && (flagsOf(value) & RESWEEP) === 0) {
+            frame.meta.delete(selector)
+        }
+    }
+    frame.nodes.length = 0
+    for (const selector of frame.resweep) {
+        const value = frame.meta.get(selector)!
+        frame.meta.set(
+            selector,
+            (flagsOf(value) & NEEDS_EVAL) !== 0 ? NEEDS_EVAL : 0,
+        )
+        frame.nodes.push(selector)
+    }
+    frame.ready.length = 0
+    frame.resweep.length = 0
+    frame.batch.length = 0
+}
+
+const settleChangedClosure = <Context>(
+    frame: SchedulerWorkspace,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    prepareChangedClosure(frame)
+    initializeReadyQueue(frame, data)
+    const graphMutated = settleReady(frame, data, context, settle, propagate)
+    activateStrandedWork(frame, graphMutated, data)
+    settleStranded(frame, data, context, settle, propagate)
+}
+
+const runMultiSeedScheduler = <Context>(
+    selectors: Set<Selector>,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    const frame = acquireSchedulerWorkspace(data)
+    try {
+        orderInitialSelectors(selectors, frame, data)
+        for (const selector of frame.batch) {
+            const value = frame.meta.get(selector)
+            if (value === undefined) continue
+            const flags = flagsOf(value)
+            if ((flags & RESWEEP) !== 0) continue
+
+            const result = settle(selector, data, context)
+            frame.meta.set(
+                selector,
+                withFlags(value, (flags & ~NEEDS_EVAL) | SETTLED),
+            )
+            if ((result & SCHEDULE_CHANGED) !== 0) {
+                discoverChangedClosure(
+                    selector,
+                    frame,
+                    data,
+                    context,
+                    propagate,
+                )
+            }
+        }
+        if (frame.resweep.length === 0) return
+
+        settleChangedClosure(frame, data, context, settle, propagate)
+    } finally {
+        releaseSchedulerWorkspace(frame)
+    }
+}
+
+const hasInitialDependency = (
+    selectors: Set<Selector>,
+    data: StoreData,
+): boolean => {
+    for (const selector of selectors) {
+        const deps = data.stateDependencies.get(selector)
+        if (!deps) continue
+        for (const dep of deps) {
+            if (!IS_PROD) recordEdge(data)
+            if (selectors.has(dep as Selector)) return true
+        }
+    }
+    return false
+}
+
+const runIndependentSeedScheduler = <Context>(
+    selectors: Set<Selector>,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    let frame: SchedulerWorkspace | undefined
+    try {
+        for (const selector of selectors) {
+            const value = frame?.meta.get(selector)
+            if (
+                frame &&
+                value !== undefined &&
+                (flagsOf(value) & RESWEEP) !== 0
+            ) {
+                markNeedsEval(selector, frame)
+                continue
+            }
+            const result = settle(selector, data, context)
+            if ((result & SCHEDULE_CHANGED) === 0) continue
+            const downstream = data.stateDependents.get(selector)
+            if (!downstream || downstream.size === 0) continue
+            if (!frame) frame = acquireSchedulerWorkspace(data)
+            discoverChangedClosure(selector, frame, data, context, propagate)
+        }
+        if (!frame || frame.resweep.length === 0) return
+        settleChangedClosure(frame, data, context, settle, propagate)
+    } finally {
+        if (frame) releaseSchedulerWorkspace(frame)
+    }
+}
+
+const runClosureScheduler = <Context>(
+    initial: Iterable<Selector>,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate: PropagateSelector<Context> | undefined,
+) => {
+    const frame = acquireSchedulerWorkspace(data)
+    try {
+        discoverClosure(initial, frame, data)
+        initializeReadyQueue(frame, data)
+        const graphMutated = settleReady(
+            frame,
+            data,
+            context,
+            settle,
+            propagate,
+        )
+        activateStrandedWork(frame, graphMutated, data)
+        settleStranded(frame, data, context, settle, propagate)
+    } finally {
+        releaseSchedulerWorkspace(frame)
+    }
+}
+
+export const scheduleSelectors = <Context>(
+    selectors: Set<Selector>,
+    data: StoreData,
+    context: Context,
+    settle: SettleSelector<Context>,
+    propagate?: PropagateSelector<Context>,
+): void => {
+    if (selectors.size === 0) return
+
+    // One initial selector keeps the historical linear fast path. Only build
+    // scheduler state when its value changed and it has downstream work.
+    if (selectors.size === 1) {
+        const selector = selectors.values().next().value as Selector
+        const result = settle(selector, data, context)
+        if ((result & SCHEDULE_CHANGED) === 0) return
+        const downstream = data.stateDependents.get(selector)
+        if (!downstream || downstream.size === 0) return
+        if (propagate) {
+            for (const child of downstream) {
+                propagate(selector, child as Selector, context)
+            }
+        }
+        runClosureScheduler(
+            downstream as Set<Selector>,
+            data,
+            context,
+            settle,
+            propagate,
+        )
+        return
+    }
+
+    // Independent selector leaves need neither ordering nor downstream
+    // discovery. This is the common live fan-out shape and keeps it off the
+    // graph workspace just like the one-selector terminal path.
+    let hasDownstream = false
+    for (const selector of selectors) {
+        const downstream = data.stateDependents.get(selector)
+        if (downstream && downstream.size > 0) {
+            hasDownstream = true
+            break
+        }
+    }
+    if (!hasDownstream) {
+        // A seed evaluation can lazily materialize new downstream edges. Reuse
+        // the independent-seed path so those edges are observed after each
+        // settlement without allocating a frame for the ordinary leaf case.
+        runIndependentSeedScheduler(selectors, data, context, settle, propagate)
+        return
+    }
+
+    if (hasInitialDependency(selectors, data)) {
+        runMultiSeedScheduler(selectors, data, context, settle, propagate)
+    } else {
+        runIndependentSeedScheduler(selectors, data, context, settle, propagate)
+    }
+}

--- a/packages/valdres/src/lib/graph/workspace.ts
+++ b/packages/valdres/src/lib/graph/workspace.ts
@@ -1,0 +1,268 @@
+import type { Selector } from "../../types/Selector"
+import type { State } from "../../types/State"
+import type { StoreData } from "../../types/StoreData"
+
+const MAX_POOLED_FRAMES = 4
+const MAX_RETAINED_ENTRIES = 1_024
+
+export type SchedulerWorkspace = {
+    meta: Map<Selector, number>
+    nodes: Selector[]
+    ready: Selector[]
+    resweep: Selector[]
+    batch: Selector[]
+    inUse: boolean
+}
+
+type DfsFrame = {
+    node: State
+    it: Iterator<State>
+}
+
+export type LivenessWorkspace = {
+    stack: State[]
+    ordered: State[]
+    dfs: DfsFrame[]
+    onPath?: Set<State>
+    region?: Set<State>
+    live?: Set<State>
+    wasLive?: Map<State, boolean>
+    mountVisited?: Set<State>
+    unmountVisited?: Set<State>
+    inUse: boolean
+    oversized: boolean
+}
+
+type WorkspacePool = {
+    scheduler: SchedulerWorkspace[]
+    liveness: LivenessWorkspace[]
+}
+
+const pools = new WeakMap<StoreData, WorkspacePool>()
+
+const poolFor = (data: StoreData): WorkspacePool => {
+    let pool = pools.get(data)
+    if (!pool) {
+        pool = { scheduler: [], liveness: [] }
+        pools.set(data, pool)
+    }
+    return pool
+}
+
+const recordSchedulerAllocations = (data: StoreData, count: number) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation)
+        instrumentation.counters.schedulerWorkAllocations += count
+}
+
+const recordLivenessAllocations = (data: StoreData, count: number) => {
+    const instrumentation = data.architectureInstrumentation
+    if (instrumentation)
+        instrumentation.counters.livenessWorkAllocations += count
+}
+
+const createSchedulerWorkspace = (data: StoreData): SchedulerWorkspace => {
+    // One Map plus four reusable arrays.
+    recordSchedulerAllocations(data, 5)
+    return {
+        meta: new Map(),
+        nodes: [],
+        ready: [],
+        resweep: [],
+        batch: [],
+        inUse: true,
+    }
+}
+
+const createLivenessWorkspace = (data: StoreData): LivenessWorkspace => {
+    // Stack, reverse-order staging, and DFS arrays; Sets/Maps stay lazy.
+    recordLivenessAllocations(data, 3)
+    return {
+        stack: [],
+        ordered: [],
+        dfs: [],
+        inUse: true,
+        oversized: false,
+    }
+}
+
+export const acquireSchedulerWorkspace = (
+    data: StoreData,
+): SchedulerWorkspace => {
+    const frames = poolFor(data).scheduler
+    for (const frame of frames) {
+        if (!frame.inUse) {
+            frame.inUse = true
+            return frame
+        }
+    }
+    if (frames.length < MAX_POOLED_FRAMES) {
+        const frame = createSchedulerWorkspace(data)
+        frames.push(frame)
+        return frame
+    }
+    return createSchedulerWorkspace(data)
+}
+
+const clearArray = <T>(array: T[]): T[] => {
+    if (array.length > MAX_RETAINED_ENTRIES) return []
+    array.length = 0
+    return array
+}
+
+export const releaseSchedulerWorkspace = (frame: SchedulerWorkspace): void => {
+    const size = frame.meta.size
+    frame.meta.clear()
+    if (size > MAX_RETAINED_ENTRIES) frame.meta = new Map()
+    frame.nodes = clearArray(frame.nodes)
+    frame.ready = clearArray(frame.ready)
+    frame.resweep = clearArray(frame.resweep)
+    frame.batch = clearArray(frame.batch)
+    frame.inUse = false
+}
+
+export const acquireLivenessWorkspace = (
+    data: StoreData,
+): LivenessWorkspace => {
+    const frames = poolFor(data).liveness
+    for (const frame of frames) {
+        if (!frame.inUse) {
+            frame.inUse = true
+            return frame
+        }
+    }
+    if (frames.length < MAX_POOLED_FRAMES) {
+        const frame = createLivenessWorkspace(data)
+        frames.push(frame)
+        return frame
+    }
+    return createLivenessWorkspace(data)
+}
+
+export const noteLivenessWorkspaceSize = (frame: LivenessWorkspace): void => {
+    if (
+        frame.stack.length > MAX_RETAINED_ENTRIES ||
+        frame.ordered.length > MAX_RETAINED_ENTRIES ||
+        frame.dfs.length > MAX_RETAINED_ENTRIES ||
+        (frame.onPath?.size ?? 0) > MAX_RETAINED_ENTRIES ||
+        (frame.region?.size ?? 0) > MAX_RETAINED_ENTRIES ||
+        (frame.live?.size ?? 0) > MAX_RETAINED_ENTRIES ||
+        (frame.wasLive?.size ?? 0) > MAX_RETAINED_ENTRIES ||
+        (frame.mountVisited?.size ?? 0) > MAX_RETAINED_ENTRIES ||
+        (frame.unmountVisited?.size ?? 0) > MAX_RETAINED_ENTRIES
+    ) {
+        frame.oversized = true
+    }
+}
+
+export const ensureOnPath = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Set<State> => {
+    if (!frame.onPath) {
+        recordLivenessAllocations(data, 1)
+        frame.onPath = new Set()
+    }
+    return frame.onPath
+}
+
+export const ensureRegion = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Set<State> => {
+    if (!frame.region) {
+        recordLivenessAllocations(data, 1)
+        frame.region = new Set()
+    }
+    return frame.region
+}
+
+export const ensureLive = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Set<State> => {
+    if (!frame.live) {
+        recordLivenessAllocations(data, 1)
+        frame.live = new Set()
+    }
+    return frame.live
+}
+
+export const ensureWasLive = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Map<State, boolean> => {
+    if (!frame.wasLive) {
+        recordLivenessAllocations(data, 1)
+        frame.wasLive = new Map()
+    }
+    return frame.wasLive
+}
+
+export const ensureMountVisited = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Set<State> => {
+    if (!frame.mountVisited) {
+        recordLivenessAllocations(data, 1)
+        frame.mountVisited = new Set()
+    }
+    return frame.mountVisited
+}
+
+export const ensureUnmountVisited = (
+    frame: LivenessWorkspace,
+    data: StoreData,
+): Set<State> => {
+    if (!frame.unmountVisited) {
+        recordLivenessAllocations(data, 1)
+        frame.unmountVisited = new Set()
+    }
+    return frame.unmountVisited
+}
+
+const clearSet = <T>(set: Set<T> | undefined): Set<T> | undefined => {
+    if (!set) return undefined
+    const size = set.size
+    set.clear()
+    return size > MAX_RETAINED_ENTRIES ? undefined : set
+}
+
+const clearMap = <K, V>(map: Map<K, V> | undefined): Map<K, V> | undefined => {
+    if (!map) return undefined
+    const size = map.size
+    map.clear()
+    return size > MAX_RETAINED_ENTRIES ? undefined : map
+}
+
+export const releaseLivenessWorkspace = (frame: LivenessWorkspace): void => {
+    if (frame.oversized) {
+        frame.stack = []
+        frame.ordered = []
+        frame.dfs = []
+        frame.onPath = undefined
+        frame.region = undefined
+        frame.live = undefined
+        frame.wasLive = undefined
+        frame.mountVisited = undefined
+        frame.unmountVisited = undefined
+        frame.oversized = false
+        frame.inUse = false
+        return
+    }
+    frame.stack = clearArray(frame.stack)
+    frame.ordered = clearArray(frame.ordered)
+    frame.dfs = clearArray(frame.dfs)
+    frame.onPath = clearSet(frame.onPath)
+    frame.region = clearSet(frame.region)
+    frame.live = clearSet(frame.live)
+    frame.wasLive = clearMap(frame.wasLive)
+    frame.mountVisited = clearSet(frame.mountVisited)
+    frame.unmountVisited = clearSet(frame.unmountVisited)
+    frame.inUse = false
+}
+
+/** Explicit disposal release. Undisposed stores are still weakly owned. */
+export const dropGraphWorkspaces = (data: StoreData): void => {
+    pools.delete(data)
+}

--- a/packages/valdres/src/lib/propagateUpdatedAtoms.ts
+++ b/packages/valdres/src/lib/propagateUpdatedAtoms.ts
@@ -24,6 +24,9 @@ import {
     installEvaluationDeps,
     isLive,
     reconcileLivenessAfterChurn,
+    scheduleSelectors,
+    SCHEDULE_CHANGED,
+    SCHEDULE_GRAPH_CHANGED,
     type EvaluationOutcome,
 } from "./graph"
 import { recordCommitError, type CommitErrors } from "./commitErrors"
@@ -60,8 +63,6 @@ import { setValueInData } from "./setValueInData"
 import { noteStateValueChanged } from "./stateRevisions"
 import {
     recordDependencyEdgeVisit,
-    recordSchedulerQueueDequeue,
-    recordSchedulerQueueEnqueue,
     recordSelectorSettlement,
     recordStoreSettlement,
 } from "./architectureInstrumentation"
@@ -1960,499 +1961,80 @@ export const settleAsyncSelectorCommit: SelectorSettleFn = (
     }
 }
 
-// Topological evaluation of a downstream subgraph. The main ready queue visits
-// each selector in `seeds` (and everything transitively reachable from them) at
-// most once, in dependency order. A finalized node is deleted from `pending`,
-// which caps duplicate pushes caused by dynamic dependency churn without a
-// separate queued/evaluated Set. If churn later proves that a settled selector
-// must run again, that selector and its downstream closure are deferred to the
-// settle phase below so wide aggregates run after upstream revisits rather than
-// once per transient wave. The seeds are direct dependents of initial selectors
-// whose values just changed in the first sweep — i.e. "level-2" selectors. We
-// only enter the topo path when there's actual downstream work, since the
-// bookkeeping (closure + pending count) is material relative to a simple BFS pass.
-const propagateDownstreamTopo = (
-    seeds: Set<Selector>,
+type SelectorScheduleContext = DepsChange & {
+    collectedSubscribers: Set<any>
+    updatedInitializedAtoms: Set<Atom>
+    isInitOnly: boolean
+    changedSelectors?: Set<Selector>
+    treeCtx?: TreeSettleContext
+    outcome: EvaluationOutcome
+}
+
+const settleScheduledSelector = (
+    selector: Selector,
     data: StoreData,
-    collectedSubscribers: Set<any>,
-    updatedInitializedAtoms: Set<Atom>,
-    isInitOnly: boolean,
-    changedSelectors?: Set<Selector>,
-    treeCtx?: TreeSettleContext,
+    context: SelectorScheduleContext,
+): number => {
+    const currentValue = data.values.get(selector)
+    if (isPromiseLike(currentValue) && context.isInitOnly) return 0
+
+    const dependents = data.stateDependents.get(selector)
+    const subscribers = data.subscriptions.get(selector)
+    if (
+        !isPromiseLike(currentValue) &&
+        (!dependents || dependents.size === 0) &&
+        (!subscribers || subscribers.size === 0)
+    ) {
+        // No live consumer — invalidate for lazy re-eval on next read.
+        if (data.values.delete(selector)) {
+            noteStateValueChanged(selector, data)
+        }
+        return 0
+    }
+
+    context.added = undefined
+    context.removed = undefined
+    const wasValueUpdated = reEvaluateSelector(
+        selector,
+        data,
+        context.updatedInitializedAtoms,
+        context,
+        context.outcome,
+        currentValue,
+        context.treeCtx,
+    )
+    const added = context.added as Set<State> | undefined
+    const removed = context.removed as Set<State> | undefined
+    let result = 0
+    if (added || removed) {
+        applyLiveDependencyDiff(selector, added, removed, data)
+        result |= SCHEDULE_GRAPH_CHANGED
+    }
+    if (wasValueUpdated) {
+        result |= SCHEDULE_CHANGED
+        if (context.changedSelectors) {
+            context.changedSelectors.add(selector)
+        }
+        if (subscribers) {
+            addSetToSet(subscribers, context.collectedSubscribers)
+        }
+    }
+    return result
+}
+
+const propagateScheduledSelector = (
+    parent: Selector,
+    child: Selector,
+    context: SelectorScheduleContext,
 ) => {
-    const closure = new Set<Selector>(seeds)
-    {
-        const stack: Selector[] = [...seeds]
-        while (stack.length > 0) {
-            const s = stack.pop() as Selector
-            const downstream = data.stateDependents.get(s)
-            if (downstream) {
-                for (const d of downstream) {
-                    if (!IS_PROD && data.architectureInstrumentation)
-                        recordDependencyEdgeVisit(data)
-                    if (!closure.has(d)) {
-                        closure.add(d)
-                        stack.push(d)
-                    }
-                }
-            }
-        }
-    }
-
-    // Pending: number of direct deps of `s` that are also in the closure
-    // (i.e. still-dirty parents). Count 0 → ready to evaluate. Atoms and
-    // out-of-closure selectors are already resolved (atoms were just
-    // updated; outside selectors are stable for this propagation).
-    const pending = new Map<Selector, number>()
-    const ready: Selector[] = []
-    for (const s of closure) {
-        const deps = data.stateDependencies.get(s)
-        let count = 0
-        if (deps) {
-            for (const d of deps) {
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordDependencyEdgeVisit(data)
-                if (closure.has(d as Selector)) count++
-            }
-        }
-        pending.set(s, count)
-        if (count === 0) {
-            ready.push(s)
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordSchedulerQueueEnqueue(data)
-        }
-    }
-    // A closure member only needs re-evaluation if at least one of its
-    // upstream parents actually changed value. Seeds reach here because
-    // a first-pass parent changed, so they start as needing eval. Pure
-    // downstream gets flagged as parents propagate change.
-    const needsEval = new Set<Selector>(seeds)
-
-    // Set when the dependency graph changes during the walk (a selector's deps
-    // were added/removed, or an out-of-closure dependent was pulled in). Only
-    // then can a node need the settle scan below, so the steady-state fast path
-    // skips it entirely.
-    let graphMutated = false
-    let resweep: Set<Selector> | undefined
-    const markForResweep = (selector: Selector) => {
-        graphMutated = true
-        if (!resweep) resweep = new Set()
-        const stack = [selector]
-        for (let i = 0; i < stack.length; i++) {
-            const s = stack[i]
-            if (resweep.has(s)) continue
-            resweep.add(s)
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordSchedulerQueueEnqueue(data)
-            const downstream = data.stateDependents.get(s)
-            if (downstream) {
-                for (const d of downstream) {
-                    if (!IS_PROD && data.architectureInstrumentation)
-                        recordDependencyEdgeVisit(data)
-                    stack.push(d)
-                }
-            }
-        }
-    }
-
-    const advance = (selector: Selector, propagateChange: boolean) => {
-        const downstream = data.stateDependents.get(selector)
-        if (!downstream) return
-        for (const d of downstream) {
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordDependencyEdgeVisit(data)
-            if (propagateChange && treeCtx)
-                mergeTreeProvenance(treeCtx, d, selector)
-            if (!closure.has(d)) {
-                // `d` is downstream of a just-changed selector but absent from
-                // the static closure, which means it was materialized AFTER the
-                // closure was built — e.g. an orphaned selector whose value was
-                // dropped by unsubscribe GC and then lazily re-initialized when
-                // a closure selector read it mid-propagation. Such a node may
-                // have read a not-yet-settled (stale) value of `selector`, and
-                // because it's untracked, a later change here would never reach
-                // it. Pull it into the closure so the topo walk re-evaluates it
-                // once `selector` settles. (Only when there is an actual change
-                // to propagate; an unchanged parent needs no re-eval.)
-                if (propagateChange) {
-                    graphMutated = true
-                    closure.add(d)
-                    pending.set(d, 0)
-                    needsEval.add(d)
-                    ready.push(d)
-                    if (!IS_PROD && data.architectureInstrumentation)
-                        recordSchedulerQueueEnqueue(data)
-                }
-                continue
-            }
-            const cur = pending.get(d)
-            if (cur === undefined) {
-                if (propagateChange) markForResweep(d)
-                continue
-            }
-            const c = cur - 1
-            pending.set(d, c)
-            if (propagateChange) needsEval.add(d)
-            if (c <= 0) {
-                ready.push(d)
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordSchedulerQueueEnqueue(data)
-            }
-        }
-    }
-
-    // FIFO head pointer preserves the original BFS sibling order — nested
-    // writes that side-effect into peer selectors during eval depend on it.
-    // Reused across every re-evaluated selector. evaluateSelector only
-    // allocates the inner Sets when deps actually changed, so steady-state
-    // settling does zero allocation here. The outcome carrier is likewise
-    // owned per pass: each re-eval overwrites and consumes it in place.
-    const depsChange: DepsChange = {}
-    const outcome = createEvaluationOutcome()
-    let head = 0
-    while (head < ready.length) {
-        const selector = ready[head++]
-        if (!IS_PROD && data.architectureInstrumentation)
-            recordSchedulerQueueDequeue(data)
-        if (resweep?.has(selector)) continue
-        if (!pending.has(selector)) continue
-
-        const currentValue = data.values.get(selector)
-
-        if (isPromiseLike(currentValue) && isInitOnly) {
-            pending.delete(selector)
-            advance(selector, false)
-            continue
-        }
-
-        if (!needsEval.has(selector)) {
-            pending.delete(selector)
-            advance(selector, false)
-            continue
-        }
-
-        const dependents = data.stateDependents.get(selector)
-        const subscribers = data.subscriptions.get(selector)
-
-        if (
-            !isPromiseLike(currentValue) &&
-            (!dependents || dependents.size === 0) &&
-            (!subscribers || subscribers.size === 0)
-        ) {
-            // No live consumer — invalidate for lazy re-eval on next read.
-            if (data.values.delete(selector)) {
-                noteStateValueChanged(selector, data)
-            }
-            pending.delete(selector)
-            advance(selector, false)
-            continue
-        }
-
-        depsChange.added = undefined
-        depsChange.removed = undefined
-        const wasValueUpdated = reEvaluateSelector(
-            selector,
-            data,
-            updatedInitializedAtoms,
-            depsChange,
-            outcome,
-            currentValue,
-            treeCtx,
-        )
-        // Casts work around a tsgo control-flow narrowing quirk where
-        // property accesses lose their narrowing after a function call.
-        const added = depsChange.added as Set<State> | undefined
-        const removed = depsChange.removed as Set<State> | undefined
-        if (added || removed) {
-            // The graph changed under the walk — a node may now be stranded.
-            graphMutated = true
-            applyLiveDependencyDiff(selector, added, removed, data)
-        }
-
-        pending.delete(selector)
-        advance(selector, wasValueUpdated)
-        if (wasValueUpdated) {
-            if (changedSelectors) changedSelectors.add(selector)
-            if (subscribers) addSetToSet(subscribers, collectedSubscribers)
-        }
-    }
-
-    // Settle stranded/resweep nodes. The `pending` counts are a snapshot taken
-    // before the walk; they assume the dependency graph is fixed for its
-    // duration. But a selector can be re-evaluated out-of-band DURING the walk —
-    // most commonly lazily re-initialized via getState when another selector
-    // reads it (after its value was dropped by an earlier
-    // orphan-invalidation/unsubscribe). If that re-eval drops a dependency it
-    // was snapshotted with, the dropped parent's reverse edge is gone, so it
-    // never decrements this node's `pending`, which then stalls above 0 and the
-    // node is never processed. Also, a node already settled by the main ready
-    // queue can receive another real changed-parent signal after graph churn; it
-    // has no `pending` entry, so it is recorded in `resweep`. Re-settle those
-    // nodes and their downstream closure with a dynamic topo fixpoint. That lets
-    // upstream revisits settle before wide downstream aggregates run, while
-    // still falling back to wave settling for cyclic regions. Guarded by
-    // `graphMutated`, so the steady-state fast path skips it entirely.
-    if (!graphMutated) return
-
-    let stranded: Set<Selector> | undefined = resweep
-    for (const s of closure) {
-        if (needsEval.has(s) && pending.has(s)) {
-            if (!stranded) stranded = new Set()
-            if (!stranded.has(s)) {
-                stranded.add(s)
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordSchedulerQueueEnqueue(data)
-            }
-        }
-    }
-    if (!stranded) return
-
-    let work = stranded
-    const hasUnsettledDependency = (selector: Selector) => {
-        const deps = data.stateDependencies.get(selector)
-        if (!deps) return false
-        for (const dep of deps) {
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordDependencyEdgeVisit(data)
-            if (dep !== selector && work.has(dep as Selector)) return true
-        }
-        return false
-    }
-    const enqueueDownstream = (selector: Selector) => {
-        const downstream = data.stateDependents.get(selector)
-        if (!downstream) return
-        for (const d of downstream) {
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordDependencyEdgeVisit(data)
-            if (treeCtx) mergeTreeProvenance(treeCtx, d, selector)
-            if (!work.has(d)) {
-                work.add(d)
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordSchedulerQueueEnqueue(data)
-            }
-        }
-    }
-    const evaluateStrandedSelector = (selector: Selector) => {
-        const currentValue = data.values.get(selector)
-        if (isPromiseLike(currentValue) && isInitOnly) return false
-        const dependents = data.stateDependents.get(selector)
-        const subscribers = data.subscriptions.get(selector)
-        if (
-            !isPromiseLike(currentValue) &&
-            (!dependents || dependents.size === 0) &&
-            (!subscribers || subscribers.size === 0)
-        ) {
-            if (data.values.delete(selector)) {
-                noteStateValueChanged(selector, data)
-            }
-            return false
-        }
-        depsChange.added = undefined
-        depsChange.removed = undefined
-        const wasValueUpdated = reEvaluateSelector(
-            selector,
-            data,
-            updatedInitializedAtoms,
-            depsChange,
-            outcome,
-            currentValue,
-            treeCtx,
-        )
-        const added = depsChange.added as Set<State> | undefined
-        const removed = depsChange.removed as Set<State> | undefined
-        if (added || removed) {
-            applyLiveDependencyDiff(selector, added, removed, data)
-        }
-        if (wasValueUpdated) {
-            if (changedSelectors) changedSelectors.add(selector)
-            if (subscribers) addSetToSet(subscribers, collectedSubscribers)
-            // Re-fetch dependents — eval may have changed them.
-            enqueueDownstream(selector)
-        }
-        return wasValueUpdated
-    }
-    while (work.size > 0) {
-        let progressed = false
-        const batch = [...work]
-        for (const selector of batch) {
-            if (!work.has(selector)) continue
-            if (hasUnsettledDependency(selector)) continue
-            work.delete(selector)
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordSchedulerQueueDequeue(data)
-            progressed = true
-            evaluateStrandedSelector(selector)
-        }
-        if (progressed) continue
-
-        // Cyclic stranded regions have no dependency-free node. Fall back to the
-        // previous wave behavior for that region so cyclic dynamic graphs still
-        // get a chance to settle instead of stalling behind the topo gate.
-        const cyclicBatch = [...work]
-        work = new Set()
-        for (const selector of cyclicBatch) {
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordSchedulerQueueDequeue(data)
-            evaluateStrandedSelector(selector)
-        }
+    if (context.treeCtx) {
+        mergeTreeProvenance(context.treeCtx, child, parent)
     }
 }
 
-const orderInitialSelectors = (
-    selectors: Set<Selector>,
-    data: StoreData,
-): Selector[] => {
-    if (selectors.size < 2) return [...selectors]
-
-    const pending = new Map<Selector, number>()
-    const downstream = new Map<Selector, Selector[]>()
-    const ready: Selector[] = []
-
-    for (const selector of selectors) {
-        let count = 0
-        const deps = data.stateDependencies.get(selector)
-        if (deps) {
-            for (const dep of deps) {
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordDependencyEdgeVisit(data)
-                if (!selectors.has(dep as Selector)) continue
-                count++
-                let list = downstream.get(dep as Selector)
-                if (!list) {
-                    list = []
-                    downstream.set(dep as Selector, list)
-                }
-                list.push(selector)
-            }
-        }
-        pending.set(selector, count)
-        if (count === 0) {
-            ready.push(selector)
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordSchedulerQueueEnqueue(data)
-        }
-    }
-
-    const ordered: Selector[] = []
-    let head = 0
-    while (head < ready.length) {
-        const selector = ready[head++]
-        if (!IS_PROD && data.architectureInstrumentation)
-            recordSchedulerQueueDequeue(data)
-        ordered.push(selector)
-        const children = downstream.get(selector)
-        if (!children) continue
-        for (const child of children) {
-            if (!IS_PROD && data.architectureInstrumentation)
-                recordDependencyEdgeVisit(data)
-            const count = (pending.get(child) ?? 0) - 1
-            pending.set(child, count)
-            if (count === 0) {
-                ready.push(child)
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordSchedulerQueueEnqueue(data)
-            }
-        }
-    }
-
-    // Cyclic initial regions rely on the old insertion-order behavior plus the
-    // liveness reconcile. Only reorder when the initial subgraph is acyclic.
-    return ordered.length === selectors.size ? ordered : [...selectors]
-}
-
-const propagateSelectorUpdatesLinearFirst = (
-    selectors: Set<Selector>,
-    data: StoreData,
-    collectedSubscribers: Set<any>,
-    updatedInitializedAtoms: Set<Atom>,
-    isInitOnly: boolean,
-    changedSelectors?: Set<Selector>,
-    treeCtx?: TreeSettleContext,
-) => {
-    let downstreamSeeds: Set<Selector> | undefined
-    const orderedSelectors = orderInitialSelectors(selectors, data)
-    const processedInitialSelectors = new Set<Selector>()
-    // Reused across every re-evaluated selector — see propagateDownstreamTopo.
-    const depsChange: DepsChange = {}
-    const outcome = createEvaluationOutcome()
-    for (const selector of orderedSelectors) {
-        const currentValue = data.values.get(selector)
-        if (isPromiseLike(currentValue) && isInitOnly) {
-            processedInitialSelectors.add(selector)
-            continue
-        }
-        const dependents = data.stateDependents.get(selector)
-        const subscribers = data.subscriptions.get(selector)
-        if (
-            !isPromiseLike(currentValue) &&
-            (!dependents || dependents.size === 0) &&
-            (!subscribers || subscribers.size === 0)
-        ) {
-            // No live consumer — invalidate for lazy re-eval on next read.
-            if (data.values.delete(selector)) {
-                noteStateValueChanged(selector, data)
-            }
-            processedInitialSelectors.add(selector)
-            continue
-        }
-        depsChange.added = undefined
-        depsChange.removed = undefined
-        const wasValueUpdated = reEvaluateSelector(
-            selector,
-            data,
-            updatedInitializedAtoms,
-            depsChange,
-            outcome,
-            currentValue,
-            treeCtx,
-        )
-        // Casts work around a tsgo control-flow narrowing quirk where
-        // property accesses lose their narrowing after a function call.
-        const added = depsChange.added as Set<State> | undefined
-        const removed = depsChange.removed as Set<State> | undefined
-        if (added || removed) {
-            applyLiveDependencyDiff(selector, added, removed, data)
-        }
-        processedInitialSelectors.add(selector)
-        if (!wasValueUpdated) continue
-        if (changedSelectors) changedSelectors.add(selector)
-        if (subscribers) addSetToSet(subscribers, collectedSubscribers)
-        // Re-fetch dependents — eval may have changed them.
-        const downstream = data.stateDependents.get(selector)
-        if (downstream && downstream.size > 0) {
-            if (!downstreamSeeds) downstreamSeeds = new Set()
-            for (const d of downstream) {
-                if (!IS_PROD && data.architectureInstrumentation)
-                    recordDependencyEdgeVisit(data)
-                if (treeCtx) mergeTreeProvenance(treeCtx, d, selector)
-                if (selectors.has(d) && !processedInitialSelectors.has(d)) {
-                    continue
-                }
-                downstreamSeeds.add(d)
-            }
-        }
-    }
-
-    if (downstreamSeeds && downstreamSeeds.size > 0) {
-        propagateDownstreamTopo(
-            downstreamSeeds,
-            data,
-            collectedSubscribers,
-            updatedInitializedAtoms,
-            isInitOnly,
-            changedSelectors,
-            treeCtx,
-        )
-    }
-}
-
-// Re-evaluate the initial dirty selectors, then topologically evaluate anything
-// downstream of selectors whose values actually shifted. The initial sweep is
-// ordered topologically when that initial subgraph is acyclic, and a downstream
-// selector already scheduled later in the same initial sweep is not queued for a
-// second topo pass. Cyclic regions keep the old insertion-order behavior because
-// the liveness churn tests rely on those transitional cycles being evaluated
-// and reconciled by the existing backstop.
+// Re-evaluate the dirty selector closure in dependency order. The graph scheduler
+// owns ordinary Kahn ordering, dynamic-dependency resweeps, and the isolated
+// insertion-order fallback for cyclic regions.
 const propagateSelectorUpdates = (
     selectors: Set<Selector>,
     data: StoreData,
@@ -2471,24 +2053,30 @@ const propagateSelectorUpdates = (
     // outside the loop — unconditional). A purely-additive loop-driven pass is
     // correct incrementally (even through cycles), so it arms neither. Allocated
     // only when a dep-set actually changes — the no-churn fast path never trips it.
-    // Take ownership of the liveness collector. The loop and
-    // propagateDownstreamTopo below run user onMount/cleanup (via
-    // mountTransitiveDeps / unmountOrphanedDeps) that can throw, so endLivenessPass
-    // runs in the `finally` (else a throwing onMount would strand the collector and
-    // permanently disable the reconcile) — and the returned region is reconciled
-    // AFTER the try, so a throwing pass doesn't re-enter user code and mask its
-    // error.
+    // Take ownership of the liveness collector. Selector settlement can run user
+    // onMount/cleanup code that throws, so endLivenessPass runs in the `finally`
+    // (else a throwing hook would strand the collector and permanently disable
+    // reconcile). Reconcile the returned region AFTER the try so a throwing pass
+    // never re-enters user code and masks its original error.
     const ownsLivenessSeeds = beginLivenessPass(data)
     let seedsToReconcile: Set<State> | null = null
     try {
-        propagateSelectorUpdatesLinearFirst(
-            selectors,
-            data,
+        const context: SelectorScheduleContext = {
+            added: undefined,
+            removed: undefined,
             collectedSubscribers,
             updatedInitializedAtoms,
             isInitOnly,
             changedSelectors,
             treeCtx,
+            outcome: createEvaluationOutcome(),
+        }
+        scheduleSelectors(
+            selectors,
+            data,
+            context,
+            settleScheduledSelector,
+            propagateScheduledSelector,
         )
     } finally {
         // Always release the collector — even if a user onMount/cleanup above threw

--- a/packages/valdres/test/import-cycles/graphBoundary.test.ts
+++ b/packages/valdres/test/import-cycles/graphBoundary.test.ts
@@ -45,6 +45,7 @@ const CORE_SCC_MEMBERS = new Set([
  *  an import that escapes this set risks re-entering the write-path cycle —
  *  extend it only for genuine leaves, consciously. */
 const GRAPH_LEAF_ALLOWLIST = new Set([
+    "src/lib/IS_PROD.ts",
     "src/lib/storeLifecycle.ts",
     "src/lib/stateRevisions.ts",
     "src/lib/getStoreRuntime.ts",
@@ -75,9 +76,7 @@ describe("graph import structure", () => {
 
     test("every SCC is a subset of the verified nine-module core", () => {
         for (const scc of sccs) {
-            const escapees = scc.filter(
-                module => !CORE_SCC_MEMBERS.has(module),
-            )
+            const escapees = scc.filter(module => !CORE_SCC_MEMBERS.has(module))
             expect(escapees).toEqual([])
         }
         expect(Math.max(0, ...sccs.map(scc => scc.length))).toBeLessThanOrEqual(

--- a/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
+++ b/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Architecture performance gates
 
-These gates measure the current Valdres architecture without changing it.
+These gates measure Valdres graph scheduling and commit architecture.
 Deterministic structural counts are the blocking signal; end-to-end latency and
 retained heap are confirmation signals. Index construction and indexing are
 explicitly out of scope.
@@ -44,9 +44,22 @@ one side of a PR comparison.
 - `schedulerQueueEnqueues` / `schedulerQueueDequeues`: ready/resweep selector
   queue work where a queue exists. The one-selector linear fast path correctly
   reports zero.
+- `schedulerWorkAllocations`: scheduler-owned `Map`/`Set`/array containers
+  created inside the measured window. Warm graph commits should reuse their
+  frame-local workspace and report zero.
+- `livenessWorkAllocations`: liveness/mount-owned work containers created inside
+  the window. Warm multi-container cyclic/reconciliation walks reuse their
+  workspace; measured-faster one-array count and mount walks remain local and
+  still report their short-lived containers.
+- `schedulerCycleFallbacks`: stalled cyclic regions settled by the isolated
+  insertion-order fallback. Ordinary acyclic graphs must report zero.
+- `livenessEdgeVisits` / `mountEdgeVisits`: dependency edges examined by
+  liveness reconciliation and mount/unmount closure walks, respectively.
+- `mountTransitions` / `unmountTransitions`: successful lifecycle state
+  transitions. These distinguish allocation savings from skipped lifecycle work.
 - `commitPlanRuns`: admitted `runCommitPlan` executions. Every single-store
-  transaction commit shape (ordinary, hooked, cleanup) must execute exactly
-  one plan; scalar direct writes correctly report zero.
+  transaction commit shape (ordinary, hooked, cleanup) must execute exactly one
+  plan; scalar direct writes correctly report zero.
 
 The collector is an internal optional `StoreData` field. It is attached only for
 one synchronous test/benchmark window, inherited by scopes created during that
@@ -55,41 +68,71 @@ instrumentation is disabled outside tests/benchmarks and is not public API.
 
 ## Deterministic baseline
 
-Baseline captured on 2026-07-20 from `origin/main` plus measurement-only
-changes. Columns are evaluations, settlements, duplicate settlements, unique
-stores, store passes, duplicate store passes, edge visits, enqueues, and
-dequeues.
+Baseline recaptured on 2026-07-29 from `b85d858d` (`origin/main`) before the
+worklist rewrite, then updated to the optimized gates. Columns are evaluations,
+settlements, duplicate settlements, unique stores, store passes, duplicate store
+passes, edge visits, enqueues, and dequeues.
 
-| Scenario                             | Eval | Settle | Dup sel | Stores | Passes | Dup store | Edges | Enq | Deq |
-| ------------------------------------ | ---: | -----: | ------: | -----: | -----: | --------: | ----: | --: | --: |
-| Atom-only write                      |    0 |      0 |       0 |      0 |      0 |         0 |     0 |   0 |   0 |
-| Live fan-out, width 8                |    8 |      8 |       0 |      1 |      1 |         0 |    16 |   8 |   8 |
-| Asymmetric DAG, depth 6              |    8 |      8 |       1 |      1 |      1 |         0 |    43 |   8 |   8 |
-| Dynamic churn, width 6               |    6 |      6 |       0 |      1 |      1 |         0 |    18 |   6 |   6 |
-| Single-store update + delete         |    2 |      2 |       1 |      1 |      2 |         1 |     3 |   0 |   0 |
-| Cross-scope transaction, depth 3     |    1 |      1 |       0 |      1 |      1 |         0 |     3 |   0 |   0 |
-| Cross-scope update + delete + unset  |    1 |      1 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
-| Cross-scope txn, plan/peer overlap   |    1 |      1 |       0 |      1 |      1 |         0 |     2 |   0 |   0 |
-| Global fan-out, width 6              |    6 |      6 |       0 |      6 |      6 |         0 |     6 |   0 |   0 |
+| Scenario                            | Eval | Settle | Dup sel | Stores | Passes | Dup store | Edges | Enq | Deq |
+| ----------------------------------- | ---: | -----: | ------: | -----: | -----: | --------: | ----: | --: | --: |
+| Atom-only write                     |    0 |      0 |       0 |      0 |      0 |         0 |     0 |   0 |   0 |
+| Live fan-out, width 8               |    8 |      8 |       0 |      1 |      1 |         0 |     8 |   0 |   0 |
+| Unchanged multi-seed closure, 200   |    2 |      2 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
+| Asymmetric DAG, depth 6             |    7 |      7 |       0 |      1 |      1 |         0 |    40 |   8 |   8 |
+| Dynamic churn, width 6              |    6 |      6 |       0 |      1 |      1 |         0 |     6 |   0 |   0 |
+| Single-store update + delete        |    2 |      2 |       1 |      1 |      2 |         1 |     3 |   0 |   0 |
+| Cross-scope transaction, depth 3    |    1 |      1 |       0 |      1 |      1 |         0 |     3 |   0 |   0 |
+| Cross-scope update + delete + unset |    1 |      1 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
+| Cross-scope txn, plan/peer overlap  |    1 |      1 |       0 |      1 |      1 |         0 |     2 |   0 |   0 |
+| Global fan-out, width 6             |    6 |      6 |       0 |      6 |      6 |         0 |     6 |   0 |   0 |
+
+The allocation instrumentation captured these before/after deterministic
+results. Every "after" row is measured after one warm commit so container
+creation, rather than logical queue work, is isolated.
+
+| Scenario                | Scheduler allocs before | Scheduler allocs after | Liveness allocs before | Liveness allocs after |
+| ----------------------- | ----------------------: | ---------------------: | ---------------------: | --------------------: |
+| Live fan-out, width 8   |                       5 |                      0 |                      0 |                     0 |
+| Asymmetric DAG, depth 6 |                      12 |                      0 |                      0 |                     0 |
+| Dynamic churn, width 6  |                       5 |                      0 |                      2 |                     2 |
+| Dynamic mount churn     |                       2 |                      0 |                      6 |                     6 |
+
+The unchanged multi-seed gate has two dirty selectors over a 200-node downstream
+chain whose values remain equal. It requires the write to stop after four edge
+visits rather than discovering all 200 descendants. Leaf fan-out and churn stay
+off the graph workspace entirely. The re-entrant mount-write gate warms nested
+scheduler frames, then requires a write during `onMount` to produce final inner
+and outer values with zero new scheduler containers.
+
+The cyclic-closure gate requires the insertion-order fallback to iterate to the
+stable `9 / 9` fixpoint. Value-divergent cycles retain a bounded settlement
+budget before cycle-closing signals are suppressed; this prevents the
+synchronous scheduler from running forever without truncating practical
+convergent cycles.
+
+Pooling the single-array live-count walks, and later the mount/unmount closure
+walks, reduced deterministic allocation counts but regressed at least one
+runtime. Those paths deliberately keep their measured-faster local containers.
+Only the multi-container cyclic DFS and exact reconciliation paths retain pooled
+liveness storage.
 
 Selector/store counts that express current commit behavior are exact. Edge and
-queue gates allow narrow structural headroom: 0–25% for linear shapes and
-approximately ±16% for the asymmetric DAG. Queue enqueues must equal dequeues.
-These are engine-independent algorithm counts, not JavaScript object-layout or
-nanosecond assertions. The update-plus-delete case deliberately reaches the same
-selector twice through the single-store cleanup settlement's per-kind passes and
-proves both duplicate detectors are live. The cross-scope rows record the
-proven-safe deduplication this table previously anticipated: the tree-level
-CommitPlan (`settleTransactionTreeCommit`) visits each affected store once with
-the union of its own and inherited triggers, so the depth-3 spanning selector
-dropped from three evaluations (one per reaching ancestor pass) to one, with
-zero duplicate settlements; the mixed-kind row proves the union spans update,
-delete, and unset triggers; and the plan/peer-overlap row proves a global peer
-that is itself a plan store folds into that single settlement instead of also
-running a separate peer pass. Cross-scope transaction commits (with or without
-global peers) additionally gate on exactly one `commitPlanRuns`. Lowering
-baselines further requires the same proven-safe standard; increasing them
-requires review.
+queue gates allow narrow structural headroom: 0–25% for linear shapes and 37–42
+visits for the asymmetric DAG. Queue enqueues must equal dequeues. These are
+engine-independent algorithm counts, not JavaScript object-layout or nanosecond
+assertions. The update-plus-delete case deliberately reaches the same selector
+twice through the single-store cleanup settlement's per-kind passes and proves
+both duplicate detectors are live. The cross-scope rows record the proven-safe
+deduplication this table previously anticipated: the tree-level CommitPlan
+(`settleTransactionTreeCommit`) visits each affected store once with the union
+of its own and inherited triggers, so the depth-3 spanning selector dropped from
+three evaluations (one per reaching ancestor pass) to one, with zero duplicate
+settlements; the mixed-kind row proves the union spans update, delete, and unset
+triggers; and the plan/peer-overlap row proves a global peer that is itself a
+plan store folds into that single settlement instead of also running a separate
+peer pass. Cross-scope transaction commits (with or without global peers)
+additionally gate on exactly one `commitPlanRuns`. Lowering baselines further
+requires the same proven-safe standard; increasing them requires review.
 
 ## Retained-memory methodology and baseline
 
@@ -109,54 +152,64 @@ also asserts every evaluation signal is live before disposal and aborted after
 disposal. These are retained-heap leak/regression gates, not total-allocation or
 RSS measurements.
 
-Observed medians below are bytes per retained unit from repeated local runs on
-Bun 1.3.14 and Node 24.16.0; benchmark CI pins the same versions. Ceilings are
-runtime-specific because the heaps differ, but are normalized per scenario unit
-and leave roughly 25–30% above the observed median. Released heap has a fixed
-ceiling: 512 KiB on Bun and 256 KiB on Node.
+Observed medians below are bytes per retained unit from an interleaved local
+base/head comparison on Bun 1.3.14 and Node 24.16.0; benchmark CI pins the same
+versions. Ceilings are runtime-specific because the heaps differ, but are
+normalized per scenario unit and leave roughly 25–30% above the observed median.
+Released heap has a fixed ceiling: 512 KiB on Bun and 256 KiB on Node.
 
 Calibration note (single-store transactions, Bun): JSC's
 `heapSize + extraMemorySize` is sensitive to the byte layout of the commit
 engine module — adding a never-called function to a pristine `commitEngine.ts`
-alone moved this scenario 157 → 229 B/unit while the Node/V8 lane stayed at
-85 B/unit. The Bun observed/ceiling values therefore absorb code-layout shifts
-(360 still detects a real per-transaction pin such as a retained MutationDraft,
-~+220 B/unit here); the Node lane is the layout-insensitive cross-check.
+alone moved this scenario 157 → 229 B/unit while the Node/V8 lane stayed at 85
+B/unit. The Bun observed/ceiling values therefore absorb code-layout shifts (360
+still detects a real per-transaction pin such as a retained MutationDraft, ~+220
+B/unit here); the Node lane is the layout-insensitive cross-check.
 
-| Scenario                            | Units | Bun B/unit | Bun ceiling | Node B/unit | Node ceiling |
-| ----------------------------------- | ----: | ---------: | ----------: | ----------: | -----------: |
-| Atom-only stores                    | 4,000 |        111 |         160 |          84 |          120 |
-| Live selector graphs                | 1,500 |      1,873 |       2,400 |       1,169 |        1,500 |
-| Dynamic dependency churn            | 1,000 |      1,581 |       2,100 |       1,179 |        1,400 |
-| Scope creation and disposal         | 1,500 |      2,474 |       3,200 |       2,668 |        3,400 |
-| Single-store transactions           | 2,500 |        230 |         360 |          85 |          120 |
-| Deep cross-scope transactions       |    64 |     22,969 |      30,000 |      10,601 |       14,000 |
-| Global fan-out                      | 1,000 |      2,870 |       3,700 |       2,629 |        3,400 |
-| Store disposal + async cancellation |   500 |      5,834 |       7,500 |       5,889 |        7,500 |
+| Scenario                            | Units | Bun base → head B/unit | Bun ceiling | Node base → head B/unit | Node ceiling |
+| ----------------------------------- | ----: | ---------------------: | ----------: | ----------------------: | -----------: |
+| Atom-only stores                    | 4,000 |              111 → 111 |         160 |                 84 → 84 |          120 |
+| Live selector graphs                | 1,500 |          1,866 → 1,858 |       2,400 |           1,169 → 1,169 |        1,500 |
+| Dynamic dependency churn            | 1,000 |          1,608 → 1,610 |       2,100 |           1,174 → 1,157 |        1,400 |
+| Scope creation and disposal         | 1,500 |          2,459 → 2,459 |       3,200 |           2,668 → 2,668 |        3,400 |
+| Single-store transactions           | 2,500 |              232 → 232 |         360 |                 85 → 85 |          120 |
+| Deep cross-scope transactions       |    64 |        23,063 → 23,117 |      30,000 |         10,603 → 10,603 |       14,000 |
+| Global fan-out                      | 1,000 |          2,920 → 2,921 |       3,700 |           2,763 → 2,763 |        3,400 |
+| Store disposal + async cancellation |   500 |          5,887 → 5,890 |       7,500 |           5,885 → 5,886 |        7,500 |
+
+The largest released-heap medians after disposal were 247,344 B on Bun and
+68,752 B on Node, below their 512 KiB and 256 KiB gates.
 
 ## Timing confirmation baseline
 
-Single-run diagnostic p50s from the same machine are below. CI's existing
-Bencher workflow remains authoritative: it runs base and head on the same runner
-three times and compares the cross-run median, avoiding fixed nanosecond gates.
+Three interleaved base/head pairs were run locally against `b85d858d` after the
+final fast-path and liveness decisions. The table reports only directly affected
+shapes, avoiding performance claims from unrelated machine drift. Atom-only uses
+five additional interleaved pairs because nanosecond rounding dominates three
+samples.
 
-| Scenario                            |  Bun p50 | Node p50 |
-| ----------------------------------- | -------: | -------: |
-| Atom-only set                       |    78 ns |   332 ns |
-| Live graph fan-out 100              |  57.3 µs |  87.3 µs |
-| Dependency churn 100                | 120.2 µs | 142.0 µs |
-| Create + dispose scope              |   542 ns |   1.3 µs |
-| Single-store transaction, 20 writes |   6.7 µs |   8.5 µs |
-| Cross-scope transaction, depth 8    |  20.5 µs |  19.0 µs |
-| Global fan-out 100                  |  26.6 µs |  36.9 µs |
-| Dispose pending selector            |   3.5 µs |   6.7 µs |
+| Scenario                                       |  Bun base → head | Node base → head |
+| ---------------------------------------------- | ---------------: | ---------------: |
+| Atom-only set                                  |       47 → 48 ns |     125 → 127 ns |
+| Live graph fan-out 100                         |   28.5 → 23.9 µs |   33.0 → 28.1 µs |
+| Unchanged multi-seed closure 200               |     578 → 503 ns |     737 → 677 ns |
+| Dependency churn 100                           |   49.2 → 43.8 µs |   72.5 → 64.0 µs |
+| Subscribe/unsubscribe 100 shared pairs         | 176.5 → 176.7 µs | 331.0 → 335.1 µs |
+| Subscribe/unsubscribe + fan-in                 | 177.4 → 181.1 µs | 337.8 → 338.0 µs |
+| Subscribe/unsubscribe + fan-in + mounted spine | 481.8 → 484.1 µs | 638.6 → 661.4 µs |
+
+Selector scheduling targets improve on both engines; atom-only remains flat and
+all three teardown medians remain within the 5% non-regression limit. CI's
+existing Bencher workflow remains authoritative: it runs base and head on the
+same runner three times and compares the cross-run median.
 
 ## Limitations
 
 - Instrumentation is disabled, rather than compiled away, on normal stores; the
   Node/Bun end-to-end lanes confirm the inactive checks in the real hot paths.
-- Edge counts intentionally cover propagation scheduling, not every selector
-  `get`, subscription callback, mount/liveness walk, or scope-tree traversal.
+- Scheduler edge counts intentionally exclude selector `get`, subscription
+  callback, mount/liveness walk, and scope-tree traversal; liveness and mount
+  edges have their own counters.
 - Microtask scheduling is counted only where Valdres owns a selector work queue.
   Host runtime queue internals and async timing are not asserted.
 - Explicit GC reduces noise but cannot make heap layout portable.

--- a/packages/valdres/test/performance/architecture.timing.ts
+++ b/packages/valdres/test/performance/architecture.timing.ts
@@ -36,6 +36,33 @@ describe("architecture timing confirmations", () => {
         })
     })
 
+    test("unchanged multi-seed closure", async () => {
+        const target = store()
+        const source = atom(0)
+        const left = selector(get => {
+            get(source)
+            return 0
+        })
+        const right = selector(get => {
+            get(source)
+            return 0
+        })
+        let sink = left
+        for (let index = 0; index < 200; index++) {
+            const dependency = sink
+            sink = selector(get => get(dependency) + 1)
+        }
+        target.sub(sink, noop)
+        target.sub(right, noop)
+        let next = 0
+        await measureOne(
+            "architecture: unchanged multi-seed closure 200",
+            () => {
+                target.set(source, ++next)
+            },
+        )
+    })
+
     test("dynamic dependency churn", async () => {
         const target = store()
         const toggle = atom(true)


### PR DESCRIPTION
## Summary

- add bounded, frame-local scheduler and cyclic-liveness scratch pools behind the `GraphRuntime` facade
- settle independent seeds before lazily discovering changed downstream closures, then evaluate acyclic work once in FIFO Kahn order
- preserve dynamic dependency replacement, re-entrant writes, convergent cycle fixpoints, lifecycle ordering, cleanup behavior, and the atom-only fast path
- keep measured-faster single-array liveness and mount walks local while pooling only multi-container reconciliation work
- add deterministic architecture counters, no-op/cycle/re-entrancy regression gates, retained-memory coverage, timing scenarios, documentation, and a patch changeset

## Review fixes included

- no-op multi-seed writes remain O(seed count): 4 edge visits, 0 queue work, and 0 workspace allocations over a 200-node downstream closure
- cyclic fallback iterates to the preserved `9 / 9` fixpoint
- self-dependencies are excluded from active-dependency blocking
- resweeps are deduplicated, graph mutation is propagated, and per-edge instrumentation is production-guarded
- reusable containers above 1,024 entries are replaced, and store disposal explicitly drops pool entries

## Deterministic results

| Scenario | Before | After |
| --- | ---: | ---: |
| Live fan-out 8 | 16 edges, 8 enqueues, 5 scheduler allocations | 8 edges, 0 enqueues, 0 allocations |
| Asymmetric DAG | 8 evaluations, 1 duplicate, 43 edges | 7 evaluations, 0 duplicates, 40 edges |
| Dynamic churn 6 | 18 edges, 6 enqueues, 5 scheduler allocations | 6 edges, 0 enqueues, 0 allocations |
| Atom-only write | 0 scheduler work | unchanged |

## Timing

Three interleaved base/head pairs, with five additional atom-only pairs:

| Scenario | Bun base → head | Node base → head |
| --- | ---: | ---: |
| Atom-only set | 47 → 48 ns | 125 → 127 ns |
| Live graph fan-out 100 | 28.5 → 23.9 µs | 33.0 → 28.1 µs |
| Unchanged closure 200 | 578 → 503 ns | 737 → 677 ns |
| Dependency churn 100 | 49.2 → 43.8 µs | 72.5 → 64.0 µs |

All teardown medians remain within the 5% non-regression threshold. Retained-memory suites pass on Bun and Node with no disposal regression.

## Validation

- full monorepo build and test suite
- Valdres semantic suite: 1,117 passed, 1 todo, 0 failed
- emitted declarations and type-level checks
- graph-boundary/import-cycle and graph-table ownership checks
- dynamic-dependency, cyclic-liveness, invariant, re-entrancy, and seeded fuzz suites
- Bun and Node retained-memory suites: 8/8 each
- complete Bun and Node benchmark suites: 50 legacy + 9 architecture each

## Residual risks

- deeper than four nested scheduler frames fall back to unpooled temporary storage
- previously non-terminating value-divergent cycles are bounded; supported convergent cycles preserve fixpoint behavior
- live stores retain bounded cleared scratch capacity until disposal or collection

Indexing and transaction-settlement restructuring remain out of scope.
