### PR TITLE
refactor(valdres): encode CommitPlan legality and quieten no-op commits

### DIFF
--- a/.changeset/commit-plan-legality.md
+++ b/.changeset/commit-plan-legality.md
@@ -1,0 +1,23 @@
+---
+"valdres": patch
+---
+
+A direct write to a global atom now builds six plan objects per commit instead
+of nine: the ordered global sets and the deferred onSet queue share one
+`[atom, value, origin]` descriptor and one queue rather than allocating a
+duplicate pair, since they describe the same write.
+
+`store.onCommitEnd` no longer fires for a commit that produced nothing. A
+transaction whose every write is value-equal, and a `reset` of an atom already
+holding its default, are now as silent as the no-op `set` and no-op `unset`
+already were. Real work performed inside such a commit — a subscriber or `onSet`
+hook writing during delivery — still coalesces into exactly one notification.
+
+Internally, the illegal `CommitPlan` states are now unrepresentable rather than
+merely unused: `beginCommit`/`endCommit` are one paired boundary capability,
+global fan-out exists only as part of a forest settlement, report preparation
+requires the report it prepares, and delete/unset work groups are non-empty or
+absent — which also removes an asymmetry where an empty `deleted` group counted
+as settlement work while an empty `unsetAtoms` group did not. Settlement work is
+evaluated once per commit instead of three times. The published bundle is
+unaffected by the accompanying engine self-checks: they are compiled out.

--- a/packages/valdres/build.ts
+++ b/packages/valdres/build.ts
@@ -15,6 +15,10 @@ export const buildOptions = {
     packages: "external" as const,
     define: {
         "process.env.VALDRES_VERSION": JSON.stringify(version),
+        // Compile out the engine self-checks (see src/lib/ENGINE_ASSERTIONS.ts).
+        // They assert invariants only valdres's own code can violate, so they
+        // belong to this repo's test loop, not to a consumer's bundle.
+        "process.env.VALDRES_ENGINE_SELF_CHECKS": JSON.stringify("off"),
         // Map NODE_ENV to itself so Bun does NOT inline it at *our* build time.
         // valdres is built once under NODE_ENV=production; without this, Bun folds
         // `process.env.NODE_ENV === "production"` to `true` in the dist, baking

--- a/packages/valdres/src/lib/architectureInstrumentation.ts
+++ b/packages/valdres/src/lib/architectureInstrumentation.ts
@@ -32,6 +32,15 @@ export type ArchitectureCounters = {
     unmountTransitions: number
     /** Admitted `runCommitPlan` executions — one per engine-sequenced commit. */
     commitPlanRuns: number
+    /** Plan-graph containers — settlements, forest entries and entry lists,
+     *  global effects, descriptor queues — built through `lib/commitPlans.ts`
+     *  in the window. A module-static plan graph is allocated once at module
+     *  load and passes `undefined`, so it never counts; what remains is the
+     *  per-commit allocation cost of the shape under measurement. The plan
+     *  object itself is an inline literal at each call site and is outside this
+     *  count. Like `assertPlanLegal`, this is an engine self-check and is
+     *  compiled out of the published bundle. */
+    commitPlanAllocations: number
 }
 
 export type ArchitectureInstrumentation = {
@@ -60,6 +69,7 @@ export const createArchitectureInstrumentation =
             mountTransitions: 0,
             unmountTransitions: 0,
             commitPlanRuns: 0,
+            commitPlanAllocations: 0,
         },
         settledSelectors: new WeakMap(),
         settledStores: new WeakSet(),
@@ -73,6 +83,17 @@ export const recordSelectorEvaluation = (data: StoreData): void => {
 export const recordCommitPlanRun = (data: StoreData): void => {
     const instrumentation = data.architectureInstrumentation
     if (instrumentation) instrumentation.counters.commitPlanRuns++
+}
+
+/** Count plan-graph containers built for one commit. `data` is undefined for a
+ *  module-static plan graph: it is allocated once at module load, so it is
+ *  deliberately outside every measurement window. */
+export const recordCommitPlanAllocations = (
+    data: StoreData | undefined,
+    count: number,
+): void => {
+    const instrumentation = data?.architectureInstrumentation
+    if (instrumentation) instrumentation.counters.commitPlanAllocations += count
 }
 
 export const recordSelectorSettlement = (

--- a/packages/valdres/src/lib/architecturePerformance.test.ts
+++ b/packages/valdres/src/lib/architecturePerformance.test.ts
@@ -89,6 +89,7 @@ describe("deterministic architecture performance gates", () => {
             unmountTransitions: 0,
             // A scalar direct write settles without an engine plan.
             commitPlanRuns: 0,
+            commitPlanAllocations: 0,
         })
     })
 
@@ -378,6 +379,78 @@ describe("deterministic architecture performance gates", () => {
             })
         })
         expect(cleanup.commitPlanRuns).toBe(1)
+    })
+
+    // The plan graph of a hot commit shape is module-static, so the only thing
+    // a commit may allocate is the data describing THAT write. These are exact
+    // gates, not budgets: a regression here means a shape started building its
+    // plan per call again.
+    test("hot commit shapes build no per-commit plan graph", () => {
+        const target = store()
+        const value = atom(0)
+        const hooked = atom(0, { onSet: noop })
+        target.sub(value, noop)
+        target.sub(hooked, noop)
+
+        // No plan at all: the scalar write settles directly.
+        const scalar = measureArchitecture(target, () => target.set(value, 1))
+        expect(scalar.commitPlanAllocations).toBe(0)
+
+        // A hooked non-global write is the allocation-free direct path.
+        const withHook = measureArchitecture(target, () =>
+            target.set(hooked, 1),
+        )
+        expect(withHook.commitPlanAllocations).toBe(0)
+
+        // The hook-free transaction singleton runs a plan without building one.
+        const bulk = measureArchitecture(target, () =>
+            target.txn(txn => txn.set(value, 2)),
+        )
+        expect(bulk.commitPlanRuns).toBe(1)
+        expect(bulk.commitPlanAllocations).toBe(0)
+    })
+
+    test("a direct global write allocates only the objects it carries", () => {
+        const origin = store()
+        const peer = store()
+        const shared = atom(0, { global: true })
+        origin.sub(shared, noop)
+        peer.sub(shared, noop)
+        origin.set(shared, 1)
+
+        const counts = measureArchitecture([origin, peer], () =>
+            origin.set(shared, 2),
+        )
+        reportCounts("Direct global write", counts)
+
+        expect(counts.commitPlanRuns).toBe(1)
+        // ONE [atom, value, origin] descriptor and ONE queue — the ordered
+        // global sets and the deferred onSet queue describe the same write, so
+        // they share both instead of allocating a duplicate pair — plus the
+        // forest entry, its list, the global effects, and the settlement.
+        expect(counts.commitPlanAllocations).toBe(6)
+        expect(peer.get(shared)).toBe(2)
+    })
+
+    test("a global write from inside a global fan-out settles independently", () => {
+        const origin = store()
+        const peer = store()
+        const outer = atom(0, { global: true })
+        const inner = atom(0, { global: true })
+        origin.sub(outer, () => origin.set(inner, origin.get(outer) * 10))
+        peer.sub(inner, noop)
+        origin.set(outer, 1)
+
+        const counts = measureArchitecture([origin, peer], () =>
+            origin.set(outer, 2),
+        )
+
+        // Outer commit + the nested one its subscriber opened.
+        expect(counts.commitPlanRuns).toBe(2)
+        // Two independent commits, six objects each — nothing is shared or
+        // borrowed across them.
+        expect(counts.commitPlanAllocations).toBe(12)
+        expect(peer.get(inner)).toBe(20)
     })
 
     // A mixed single-store transaction now settles through the same commit

--- a/packages/valdres/src/lib/cacheController.ts
+++ b/packages/valdres/src/lib/cacheController.ts
@@ -1,4 +1,5 @@
 import type { Atom, CacheMeta } from "../types/Atom"
+import type { CommitForestEntry } from "../types/CommitForestSettleFn"
 import type { InternalGlobalAtom } from "../types/InternalGlobalAtom"
 import type { State } from "../types/State"
 import type { StoreData } from "../types/StoreData"
@@ -9,6 +10,13 @@ import { cacheState } from "./cacheState"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors, recordCommitError } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
+import {
+    forestEntry,
+    forestSettlement,
+    NO_ON_SETS,
+    NO_SETTLEMENT,
+    updateSettlement,
+} from "./commitPlans"
 import { equal } from "./equal"
 import { hasAtomCommitObservers } from "./hasAtomCommitObservers"
 import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
@@ -34,19 +42,14 @@ const commitLocalWrite = (
     admit: () => boolean,
 ): boolean => {
     const settlement = hasAtomCommitObservers(state, data)
-        ? {
-              kind: "update" as const,
-              atoms: [state],
-              settle: settleCommit,
-              flags: SETTLE_DEFAULT,
-          }
-        : { kind: "none" as const }
+        ? updateSettlement(data, [state], settleCommit, SETTLE_DEFAULT)
+        : NO_SETTLEMENT
     return runCommitPlan({
         data,
         settlement,
         admit,
         apply: () => setValueInData(state, value, data),
-        onSets: [],
+        onSets: NO_ON_SETS,
         errors: createCommitErrors(),
         report: "revalidate",
     })
@@ -60,10 +63,10 @@ const commitFreshness = (
 ): boolean =>
     runCommitPlan({
         data,
-        settlement: { kind: "none" },
+        settlement: NO_SETTLEMENT,
         admit,
         apply: () => cacheState.recordWrite(state, data, refreshedAt),
-        onSets: [],
+        onSets: NO_ON_SETS,
         errors: createCommitErrors(),
         report: undefined,
     })
@@ -191,22 +194,16 @@ const retain = (
         refreshedAt?: number,
     ): boolean => {
         const snapshot = [...globalState!.stores]
-        const entries: {
-            data: StoreData
-            updatedAtoms: Atom<any>[]
-            deleted: undefined
-            unsetAtoms: undefined
-            children: undefined
-        }[] = []
+        const entries: CommitForestEntry[] = []
         const errors = createCommitErrors()
         return runCommitPlan({
             data,
-            settlement: {
-                kind: "forest",
+            settlement: forestSettlement(
+                data,
                 entries,
-                globalUpdates: undefined,
-                settle: settleCommitForest,
-            },
+                undefined,
+                settleCommitForest,
+            ),
             admit: () => current(requestGeneration),
             apply: () => {
                 for (const store of snapshot) {
@@ -234,20 +231,22 @@ const retain = (
                         }
                         setValueInData(target, value, store)
                         if (hasAtomCommitObservers(target, store)) {
-                            entries.push({
-                                data: store,
-                                updatedAtoms: [target],
-                                deleted: undefined,
-                                unsetAtoms: undefined,
-                                children: undefined,
-                            })
+                            entries.push(
+                                forestEntry(
+                                    store,
+                                    [target],
+                                    undefined,
+                                    undefined,
+                                    undefined,
+                                ),
+                            )
                         }
                     } catch (error) {
                         recordCommitError(errors, error)
                     }
                 }
             },
-            onSets: [],
+            onSets: NO_ON_SETS,
             errors,
             report: "revalidate",
         })

--- a/packages/valdres/src/lib/commitEngine.test.ts
+++ b/packages/valdres/src/lib/commitEngine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test"
 import { atom } from "../atom"
+import type { Atom } from "../types/Atom"
 import { atomFamily } from "../atomFamily"
 import { store } from "../store"
 import type { CommitForestSettleFn } from "../types/CommitForestSettleFn"
@@ -167,6 +168,102 @@ describe("commitEngine", () => {
             expect(commitEnds).toHaveBeenCalledTimes(0)
         })
 
+        test("an all-empty plan opens no boundary of its own", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const events: string[] = []
+            store1.onCommitEnd(() => events.push("commitEnd"))
+
+            runCommitPlan({
+                data,
+                settlement: {
+                    kind: "update",
+                    atoms: [],
+                    settle: (() => events.push("settle")) as SettleFn,
+                    flags: SETTLE_DEFAULT,
+                },
+                onSets: [],
+                errors: createCommitErrors(),
+                report: undefined,
+                boundary: {
+                    begin: root => {
+                        events.push("begin")
+                        return root.tree
+                    },
+                    end: () => events.push("end"),
+                },
+            })
+
+            // Nothing to apply, fan out, run, settle, or flush is not a commit,
+            // so onCommitEnd must not fire for it.
+            expect(events).toEqual([])
+        })
+
+        test("a plan with deferred work opens its boundary even when nothing settles", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const events: string[] = []
+            const hooked = atom(0, { onSet: () => events.push("hook") })
+
+            runCommitPlan({
+                data,
+                settlement: {
+                    kind: "update",
+                    atoms: [],
+                    settle: (() => events.push("settle")) as SettleFn,
+                    flags: SETTLE_DEFAULT,
+                },
+                onSets: [[hooked, 1, data]],
+                errors: createCommitErrors(),
+                report: undefined,
+                flushReport: () => events.push("flush"),
+                boundary: {
+                    begin: root => {
+                        events.push("begin")
+                        return root.tree
+                    },
+                    end: () => events.push("end"),
+                },
+            })
+
+            expect(events).toEqual(["begin", "hook", "flush", "end"])
+        })
+
+        test("the settlement gate is evaluated once, after apply and fan-out", () => {
+            const store1 = store()
+            const data = getStoreData(store1)
+            const a = atom(0)
+            const order: string[] = []
+            const settlement = {
+                kind: "update" as const,
+                atoms: [] as Atom<any>[],
+                // A settle that empties its own trigger list must not retract
+                // the cleanup phase that the same commit already qualified for.
+                settle: (() => {
+                    order.push("settle")
+                    settlement.atoms = []
+                }) as SettleFn,
+                flags: SETTLE_DEFAULT,
+            }
+
+            runCommitPlan({
+                data,
+                settlement,
+                // Work appears during apply — the gate cannot be answered before
+                // the write phase, only once after it.
+                apply: () => {
+                    order.push("apply")
+                    settlement.atoms = [a]
+                },
+                onSets: [],
+                errors: createCommitErrors(),
+                report: undefined,
+                afterSettle: () => order.push("cleanup"),
+            })
+
+            expect(order).toEqual(["apply", "settle", "cleanup"])
+        })
+
         test("failed admission runs no phase and opens no boundary", () => {
             const store1 = store()
             const data = getStoreData(store1)
@@ -182,11 +279,13 @@ describe("commitEngine", () => {
                 errors: createCommitErrors(),
                 report: undefined,
                 afterSettle: () => events.push("after"),
-                beginCommit: root => {
-                    events.push("begin")
-                    return root
+                boundary: {
+                    begin: root => {
+                        events.push("begin")
+                        return root.tree
+                    },
+                    end: () => events.push("end"),
                 },
-                endCommit: () => events.push("end"),
             })
 
             expect(admitted).toBe(false)
@@ -233,12 +332,14 @@ describe("commitEngine", () => {
                 beforeSettle: () => order.push("report"),
                 afterSettle: () => order.push("cleanup"),
                 flushReport: () => order.push("flush"),
-                beginCommit: root => {
-                    order.push("begin")
-                    return root
+                boundary: {
+                    begin: root => {
+                        order.push("begin")
+                        return root.tree
+                    },
+                    end: (_tree, swallowErrors) =>
+                        order.push(`end:${swallowErrors}`),
                 },
-                endCommit: (_root, swallowErrors) =>
-                    order.push(`end:${swallowErrors}`),
             })
 
             expect(order).toEqual([
@@ -275,13 +376,15 @@ describe("commitEngine", () => {
                     onSets: [[a, 1, data]],
                     errors: createCommitErrors(),
                     report: undefined,
-                    beginCommit: root => {
-                        order.push("begin")
-                        return root
-                    },
-                    endCommit: () => {
-                        order.push("end")
-                        throw new Error("end")
+                    boundary: {
+                        begin: root => {
+                            order.push("begin")
+                            return root.tree
+                        },
+                        end: () => {
+                            order.push("end")
+                            throw new Error("end")
+                        },
                     },
                     afterCommit: () => {
                         order.push("finalize")
@@ -323,9 +426,11 @@ describe("commitEngine", () => {
                     report: "unset",
                     afterSettle: cleanup,
                     flushReport: flush,
-                    beginCommit: root => root,
-                    endCommit: (_root, swallowErrors) =>
-                        endStates.push(swallowErrors),
+                    boundary: {
+                        begin: root => root.tree,
+                        end: (_tree, swallowErrors) =>
+                            endStates.push(swallowErrors),
+                    },
                     continueAfterError: false,
                 }),
             ).toThrow(settleError)
@@ -396,6 +501,7 @@ describe("commitEngine", () => {
                 settlement: {
                     kind: "forest",
                     entries,
+                    global: undefined,
                     globalUpdates: undefined,
                     settle,
                 },
@@ -439,6 +545,7 @@ describe("commitEngine", () => {
                                 children: undefined,
                             },
                         ],
+                        global: undefined,
                         globalUpdates: undefined,
                         settle,
                     },
@@ -470,6 +577,7 @@ describe("commitEngine", () => {
                             children: undefined,
                         },
                     ],
+                    global: undefined,
                     globalUpdates: undefined,
                     settle: deleteSettle,
                 },
@@ -493,6 +601,7 @@ describe("commitEngine", () => {
                             children: undefined,
                         },
                     ],
+                    global: undefined,
                     globalUpdates: undefined,
                     settle: unsetSettle,
                 },

--- a/packages/valdres/src/lib/commitEngine.ts
+++ b/packages/valdres/src/lib/commitEngine.ts
@@ -1,4 +1,5 @@
 import type { Atom } from "../types/Atom"
+import type { CommitForestEntry } from "../types/CommitForestSettleFn"
 import type { CommitPlan } from "../types/CommitPlan"
 import type { SettleFn } from "../types/SettleFn"
 import type { StoreData } from "../types/StoreData"
@@ -6,7 +7,9 @@ import type { StoreTreeRuntime } from "./storeTreeRuntime"
 import { recordCommitPlanRun } from "./architectureInstrumentation"
 import { recordCommitError, throwCommitError } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
+import { assertPlanLegal } from "./commitPlans"
 import { getStoreRuntime } from "./getStoreRuntime"
+import { IS_PROD } from "./IS_PROD"
 import { runOnSets } from "./runOnSets"
 
 /**
@@ -84,14 +87,14 @@ export const runHookedDirectWrite = <Value>(
 
 // Module-level phase gates: runCommitPlan is on the per-commit hot path of
 // every migrated write shape, so its guards must not allocate per run.
-const treeHasWork = (
-    entries: Extract<CommitPlan["settlement"], { kind: "forest" }>["entries"],
-) => {
+const treeHasWork = (entries: CommitForestEntry[]) => {
     for (const entry of entries) {
+        // Every group is now non-empty-or-absent, so all three trigger kinds
+        // answer "is there work here" the same way.
         if (
             entry.updatedAtoms.length > 0 ||
             entry.deleted !== undefined ||
-            (entry.unsetAtoms !== undefined && entry.unsetAtoms.length > 0)
+            entry.unsetAtoms !== undefined
         ) {
             return true
         }
@@ -118,22 +121,72 @@ const planShouldContinue = (plan: CommitPlan) =>
  * → phase 8 cleanup/deferred flush → phase 9 (first captured error rethrown).
  *
  * The settlement's non-empty atom-list guard is contractual, not an
- * optimization: a plan whose every write was value-equal must not settle.
- * Standalone reset may still own an explicit outer boundary because its public
- * historical behavior treats the reset call itself as a commit; ordinary bulk
- * plans do not, so their no-op trace remains empty.
+ * optimization: a plan whose every write was value-equal must not settle. It is
+ * evaluated ONCE per commit — settlement work is final as soon as `apply` and
+ * global fan-out have run — and the same answer gates report preparation,
+ * settlement, and post-notification cleanup.
+ *
+ * A plan with nothing to apply, fan out, run, settle, or flush is not a commit
+ * at all: it opens no boundary, so it cannot fire `onCommitEnd` for a commit
+ * that never happened. Standalone reset may still own an explicit outer
+ * boundary because its public historical behavior treats the reset call itself
+ * as a commit; ordinary bulk plans do not, so their no-op trace remains empty.
  */
+// Declared at module scope (not global) so we don't conflict with a
+// consumer's @types/node or bun-types — mirroring src/lib/IS_PROD.ts.
+declare const process: { env: { VALDRES_ENGINE_SELF_CHECKS?: string } }
+
 export const runCommitPlan = (plan: CommitPlan) => {
-    const settlement = plan.settlement
-    let commitTree: StoreTreeRuntime | undefined
-    let completed = false
+    // Engine self-check. A CommitPlan is never built by user code, so an
+    // illegal one is a bug in THIS package — the audience is valdres
+    // development, not a consumer's dev build. `build.ts` therefore defines
+    // `process.env.VALDRES_ENGINE_SELF_CHECKS` as "off", which folds this to
+    // `if (!IS_PROD && false)`; a consumer's bundler drops the branch and
+    // tree-shakes `assertPlanLegal` and its whole graph, so consumers pay
+    // nothing at all. The env read is written INLINE rather than behind a
+    // shared const because only the inline form folds — bundlers do not
+    // propagate a module-level boolean into this branch. Running against
+    // `src/` leaves the flag unset, so this repo's own test suite checks every
+    // plan the engine executes. `!IS_PROD` is first so the benchmark lane,
+    // which runs `src/` under NODE_ENV=production, short-circuits before the
+    // per-commit `process.env` read and measures what the dist does.
+    if (!IS_PROD && process.env.VALDRES_ENGINE_SELF_CHECKS !== "off")
+        assertPlanLegal(plan)
 
     // Admission is deliberately the very first observable operation. A stale,
     // cancelled, or disposed async result cannot open a commit boundary or run
     // any user code merely by arriving late.
     if (plan.admit && !plan.admit()) return false
     recordCommitPlanRun(plan.data)
-    if (plan.beginCommit) commitTree = plan.beginCommit(plan.data)
+
+    const settlement = plan.settlement
+    const boundary = plan.boundary
+    // The only settlement that owns global fan-out — narrowed once so both the
+    // phase-two write-back and the settle dispatch stay monomorphic.
+    const globalForest =
+        settlement.kind === "forest" && settlement.global !== undefined
+            ? settlement
+            : undefined
+    // Settlement work is fixed once apply and global fan-out have run. A plan
+    // with neither is already final at entry, so its single evaluation happens
+    // here and also answers the boundary question below.
+    const workIsFinal = plan.apply === undefined && globalForest === undefined
+    let hasWork = workIsFinal ? settlementHasWork(settlement) : false
+
+    let commitTree: StoreTreeRuntime | undefined
+    let completed = false
+    // A plan already known to be empty at entry is not a commit at all, so it
+    // opens nothing (a deferred flush alone does not count: an empty sink
+    // notifies nobody). A plan whose emptiness only its own write phase can
+    // decide must open first — the write phase runs inside the boundary — and
+    // reports the answer to `end` below, which is what keeps a no-op reset or
+    // an all-equal transaction from announcing a commit.
+    if (
+        boundary !== undefined &&
+        (!workIsFinal || hasWork || plan.onSets.length > 0)
+    ) {
+        commitTree = boundary.begin(plan.data)
+    }
     try {
         let applied = true
         if (plan.apply) {
@@ -145,17 +198,14 @@ export const runCommitPlan = (plan: CommitPlan) => {
             }
         }
 
-        if (applied && plan.globalEffects) {
+        if (applied && globalForest) {
             try {
-                const updates = plan.globalEffects.apply(
-                    plan.globalEffects.sets,
+                const updates = globalForest.global.apply(
+                    globalForest.global.sets,
                     plan.errors,
                 )
-                plan.globalEffects.updates =
+                globalForest.globalUpdates =
                     updates.size > 0 ? updates : undefined
-                if (settlement.kind === "forest") {
-                    settlement.globalUpdates = plan.globalEffects.updates
-                }
             } catch (error) {
                 recordCommitError(plan.errors, error)
             }
@@ -163,12 +213,13 @@ export const runCommitPlan = (plan: CommitPlan) => {
 
         if (applied) runOnSets(plan.onSets, plan.errors)
 
+        if (applied && !workIsFinal) hasWork = settlementHasWork(settlement)
+
         if (
             applied &&
-            settlementHasWork(settlement) &&
+            hasWork &&
             planShouldContinue(plan) &&
-            plan.beforeSettle &&
-            plan.report
+            plan.beforeSettle !== undefined
         ) {
             try {
                 plan.beforeSettle(plan.report)
@@ -177,11 +228,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
             }
         }
 
-        if (
-            applied &&
-            settlementHasWork(settlement) &&
-            planShouldContinue(plan)
-        ) {
+        if (applied && hasWork && planShouldContinue(plan)) {
             try {
                 if (settlement.kind === "update") {
                     settlement.settle(
@@ -202,7 +249,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
                     settlement.settle(
                         settlement.entries,
                         settlement.globalUpdates,
-                        plan.globalEffects?.source,
+                        settlement.global?.source,
                         plan.report,
                         plan.errors,
                     )
@@ -220,7 +267,7 @@ export const runCommitPlan = (plan: CommitPlan) => {
 
         if (
             applied &&
-            settlementHasWork(settlement) &&
+            hasWork &&
             planShouldContinue(plan) &&
             plan.afterSettle
         ) {
@@ -240,9 +287,21 @@ export const runCommitPlan = (plan: CommitPlan) => {
         }
         completed = true
     } finally {
-        if (commitTree && plan.endCommit) {
+        if (commitTree) {
             try {
-                plan.endCommit(commitTree, plan.errors.hasError || !completed)
+                boundary!.end(
+                    commitTree,
+                    plan.errors.hasError || !completed,
+                    // What the boundary could not know when it opened: a plan
+                    // whose write phase produced no settlement work, ran no
+                    // hook, and captured no error committed nothing, so it
+                    // announces nothing. Work done by a NESTED commit inside it
+                    // is recorded on the tree and still notifies.
+                    hasWork ||
+                        plan.onSets.length > 0 ||
+                        plan.errors.hasError ||
+                        !completed,
+                )
             } catch (error) {
                 recordCommitError(plan.errors, error)
             }

--- a/packages/valdres/src/lib/commitPlan.types.test.ts
+++ b/packages/valdres/src/lib/commitPlan.types.test.ts
@@ -1,0 +1,166 @@
+import type { Atom } from "../types/Atom"
+import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+import type { CommitForestEntry } from "../types/CommitForestSettleFn"
+import type { CommitPlan, PlannedGlobalEffects } from "../types/CommitPlan"
+import type { StoreData } from "../types/StoreData"
+import type { DeferredOnSet } from "./runOnSets"
+
+/**
+ * Type-level gates for the CommitPlan legality rules. Every `@ts-expect-error`
+ * below marks a plan the engine must never be handed: the encoding is what
+ * makes it unbuildable, and `bun run typecheck:types` is what enforces that.
+ * The runtime `assertPlanLegal` backstop — for plans assembled through a cast —
+ * is covered in commitPlans.test.ts.
+ *
+ * Nothing here executes: the fixtures are `undefined as unknown as T`.
+ */
+const data = undefined as unknown as StoreData
+const someAtom = undefined as unknown as Atom<number>
+const someMember = undefined as unknown as AtomFamilyAtom<number, [string]>
+const injected = undefined as any
+const errors = undefined as unknown as CommitPlan["errors"]
+const onSets: DeferredOnSet[] = []
+const base = { data, onSets, errors }
+const global = undefined as unknown as PlannedGlobalEffects
+
+const assertReportIsRequiredForPreparation = () => {
+    const legal: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: "set",
+        beforeSettle: () => {},
+    }
+    // @ts-expect-error `beforeSettle` prepares a report the plan does not carry
+    const missingReport: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: undefined,
+        beforeSettle: () => {},
+    }
+    void legal
+    void missingReport
+}
+
+const assertGlobalEffectsRequireAForest = () => {
+    const legal: CommitPlan = {
+        ...base,
+        settlement: {
+            kind: "forest",
+            entries: [],
+            global,
+            globalUpdates: undefined,
+            settle: injected,
+        },
+        report: undefined,
+    }
+    const onScalarSettlement: CommitPlan = {
+        ...base,
+        settlement: {
+            kind: "update",
+            atoms: [someAtom],
+            settle: injected,
+            flags: injected,
+            // @ts-expect-error global fan-out belongs to the forest settlement
+            global,
+        },
+        report: undefined,
+    }
+    const onPlan: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: undefined,
+        // @ts-expect-error a plan no longer owns global effects; the forest does
+        globalEffects: global,
+    }
+    void legal
+    void onScalarSettlement
+    void onPlan
+}
+
+const assertPeerUpdatesRequireGlobalEffects = () => {
+    const orphanUpdates: CommitPlan = {
+        ...base,
+        settlement: {
+            kind: "forest",
+            entries: [],
+            global: undefined,
+            // @ts-expect-error no global effects can ever produce these
+            globalUpdates: new Map(),
+            settle: injected,
+        },
+        report: undefined,
+    }
+    void orphanUpdates
+}
+
+const assertWorkGroupsAreNonEmpty = () => {
+    const legal: CommitForestEntry = {
+        data,
+        updatedAtoms: [],
+        deleted: [someMember],
+        unsetAtoms: [someAtom],
+        children: undefined,
+    }
+    const emptyDeleted: CommitForestEntry = {
+        data,
+        updatedAtoms: [],
+        // @ts-expect-error an empty delete group must be undefined, not []
+        deleted: [],
+        unsetAtoms: undefined,
+        children: undefined,
+    }
+    const emptyUnset: CommitForestEntry = {
+        data,
+        updatedAtoms: [],
+        deleted: undefined,
+        // @ts-expect-error an empty unset group must be undefined, not []
+        unsetAtoms: [],
+        children: undefined,
+    }
+    const maybeEmpty: Atom<any>[] = []
+    const unnarrowed: CommitForestEntry = {
+        data,
+        updatedAtoms: [],
+        deleted: undefined,
+        // @ts-expect-error a possibly-empty list must go through `workGroup`
+        unsetAtoms: maybeEmpty,
+        children: undefined,
+    }
+    void legal
+    void emptyDeleted
+    void emptyUnset
+    void unnarrowed
+}
+
+const assertBoundariesArePaired = () => {
+    const openOnly: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: undefined,
+        // @ts-expect-error a boundary that only opens can never be closed
+        boundary: { begin: (store: StoreData) => store.tree },
+    }
+    const closeOnly: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: undefined,
+        // @ts-expect-error a boundary that only closes was never opened
+        boundary: { end: () => {} },
+    }
+    const unpaired: CommitPlan = {
+        ...base,
+        settlement: { kind: "none" },
+        report: undefined,
+        // @ts-expect-error begin/end are one capability, not two plan fields
+        beginCommit: (store: StoreData) => store.tree,
+    }
+    void openOnly
+    void closeOnly
+    void unpaired
+}
+
+void assertReportIsRequiredForPreparation
+void assertGlobalEffectsRequireAForest
+void assertPeerUpdatesRequireGlobalEffects
+void assertWorkGroupsAreNonEmpty
+void assertBoundariesArePaired

--- a/packages/valdres/src/lib/commitPlans.test.ts
+++ b/packages/valdres/src/lib/commitPlans.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test"
+import { atom } from "../atom"
+import { atomFamily } from "../atomFamily"
+import { store } from "../store"
+import type { CommitPlan } from "../types/CommitPlan"
+import { createCommitErrors } from "./commitErrors"
+import { SETTLE_DEFAULT } from "./commitIntents"
+import {
+    assertPlanLegal,
+    forestEntry,
+    globalEffects,
+    forestSettlement,
+    globalWriteQueue,
+    NO_ON_SETS,
+    NO_SETTLEMENT,
+    singleStoreForest,
+    updateSettlement,
+    workGroup,
+} from "./commitPlans"
+import { getStoreData } from "./getStoreData"
+import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
+
+const data = () => getStoreData(store())
+
+// Every case below is unreachable through the plan types — each one needs a
+// cast to build. That is the point: `assertPlanLegal` is the dev-time backstop
+// for a plan assembled by a cast or mutated mid-flight, and these pin that the
+// backstop actually covers each invariant the types encode.
+const illegal = (plan: unknown) =>
+    expect(() => assertPlanLegal(plan as CommitPlan)).toThrow(
+        /illegal CommitPlan/,
+    )
+
+describe("commitPlans", () => {
+    describe("constructors", () => {
+        test("a single-store forest is one entry with no cleanup groups", () => {
+            const store1 = data()
+            const a = atom(0)
+            const entries = singleStoreForest(store1, [a])
+
+            expect(entries).toHaveLength(1)
+            expect(entries[0]).toEqual({
+                data: store1,
+                updatedAtoms: [a],
+                deleted: undefined,
+                unsetAtoms: undefined,
+                children: undefined,
+            })
+        })
+
+        test("a global write shares one descriptor between sets and onSets", () => {
+            const store1 = data()
+            const shared = atom(0, { global: true })
+            const queue = globalWriteQueue(shared as any, 3, store1)
+
+            expect(queue).toEqual([[shared, 3, store1] as any])
+            // One queue, one triple — the ordered global sets and the deferred
+            // onSet queue describe the same write.
+            const settlement = forestSettlement(
+                store1,
+                singleStoreForest(store1, [shared]),
+                globalEffects(store1, queue, "set", () => new Map()),
+                settleCommitForest,
+            )
+            expect(settlement.global.sets).toBe(queue)
+        })
+
+        test("workGroup collapses an empty group to undefined", () => {
+            const a = atom(0)
+            expect(workGroup([])).toBeUndefined()
+            expect(workGroup([a])).toEqual([a])
+        })
+
+        test("the shared no-op settlement and hook queue are frozen", () => {
+            expect(Object.isFrozen(NO_SETTLEMENT)).toBe(true)
+            expect(Object.isFrozen(NO_ON_SETS)).toBe(true)
+        })
+    })
+
+    describe("assertPlanLegal", () => {
+        const legal = (): CommitPlan => {
+            const store1 = data()
+            return {
+                data: store1,
+                settlement: updateSettlement(
+                    store1,
+                    [atom(0)],
+                    settleCommit,
+                    SETTLE_DEFAULT,
+                ),
+                onSets: NO_ON_SETS,
+                errors: createCommitErrors(),
+                report: undefined,
+            }
+        }
+
+        test("accepts every shape the constructors produce", () => {
+            const store1 = data()
+            const a = atom(0)
+            const member = atomFamily<number, [string]>(0)("x")
+
+            expect(() => assertPlanLegal(legal())).not.toThrow()
+            expect(() =>
+                assertPlanLegal({
+                    data: store1,
+                    settlement: forestSettlement(
+                        store1,
+                        [
+                            forestEntry(
+                                store1,
+                                [a],
+                                workGroup([member]),
+                                workGroup([a]),
+                                undefined,
+                            ),
+                        ],
+                        undefined,
+                        settleCommitForest,
+                    ),
+                    onSets: NO_ON_SETS,
+                    errors: createCommitErrors(),
+                    report: "set",
+                }),
+            ).not.toThrow()
+            expect(() =>
+                assertPlanLegal({
+                    data: store1,
+                    settlement: NO_SETTLEMENT,
+                    onSets: NO_ON_SETS,
+                    errors: createCommitErrors(),
+                    report: undefined,
+                }),
+            ).not.toThrow()
+        })
+
+        test("rejects report preparation with no delivery target", () => {
+            illegal({ ...legal(), report: undefined, beforeSettle: () => {} })
+        })
+
+        test("rejects a boundary that is not a begin/end pair", () => {
+            illegal({ ...legal(), boundary: { begin: (d: any) => d.tree } })
+            illegal({ ...legal(), boundary: { end: () => {} } })
+        })
+
+        test("rejects a missing hook queue or error accumulator", () => {
+            illegal({ ...legal(), onSets: undefined })
+            illegal({ ...legal(), errors: undefined })
+        })
+
+        test("rejects global fan-out outside a forest settlement", () => {
+            const plan = legal()
+            illegal({
+                ...plan,
+                settlement: {
+                    ...plan.settlement,
+                    global: globalEffects(
+                        undefined,
+                        [],
+                        "set",
+                        () => new Map(),
+                    ),
+                },
+            })
+        })
+
+        test("rejects peer updates with no global effects to produce them", () => {
+            const store1 = data()
+            const settlement = forestSettlement(
+                store1,
+                [],
+                undefined,
+                settleCommitForest,
+            )
+            illegal({
+                ...legal(),
+                settlement: { ...settlement, globalUpdates: new Map() },
+            })
+        })
+
+        test("rejects peer updates already populated before the commit ran", () => {
+            const store1 = data()
+            const settlement = forestSettlement(
+                store1,
+                [],
+                globalEffects(store1, [], "set", () => new Map()),
+                settleCommitForest,
+            )
+            settlement.globalUpdates = new Map()
+            illegal({ ...legal(), settlement })
+        })
+
+        test("rejects global effects without an ordered descriptor queue", () => {
+            const store1 = data()
+            const settlement = forestSettlement(
+                store1,
+                [],
+                globalEffects(store1, [], "set", () => new Map()),
+                settleCommitForest,
+            )
+            settlement.global.sets = undefined as any
+            illegal({ ...legal(), settlement })
+        })
+
+        test("rejects an empty deleted or unset group anywhere in the forest", () => {
+            const store1 = data()
+            const forest = (entry: unknown) =>
+                illegal({
+                    ...legal(),
+                    settlement: forestSettlement(
+                        store1,
+                        [entry as any],
+                        undefined,
+                        settleCommitForest,
+                    ),
+                })
+
+            // The asymmetry this replaces: an empty `deleted` used to count as
+            // settlement work while an empty `unsetAtoms` did not. Neither is
+            // representable now, and both are rejected the same way.
+            forest({
+                data: store1,
+                updatedAtoms: [],
+                deleted: [],
+                unsetAtoms: undefined,
+                children: undefined,
+            })
+            forest({
+                data: store1,
+                updatedAtoms: [],
+                deleted: undefined,
+                unsetAtoms: [],
+                children: undefined,
+            })
+            forest({
+                data: store1,
+                updatedAtoms: [],
+                deleted: undefined,
+                unsetAtoms: undefined,
+                children: [
+                    {
+                        data: store1,
+                        updatedAtoms: [],
+                        deleted: [],
+                        unsetAtoms: undefined,
+                        children: undefined,
+                    },
+                ],
+            })
+        })
+
+        test("rejects an update or delete settlement with no atom list", () => {
+            const plan = legal()
+            illegal({
+                ...plan,
+                settlement: { ...plan.settlement, atoms: undefined },
+            })
+            illegal({
+                ...plan,
+                settlement: { kind: "delete", atoms: undefined, settle: noop },
+            })
+        })
+    })
+})
+
+const noop = () => {}

--- a/packages/valdres/src/lib/commitPlans.ts
+++ b/packages/valdres/src/lib/commitPlans.ts
@@ -1,0 +1,298 @@
+declare const process: { env: { VALDRES_ENGINE_SELF_CHECKS?: string } }
+
+import type { Atom } from "../types/Atom"
+import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
+import type {
+    CommitForestEntry,
+    CommitForestSettleFn,
+} from "../types/CommitForestSettleFn"
+import type {
+    CommitForestSettlement,
+    CommitPlan,
+    DeleteSettlement,
+    GlobalEffectsApply,
+    GlobalForestSettlement,
+    LocalForestSettlement,
+    NoSettlement,
+    PlannedGlobalEffects,
+    SelectorSettlement,
+    UpdateSettlement,
+} from "../types/CommitPlan"
+import type { DeferredGlobalSet } from "./globalAtomFanOut"
+import type { InternalGlobalAtom } from "../types/InternalGlobalAtom"
+import type { NonEmpty } from "../types/NonEmpty"
+import type { Selector } from "../types/Selector"
+import type { SelectorSettleFn } from "../types/SelectorSettleFn"
+import type { SettleFlags } from "../types/SettleFlags"
+import type { SettleFn } from "../types/SettleFn"
+import type { StoreChangeSource } from "../types/StoreChangeSource"
+import type { StoreData } from "../types/StoreData"
+import type { DeferredOnSet } from "./runOnSets"
+import { recordCommitPlanAllocations } from "./architectureInstrumentation"
+import { IS_PROD } from "./IS_PROD"
+
+/**
+ * Typed constructors for the legal `CommitPlan` shapes, plus the legality
+ * assertion the engine runs on every plan it is handed. That assertion is an
+ * engine self-check: it is compiled out of the published bundle, so it costs
+ * consumers nothing (see the guard in `commitEngine.ts`).
+ *
+ * Plans stay deliberately mutable — the hot commit shapes reuse a module-static
+ * plan graph and the engine writes phase-two results back into the settlement —
+ * so illegal states are excluded by CONSTRUCTION rather than by freezing. Every
+ * forest literal in the core goes through `forestEntry`/`singleStoreForest`
+ * here, so the shape of a commit forest is defined once.
+ *
+ * Each constructor takes the commit's store as its first argument purely to
+ * stamp the deterministic `commitPlanAllocations` counter. A module-static plan
+ * graph passes `undefined`: it is allocated once at module load, not per
+ * commit, and must never inflate a measured commit's count.
+ *
+ * This module deliberately imports no propagation, fan-out, or write-path
+ * module — `settle` and `apply` primitives arrive by injection — so it can
+ * never join the core write-path import cycle (see test/import-cycles).
+ */
+
+// Same engine self-check budget as `assertPlanLegal`: `commitPlanAllocations`
+// exists so valdres's own architecture gates can assert what a commit shape
+// allocates, and it is compiled out of the published bundle by the define in
+// `build.ts` (see the guard in `commitEngine.ts` for why the env read is
+// written inline rather than behind a shared const).
+const count = (store: StoreData | undefined, allocations: number) => {
+    if (
+        process.env.VALDRES_ENGINE_SELF_CHECKS !== "off" &&
+        !IS_PROD &&
+        store?.architectureInstrumentation
+    )
+        recordCommitPlanAllocations(store, allocations)
+}
+
+/** Shared empty hook queue for plans whose write phase enqueues nothing.
+ *  `runOnSets` only reads, so one instance serves every such plan; freezing
+ *  makes an accidental enqueue fail loudly instead of leaking into the next
+ *  plan that borrows it. */
+export const NO_ON_SETS: DeferredOnSet[] = []
+Object.freeze(NO_ON_SETS)
+
+/** Guarded cleanup and freshness commits settle nothing. The shape carries no
+ *  per-commit state, so one frozen instance serves all of them. */
+export const NO_SETTLEMENT: NoSettlement = Object.freeze({
+    kind: "none" as const,
+})
+
+/** Narrow a finished work list to the representation a forest entry accepts:
+ *  an empty group is no work, and no work is `undefined`. */
+export const workGroup = <T>(items: T[]): NonEmpty<T> | undefined =>
+    items.length > 0 ? (items as NonEmpty<T>) : undefined
+
+/** One store's slot in a commit forest. */
+export const forestEntry = (
+    data: StoreData,
+    updatedAtoms: Atom<any>[],
+    deleted: NonEmpty<AtomFamilyAtom<any, any>> | undefined,
+    unsetAtoms: NonEmpty<Atom<any>> | undefined,
+    children: CommitForestEntry[] | undefined,
+): CommitForestEntry => {
+    count(data, 1)
+    return { data, updatedAtoms, deleted, unsetAtoms, children }
+}
+
+/** The one-entry, one-root forest every single-store commit uses — an ordinary
+ *  direct global write, a reset, an async resolution, a cleanup transaction. */
+export const singleStoreForest = (
+    data: StoreData,
+    updatedAtoms: Atom<any>[],
+    deleted?: NonEmpty<AtomFamilyAtom<any, any>>,
+    unsetAtoms?: NonEmpty<Atom<any>>,
+): CommitForestEntry[] => {
+    const entries = [
+        forestEntry(data, updatedAtoms, deleted, unsetAtoms, undefined),
+    ]
+    count(data, 1)
+    return entries
+}
+
+/**
+ * The settlement for a commit spanning one or more stores. `global` is the
+ * whole discriminant: without it there is no fan-out and therefore no peer
+ * `globalUpdates` to fold in; with it, the engine applies the effects before
+ * hooks and writes the resulting peer groups back onto this same settlement.
+ */
+export function forestSettlement(
+    store: StoreData | undefined,
+    entries: CommitForestEntry[],
+    global: undefined,
+    settle: CommitForestSettleFn,
+): LocalForestSettlement
+export function forestSettlement(
+    store: StoreData | undefined,
+    entries: CommitForestEntry[],
+    global: PlannedGlobalEffects,
+    settle: CommitForestSettleFn,
+): GlobalForestSettlement
+export function forestSettlement(
+    store: StoreData | undefined,
+    entries: CommitForestEntry[],
+    global: PlannedGlobalEffects | undefined,
+    settle: CommitForestSettleFn,
+): CommitForestSettlement
+export function forestSettlement(
+    store: StoreData | undefined,
+    entries: CommitForestEntry[],
+    global: PlannedGlobalEffects | undefined,
+    settle: CommitForestSettleFn,
+): CommitForestSettlement {
+    count(store, 1)
+    return {
+        kind: "forest",
+        entries,
+        global,
+        globalUpdates: undefined,
+        settle,
+    } as CommitForestSettlement
+}
+
+/** Ordered global fan-out over an already-finalized descriptor queue. */
+export const globalEffects = (
+    store: StoreData | undefined,
+    sets: DeferredGlobalSet[],
+    source: StoreChangeSource,
+    apply: GlobalEffectsApply,
+): PlannedGlobalEffects => {
+    count(store, 1)
+    return { sets, source, apply }
+}
+
+/** Global fan-out whose descriptors are collected by the plan's own write
+ *  phase: the queue starts empty and `apply` fills it before hooks run. */
+export const pendingGlobalEffects = (
+    store: StoreData | undefined,
+    source: StoreChangeSource,
+    apply: GlobalEffectsApply,
+): PlannedGlobalEffects => {
+    count(store, 2)
+    return { sets: [], source, apply }
+}
+
+/** The descriptor queue for a commit that writes ONE global atom. The ordered
+ *  global sets and the deferred onSet queue describe the same write, so they
+ *  share one triple and one queue instead of allocating a duplicate pair. */
+export const globalWriteQueue = (
+    atom: InternalGlobalAtom<any>,
+    value: any,
+    origin: StoreData,
+): DeferredGlobalSet[] => {
+    count(origin, 2)
+    return [[atom, value, origin]]
+}
+
+export const updateSettlement = (
+    store: StoreData | undefined,
+    atoms: Atom<any>[],
+    settle: SettleFn,
+    flags: SettleFlags,
+): UpdateSettlement => {
+    count(store, 1)
+    return { kind: "update", atoms, settle, flags }
+}
+
+export const deleteSettlement = (
+    store: StoreData | undefined,
+    atoms: AtomFamilyAtom<any, any>[],
+    settle: DeleteSettlement["settle"],
+): DeleteSettlement => {
+    count(store, 1)
+    return { kind: "delete", atoms, settle }
+}
+
+export const selectorSettlement = (
+    store: StoreData | undefined,
+    selector: Selector<any>,
+    settle: SelectorSettleFn,
+): SelectorSettlement => {
+    count(store, 1)
+    return { kind: "selector", selector, settle }
+}
+
+/**
+ * The invariants, one terse phrase each. Kept short and shared because this
+ * table is the only part of the dev-time backstop that ships as data:
+ *
+ *   0  report preparation with no delivery target
+ *   1  a boundary that does not pair begin with end
+ *   2  a plan missing its hook queue or error accumulator
+ *   3  global fan-out on a settlement that is not the forest
+ *   4  peer updates with no global effects to produce them, or already
+ *      populated before the commit ran (a static settlement left dirty)
+ *   5  global effects with no ordered descriptor queue
+ *   6  an empty delete/unset work group, which must be `undefined`
+ *   7  an update/delete settlement with no atom list
+ */
+const ILLEGAL = [
+    "beforeSettle without report",
+    "unpaired boundary",
+    "no onSets/errors",
+    "global effects outside a forest",
+    "bad globalUpdates",
+    "global effects without sets",
+    "empty work group; use undefined",
+    "settlement without atoms",
+]
+
+const illegal = (code: number): never => {
+    throw new Error(`valdres: illegal CommitPlan — ${ILLEGAL[code]}`)
+}
+
+const assertEntryLegal = (entry: CommitForestEntry) => {
+    if (entry.deleted?.length === 0 || entry.unsetAtoms?.length === 0)
+        illegal(6)
+    if (entry.children)
+        for (const child of entry.children) assertEntryLegal(child)
+}
+
+/**
+ * Re-check every invariant the plan types encode, on the plan the engine is
+ * about to run. Dev-only: the types already exclude these states at every
+ * ordinary call site, so this is the backstop for a plan assembled through a
+ * cast, mutated mid-flight, or built by a module-static singleton whose fields
+ * are reassigned per commit.
+ */
+export const assertPlanLegal = (plan: CommitPlan) => {
+    if (plan.beforeSettle !== undefined && plan.report === undefined) illegal(0)
+    const boundary = plan.boundary
+    if (
+        boundary !== undefined &&
+        (typeof boundary.begin !== "function" ||
+            typeof boundary.end !== "function")
+    )
+        illegal(1)
+    if (!Array.isArray(plan.onSets) || !plan.errors) illegal(2)
+
+    const settlement = plan.settlement
+    // Read through the discriminant so a plan assembled by a cast — the only
+    // way these arrangements can still occur — is caught rather than narrowed
+    // away at compile time.
+    const shape = settlement as {
+        kind: string
+        global?: { sets?: unknown }
+        globalUpdates?: unknown
+        atoms?: unknown
+    }
+    if (shape.kind === "forest") {
+        // `globalUpdates` is phase-two output: without effects nothing can
+        // produce it, and with them a value already present means the previous
+        // commit's peer groups would settle again with this one.
+        if (shape.globalUpdates !== undefined) illegal(4)
+        if (shape.global !== undefined && !Array.isArray(shape.global.sets))
+            illegal(5)
+        for (const entry of (settlement as CommitForestSettlement).entries)
+            assertEntryLegal(entry)
+        return
+    }
+    if (shape.global !== undefined) illegal(3)
+    if (
+        (shape.kind === "update" || shape.kind === "delete") &&
+        !Array.isArray(shape.atoms)
+    )
+        illegal(7)
+}

--- a/packages/valdres/src/lib/coordinateAsyncWrite.ts
+++ b/packages/valdres/src/lib/coordinateAsyncWrite.ts
@@ -5,6 +5,14 @@ import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { createScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
+import {
+    globalEffects,
+    forestSettlement,
+    globalWriteQueue,
+    NO_ON_SETS,
+    singleStoreForest,
+    updateSettlement,
+} from "./commitPlans"
 import { applyGlobalSets } from "./globalAtomFanOut"
 import { hasAtomCommitObservers } from "./hasAtomCommitObservers"
 import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
@@ -206,31 +214,17 @@ const settleAsyncAtomResolution = <Value>(
     const errors = createCommitErrors()
     const isGlobal = hasOnSet && isGlobalAtom(atom)
     if (isGlobal) {
-        const settlement = {
-            kind: "forest" as const,
-            entries: [
-                {
-                    data,
-                    updatedAtoms: [atom] as Atom<any>[],
-                    deleted: undefined,
-                    unsetAtoms: undefined,
-                    children: undefined,
-                },
-            ],
-            globalUpdates: undefined as
-                | ReturnType<typeof applyGlobalSets>
-                | undefined,
-            settle: settleCommitForest,
-        }
+        // One atom, one store: the ordered global sets and the deferred onSet
+        // queue describe the same write, so they share one descriptor queue.
+        const queue = globalWriteQueue(atom, resolvedValue, data)
         runCommitPlan({
             data,
-            settlement,
-            globalEffects: {
-                sets: [[atom, resolvedValue, data]],
-                source: "async-set",
-                updates: undefined,
-                apply: applyGlobalSets,
-            },
+            settlement: forestSettlement(
+                data,
+                singleStoreForest(data, [atom]),
+                globalEffects(data, queue, "async-set", applyGlobalSets),
+                settleCommitForest,
+            ),
             admit: () =>
                 admitAsyncAtomTransition(
                     atom,
@@ -250,7 +244,7 @@ const settleAsyncAtomResolution = <Value>(
                     undefined,
                 )
             },
-            onSets: [[atom, resolvedValue, data]],
+            onSets: queue,
             errors,
             report: "async-set",
         })
@@ -258,12 +252,12 @@ const settleAsyncAtomResolution = <Value>(
     }
     runCommitPlan({
         data,
-        settlement: {
-            kind: "update",
-            atoms: [atom],
-            settle: settleCommit,
-            flags: SETTLE_DEFAULT,
-        },
+        settlement: updateSettlement(
+            data,
+            [atom],
+            settleCommit,
+            SETTLE_DEFAULT,
+        ),
         admit: () =>
             admitAsyncAtomTransition(
                 atom,
@@ -283,7 +277,7 @@ const settleAsyncAtomResolution = <Value>(
                 undefined,
             )
         },
-        onSets: hasOnSet ? [[atom, resolvedValue, data]] : [],
+        onSets: hasOnSet ? [[atom, resolvedValue, data]] : NO_ON_SETS,
         errors,
         report: "async-set",
     })

--- a/packages/valdres/src/lib/deleteFamilyAtom.ts
+++ b/packages/valdres/src/lib/deleteFamilyAtom.ts
@@ -2,6 +2,7 @@ import type { AtomFamilyAtom } from "../types/AtomFamilyAtom"
 import type { StoreData } from "../types/StoreData"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
+import { deleteSettlement, NO_ON_SETS } from "./commitPlans"
 import { settleDeletedCommit } from "./propagateUpdatedAtoms"
 import { noteStateValueChanged } from "./stateRevisions"
 
@@ -20,12 +21,8 @@ export const deleteFamilyAtom = <
     // family(...args) starts returning a different object for the same key.
     runCommitPlan({
         data,
-        settlement: {
-            kind: "delete",
-            atoms: [atom],
-            settle: settleDeletedCommit,
-        },
-        onSets: [],
+        settlement: deleteSettlement(data, [atom], settleDeletedCommit),
+        onSets: NO_ON_SETS,
         errors: createCommitErrors(),
         report: "delete",
         continueAfterError: false,

--- a/packages/valdres/src/lib/getState.ts
+++ b/packages/valdres/src/lib/getState.ts
@@ -12,6 +12,7 @@ import { isSelector } from "../utils/isSelector"
 import { createScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_SKIP_FAMILY_INDEX } from "./commitIntents"
+import { NO_ON_SETS, updateSettlement } from "./commitPlans"
 import {
     clearStaleSelectorActivation,
 } from "./graph"
@@ -121,12 +122,12 @@ const coordinateDeletedMemberDefault = <Value>(
             }
             runCommitPlan({
                 data,
-                settlement: {
-                    kind: "update",
-                    atoms: [state],
-                    settle: settleCommit,
-                    flags: SETTLE_SKIP_FAMILY_INDEX,
-                },
+                settlement: updateSettlement(
+                    data,
+                    [state],
+                    settleCommit,
+                    SETTLE_SKIP_FAMILY_INDEX,
+                ),
                 admit: () =>
                     admitDeletedMemberDefaultTransition(
                         state,
@@ -145,7 +146,7 @@ const coordinateDeletedMemberDefault = <Value>(
                         undefined,
                         undefined,
                     ),
-                onSets: [],
+                onSets: NO_ON_SETS,
                 errors: createCommitErrors(),
                 report: undefined,
             })

--- a/packages/valdres/src/lib/globalAtom.ts
+++ b/packages/valdres/src/lib/globalAtom.ts
@@ -1,6 +1,7 @@
 import { equal } from "./equal"
 import type { AtomDefaultValue } from "../types/AtomDefaultValue"
 import type { AtomOnInit } from "../types/AtomOnInit"
+import type { CommitForestEntry } from "../types/CommitForestSettleFn"
 import type { GlobalAtomResetSelfFunc } from "../types/GlobalAtomResetSelfFunc"
 import type { GlobalAtomSetSelfFunc } from "../types/GlobalAtomSetSelfFunc"
 import type { AtomOnSet } from "./../types/AtomOnSet"
@@ -10,6 +11,11 @@ import type { StoreData } from "./../types/StoreData"
 import { cacheController } from "./cacheController"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors, recordCommitError } from "./commitErrors"
+import {
+    forestEntry,
+    forestSettlement,
+    NO_ON_SETS,
+} from "./commitPlans"
 import { globalOnSetMarker } from "./globalOnSetMarker"
 import {
     isLive,
@@ -143,28 +149,25 @@ export const globalAtom = <Value = unknown>(
             }
         }
 
-        const entries = []
+        const entries: CommitForestEntry[] = []
         for (const store of snapshot) {
             detach(store)
             detachOwnValue(atom, store)
-            entries.push({
-                data: store,
-                updatedAtoms: [atom],
-                deleted: undefined,
-                unsetAtoms: undefined,
-                children: undefined,
-            })
+            entries.push(
+                forestEntry(store, [atom], undefined, undefined, undefined),
+            )
         }
 
+        const origin = subscribedStores[0] ?? snapshot[0] ?? globalStoreData
         runCommitPlan({
-            data: subscribedStores[0] ?? snapshot[0] ?? globalStoreData,
-            settlement: {
-                kind: "forest",
+            data: origin,
+            settlement: forestSettlement(
+                origin,
                 entries,
-                globalUpdates: undefined,
-                settle: settleCommitForest,
-            },
-            onSets: [],
+                undefined,
+                settleCommitForest,
+            ),
+            onSets: NO_ON_SETS,
             errors,
             report: "reset",
             afterCommit: () => {

--- a/packages/valdres/src/lib/initAtom.ts
+++ b/packages/valdres/src/lib/initAtom.ts
@@ -7,6 +7,7 @@ import { isSelector } from "../utils/isSelector"
 import { createScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SEED_WRITE, SETTLE_DEFAULT } from "./commitIntents"
+import { NO_ON_SETS, updateSettlement } from "./commitPlans"
 import { getState } from "./getState"
 import { hasAtomCommitObservers } from "./hasAtomCommitObservers"
 import { settleCommit } from "./propagateUpdatedAtoms"
@@ -132,12 +133,12 @@ export const getAtomInitValue = <V = any>(
                     }
                     runCommitPlan({
                         data,
-                        settlement: {
-                            kind: "update",
-                            atoms: [atom],
-                            settle: settleCommit,
-                            flags: SETTLE_DEFAULT,
-                        },
+                        settlement: updateSettlement(
+                            data,
+                            [atom],
+                            settleCommit,
+                            SETTLE_DEFAULT,
+                        ),
                         admit: () =>
                             admitFunctionDefaultTransition(
                                 atom,
@@ -156,7 +157,7 @@ export const getAtomInitValue = <V = any>(
                                 undefined,
                                 undefined,
                             ),
-                        onSets: [],
+                        onSets: NO_ON_SETS,
                         errors: createCommitErrors(),
                         report: "async-set",
                     })

--- a/packages/valdres/src/lib/initSelector.ts
+++ b/packages/valdres/src/lib/initSelector.ts
@@ -28,7 +28,7 @@ import {
 import { createGuardedScalarCommit, runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
-import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { activeCommitBoundary, commitEndRegistry } from "./onCommitEnd"
 import {
     settleCommit,
     settleAsyncSelectorCommit,
@@ -51,6 +51,7 @@ import { validateResolvedValue } from "./validateResolvedValue"
 import { validateSchema } from "./validateSchema"
 import { recordSelectorEvaluation } from "./architectureInstrumentation"
 import { IS_PROD } from "./IS_PROD"
+import { NO_ON_SETS, NO_SETTLEMENT, selectorSettlement } from "./commitPlans"
 
 export { isSuspendError } from "./asyncDependencyTracking"
 
@@ -853,7 +854,7 @@ export const handleSelectorResult = <Value>(
                 if (!validateResolvedValue(selector, resolved, data)) {
                     runCommitPlan({
                         data,
-                        settlement: { kind: "none" },
+                        settlement: NO_SETTLEMENT,
                         admit: () =>
                             admitNativeSelectorCleanup(
                                 selector,
@@ -872,7 +873,7 @@ export const handleSelectorResult = <Value>(
                                 evaluationContext,
                                 evalDependencyRevisions,
                             ),
-                        onSets: [],
+                        onSets: NO_ON_SETS,
                         errors: createCommitErrors(),
                         report: undefined,
                     })
@@ -897,11 +898,11 @@ export const handleSelectorResult = <Value>(
                 }
                 runCommitPlan({
                     data,
-                    settlement: {
-                        kind: "selector",
+                    settlement: selectorSettlement(
+                        data,
                         selector,
-                        settle: settleAsyncSelectorCommit,
-                    },
+                        settleAsyncSelectorCommit,
+                    ),
                     admit: () =>
                         admitNativeSelectorSettlement(
                             selector,
@@ -920,13 +921,10 @@ export const handleSelectorResult = <Value>(
                             evaluationContext,
                             evalDependencyRevisions,
                         ),
-                    onSets: [],
+                    onSets: NO_ON_SETS,
                     errors: createCommitErrors(),
                     report: "async-set",
-                    beginCommit:
-                        commitEndRegistry.count === 0 ? undefined : beginCommit,
-                    endCommit:
-                        commitEndRegistry.count === 0 ? undefined : endCommit,
+                    boundary: activeCommitBoundary(),
                 })
             },
             () => {
@@ -935,7 +933,7 @@ export const handleSelectorResult = <Value>(
                     evaluationContext.asyncDependencyRevisions = undefined
                 runCommitPlan({
                     data,
-                    settlement: { kind: "none" },
+                    settlement: NO_SETTLEMENT,
                     admit: () =>
                         admitNativeSelectorCleanup(
                             selector,
@@ -954,7 +952,7 @@ export const handleSelectorResult = <Value>(
                             evaluationContext,
                             undefined,
                         ),
-                    onSets: [],
+                    onSets: NO_ON_SETS,
                     errors: createCommitErrors(),
                     report: undefined,
                 })

--- a/packages/valdres/src/lib/onCommitEnd.test.ts
+++ b/packages/valdres/src/lib/onCommitEnd.test.ts
@@ -111,6 +111,94 @@ describe("store.onCommitEnd", () => {
         unsub()
     })
 
+    test("a no-op txn (every write value-equal) does not commit, so it does not fire", () => {
+        const store1 = store()
+        const a = atom(1)
+        const b = atom(2)
+        store1.get(a)
+        store1.get(b)
+        const fired = mock(() => {})
+        const unsub = store1.onCommitEnd(fired)
+        store1.txn(txn => {
+            txn.set(a, 1)
+            txn.set(b, 2)
+        })
+        expect(fired).toHaveBeenCalledTimes(0)
+        unsub()
+    })
+
+    test("a no-op reset (already at the default) does not fire", () => {
+        const store1 = store()
+        const a = atom(1)
+        store1.get(a)
+        const fired = mock(() => {})
+        const unsub = store1.onCommitEnd(fired)
+        store1.reset(a)
+        expect(fired).toHaveBeenCalledTimes(0)
+        store1.set(a, 2)
+        store1.reset(a)
+        expect(fired).toHaveBeenCalledTimes(2)
+        unsub()
+    })
+
+    // The boundary of a commit whose write phase runs inside it is opened
+    // before its emptiness is known, so these pin the two halves of the answer
+    // it reports on close.
+    test("a hooked txn that changes something still fires exactly once", () => {
+        const store1 = store()
+        const hooked = atom(0, { onSet: () => {} })
+        const plain = atom(0)
+        const fired = mock(() => {})
+        const unsub = store1.onCommitEnd(fired)
+        store1.txn(txn => {
+            txn.set(hooked, 1)
+            txn.set(plain, 1)
+        })
+        expect(fired).toHaveBeenCalledTimes(1)
+        unsub()
+    })
+
+    test("a commit whose subscriber throws still fires — the writes landed", () => {
+        const store1 = store()
+        const a = atom(0)
+        const fired = mock(() => {})
+        store1.sub(a, () => {
+            throw new Error("subscriber boom")
+        })
+        const unsub = store1.onCommitEnd(fired)
+        expect(() => store1.txn(txn => txn.set(a, 1))).toThrow(
+            "subscriber boom",
+        )
+        expect(store1.get(a)).toBe(1)
+        expect(fired).toHaveBeenCalledTimes(1)
+        unsub()
+    })
+
+    test("a no-op outer commit still fires once for work a nested commit does", () => {
+        const store1 = store()
+        const trigger = atom(0)
+        const nested = atom(0)
+        const events: string[] = []
+        let cascaded = false
+        // The hook runs inside the outer commit; its write is the only work.
+        const hooked = atom(0, {
+            onSet: () => {
+                if (cascaded) return
+                cascaded = true
+                store1.set(nested, 99)
+            },
+        })
+        store1.sub(nested, () => events.push("sub-nested"))
+        const unsub = store1.onCommitEnd(() => events.push("commit-end"))
+        store1.txn(txn => {
+            txn.set(hooked, 1)
+            txn.set(trigger, 0) // value-equal, contributes nothing
+        })
+        expect(store1.get(nested)).toBe(99)
+        expect(events).toEqual(["sub-nested", "commit-end"])
+        unsub()
+    })
+
     test("unset with no own value is a no-op and does not fire", () => {
         const store1 = store()
         const a = atom(0)

--- a/packages/valdres/src/lib/onCommitEnd.ts
+++ b/packages/valdres/src/lib/onCommitEnd.ts
@@ -1,3 +1,4 @@
+import type { CommitBoundary } from "../types/CommitPlan"
 import type { StoreData } from "../types/StoreData"
 import type { StoreTreeRuntime } from "./storeTreeRuntime"
 import { trackStoreCleanup, untrackStoreCleanup } from "./storeLifecycle"
@@ -41,12 +42,29 @@ export const beginCommit = (data: StoreData): StoreTreeRuntime => {
  *  hook writing during the commit) just decrement: their writes coalesce into
  *  the outermost commit's single notification.
  *
+ *  `didWork` is false when the closing boundary's own commit turned out to be a
+ *  no-op — a reset to the value already held, a transaction whose every write
+ *  was value-equal. Such a boundary MUST be opened before its write phase can
+ *  answer the question (the write phase runs inside it), so it answers on close
+ *  instead, and a tree with no work anywhere in the chain notifies nobody. That
+ *  makes `onCommitEnd` consistent with the no-op `set` and no-op `unset` it
+ *  already stays silent for. Every other caller opens its boundary around work
+ *  it has already committed to doing, hence the default.
+ *
  *  Every listener fires even if one throws; the first error is rethrown unless
  *  `swallowErrors` — used when the commit itself is already throwing, so a
  *  listener error never masks the original failure (same contract as the
  *  onChange flush in the transaction commit pipeline). */
-export const endCommit = (tree: StoreTreeRuntime, swallowErrors: boolean) => {
+export const endCommit = (
+    tree: StoreTreeRuntime,
+    swallowErrors: boolean,
+    didWork = true,
+) => {
+    if (didWork) tree.commitDidWork = true
     if (--tree.commitDepth !== 0) return
+    const committed = tree.commitDidWork
+    tree.commitDidWork = false
+    if (!committed) return
     const listeners = tree.commitEndListeners
     // The size re-check is the backstop for the `undefined ⟺ empty` invariant
     // the registration path maintains below.
@@ -67,6 +85,21 @@ export const endCommit = (tree: StoreTreeRuntime, swallowErrors: boolean) => {
     }
     if (hasError && !swallowErrors) throw firstError
 }
+
+/** The one paired boundary every engine-sequenced commit uses. Begin and end
+ *  ship together as a single frozen capability, so a plan can neither open a
+ *  boundary it won't close nor claim a close it never opened. Module-static:
+ *  taking a boundary costs no allocation. */
+const COMMIT_END_BOUNDARY: CommitBoundary = Object.freeze({
+    begin: beginCommit,
+    end: endCommit,
+})
+
+/** The outer commit boundary a standalone local operation should carry, or
+ *  undefined when no `onCommitEnd` listener exists anywhere — a single counter
+ *  read on the common path. */
+export const activeCommitBoundary = (): CommitBoundary | undefined =>
+    commitEndRegistry.count === 0 ? undefined : COMMIT_END_BOUNDARY
 
 /** Register a commit-end listener on `data`'s store tree — the implementation
  *  behind `store.onCommitEnd`. Listeners live on the tree's ROOT store: a

--- a/packages/valdres/src/lib/resetAtom.ts
+++ b/packages/valdres/src/lib/resetAtom.ts
@@ -5,6 +5,12 @@ import { isGlobalAtom } from "../utils/isGlobalAtom"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_DEFAULT } from "./commitIntents"
+import {
+    forestSettlement,
+    pendingGlobalEffects,
+    singleStoreForest,
+    updateSettlement,
+} from "./commitPlans"
 import { applyGlobalSets, collectGlobalOnSets } from "./globalAtomFanOut"
 import { getAtomInitValue } from "./initAtom"
 import {
@@ -12,7 +18,7 @@ import {
     createChangeSink,
     flushChangeSink,
 } from "./notifyChangeListeners"
-import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { activeCommitBoundary } from "./onCommitEnd"
 import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
 import type { DeferredOnSet } from "./runOnSets"
 import {
@@ -57,38 +63,26 @@ export const resetAtom = <V>(
             ? undefined
             : createChangeSink(undefined, "reset")
     const errors = createCommitErrors()
+    // A global reset discovers its peer descriptors during its own write phase,
+    // so it hands the forest the queue it is about to fill.
     const globalEffects: PlannedGlobalEffects | undefined = isGlobalAtom(atom)
-        ? {
-              sets: [],
-              source: "set",
-              updates: undefined,
-              apply: applyGlobalSets,
-          }
+        ? pendingGlobalEffects(data, "set", applyGlobalSets)
         : undefined
     runCommitPlan({
         data,
-        globalEffects,
         settlement: globalEffects
-            ? {
-                  kind: "forest",
-                  entries: [
-                      {
-                          data,
-                          updatedAtoms,
-                          deleted: undefined,
-                          unsetAtoms: undefined,
-                          children: undefined,
-                      },
-                  ],
-                  globalUpdates: undefined,
-                  settle: settleCommitForest,
-              }
-            : {
-                  kind: "update",
-                  atoms: updatedAtoms,
-                  settle: settleCommit,
-                  flags: SETTLE_DEFAULT,
-              },
+            ? forestSettlement(
+                  data,
+                  singleStoreForest(data, updatedAtoms),
+                  globalEffects,
+                  settleCommitForest,
+              )
+            : updateSettlement(
+                  data,
+                  updatedAtoms,
+                  settleCommit,
+                  SETTLE_DEFAULT,
+              ),
         apply: () => {
             updatedAtoms.push(
                 ...writeAtoms(
@@ -108,8 +102,7 @@ export const resetAtom = <V>(
         errors,
         report: changeSink,
         flushReport: changeSink ? () => flushChangeSink(changeSink) : undefined,
-        beginCommit: commitEndRegistry.count === 0 ? undefined : beginCommit,
-        endCommit: commitEndRegistry.count === 0 ? undefined : endCommit,
+        boundary: activeCommitBoundary(),
     })
     return value
 }

--- a/packages/valdres/src/lib/setAtom.ts
+++ b/packages/valdres/src/lib/setAtom.ts
@@ -1,5 +1,8 @@
 import type { Atom } from "../types/Atom"
 import type { DirectWriteIntent } from "../types/CommitIntent"
+import type { CommitForestEntry } from "../types/CommitForestSettleFn"
+import type { UnreportedCommitPlan } from "../types/CommitPlan"
+import type { InternalGlobalAtom } from "../types/InternalGlobalAtom"
 import type { SetAtomValue } from "../types/SetAtomValue"
 import type { StoreData } from "../types/StoreData"
 import { isGlobalAtom } from "../utils/isGlobalAtom"
@@ -7,7 +10,14 @@ import { isPromiseLike } from "../utils/isPromiseLike"
 import { runHookedDirectWrite, runCommitPlan } from "./commitEngine"
 import { DIRECT_WRITE, SETTLE_DEFAULT } from "./commitIntents"
 import { createCommitErrors } from "./commitErrors"
+import {
+    forestSettlement,
+    globalEffects,
+    globalWriteQueue,
+    singleStoreForest,
+} from "./commitPlans"
 import { coordinateAsyncWrite } from "./coordinateAsyncWrite"
+import type { DeferredGlobalSet } from "./globalAtomFanOut"
 import {
     applyGlobalSets,
     tryApplyUnobservedGlobalSet,
@@ -18,6 +28,37 @@ import { isFunction } from "./isFunction"
 import { resolvePendingDefault } from "./resolvePendingDefault"
 import { setValueInData } from "./setValueInData"
 import { validateSchema } from "./validateSchema"
+
+// ——— Direct global-write plan ———
+// `store.set(globalAtom, value)` is the one plan-bearing shape on the direct
+// write path, and the only one that fans out to peer stores. Six objects carry
+// it: the [atom, value, origin] descriptor and the one-element queue that
+// serves BOTH the ordered global sets and the deferred onSet queue (they
+// describe the same write, so there is one of each, not two), the forest entry
+// and its list, the global effects, and the settlement.
+//
+// A module-static, borrow-and-restore plan graph would take that to four, but
+// it costs ~0.5% of a consumer's gzipped bundle plus a reentrancy guard, to
+// save two objects on a path that already fans out to N stores and runs user
+// hooks. The bytes lose. The hot shapes that DO reuse a static plan — the
+// scalar write (no plan at all) and the hook-free bulk commit — are the ones
+// where a plan per commit would actually show up.
+const globalWritePlanFor = (
+    data: StoreData,
+    queue: DeferredGlobalSet[],
+    entries: CommitForestEntry[],
+): UnreportedCommitPlan => ({
+    data,
+    settlement: forestSettlement(
+        data,
+        entries,
+        globalEffects(data, queue, "set", applyGlobalSets),
+        settleCommitForest,
+    ),
+    onSets: queue,
+    errors: createCommitErrors(),
+    report: "set",
+})
 
 /**
  * Direct-write coordinator of the commit engine: one atom, one store. Phases
@@ -122,33 +163,13 @@ export const setAtom = <Value = any>(
             ) {
                 return syncValue
             }
-            const errors = createCommitErrors()
-            runCommitPlan({
-                data,
-                globalEffects: {
-                    sets: [[atom, syncValue, data]],
-                    source: "set",
-                    updates: undefined,
-                    apply: applyGlobalSets,
-                },
-                settlement: {
-                    kind: "forest",
-                    entries: [
-                        {
-                            data,
-                            updatedAtoms,
-                            deleted: undefined,
-                            unsetAtoms: undefined,
-                            children: undefined,
-                        },
-                    ],
-                    globalUpdates: undefined,
-                    settle: settleCommitForest,
-                },
-                onSets: [[atom, syncValue, data]],
-                errors,
-                report: "set",
-            })
+            runCommitPlan(
+                globalWritePlanFor(
+                    data,
+                    globalWriteQueue(atom, syncValue, data),
+                    singleStoreForest(data, updatedAtoms),
+                ),
+            )
         } else {
             runHookedDirectWrite(
                 atom,

--- a/packages/valdres/src/lib/setAtoms.ts
+++ b/packages/valdres/src/lib/setAtoms.ts
@@ -1,6 +1,6 @@
 import type { Atom } from "../types/Atom"
 import type { BulkWriteIntent } from "../types/CommitIntent"
-import type { CommitPlan } from "../types/CommitPlan"
+import type { UnreportedCommitPlan } from "../types/CommitPlan"
 import type { InternalAtom } from "../types/InternalAtom"
 import type { StoreData } from "../types/StoreData"
 import { isFamilyAtom } from "../utils/isFamilyAtom"
@@ -8,10 +8,16 @@ import { isPromiseLike } from "../utils/isPromiseLike"
 import { runCommitPlan } from "./commitEngine"
 import { SETTLE_DEFAULT } from "./commitIntents"
 import { createCommitErrors } from "./commitErrors"
+import {
+    globalEffects,
+    forestSettlement,
+    singleStoreForest,
+    updateSettlement,
+} from "./commitPlans"
 import { equal } from "./equal"
 import { applyGlobalSets, collectGlobalOnSets } from "./globalAtomFanOut"
 import { flushChangeSink, type ChangeSink } from "./notifyChangeListeners"
-import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { activeCommitBoundary } from "./onCommitEnd"
 import { settleCommit, settleCommitForest } from "./propagateUpdatedAtoms"
 import type { DeferredOnSet } from "./runOnSets"
 import { setValueInData } from "./setValueInData"
@@ -76,12 +82,12 @@ export const commitAtoms = (
     if (!globalSets) {
         runCommitPlan({
             data,
-            settlement: {
-                kind: "update",
-                atoms: updatedAtoms,
-                settle: settleCommit,
-                flags: SETTLE_DEFAULT,
-            },
+            settlement: updateSettlement(
+                data,
+                updatedAtoms,
+                settleCommit,
+                SETTLE_DEFAULT,
+            ),
             onSets,
             errors,
             report: intent.report,
@@ -90,26 +96,12 @@ export const commitAtoms = (
     }
     runCommitPlan({
         data,
-        globalEffects: {
-            sets: globalSets,
-            source: "set",
-            updates: undefined,
-            apply: applyGlobalSets,
-        },
-        settlement: {
-            kind: "forest",
-            entries: [
-                {
-                    data,
-                    updatedAtoms,
-                    deleted: undefined,
-                    unsetAtoms: undefined,
-                    children: undefined,
-                },
-            ],
-            globalUpdates: undefined,
-            settle: settleCommitForest,
-        },
+        settlement: forestSettlement(
+            data,
+            singleStoreForest(data, updatedAtoms),
+            globalEffects(data, globalSets, "set", applyGlobalSets),
+            settleCommitForest,
+        ),
         onSets,
         errors,
         report: intent.report,
@@ -183,12 +175,12 @@ let hookFreeData: StoreData = undefined!
 let hookFreeInitialized: Set<Atom> = undefined!
 let hookFreeSink: ChangeSink | undefined
 
-const hookFreeSettlement = {
-    kind: "update" as const,
-    atoms: EMPTY_UPDATED_ATOMS,
-    settle: settleCommit,
-    flags: SETTLE_DEFAULT,
-}
+const hookFreeSettlement = updateSettlement(
+    undefined,
+    EMPTY_UPDATED_ATOMS,
+    settleCommit,
+    SETTLE_DEFAULT,
+)
 
 const hookFreeApply = () => {
     if (
@@ -212,7 +204,7 @@ const hookFreeFlushReport = () => flushChangeSink(hookFreeSink!)
 
 const hookFreeErrors = createCommitErrors()
 
-const hookFreePlan: CommitPlan = {
+const hookFreePlan: UnreportedCommitPlan = {
     data: undefined as unknown as StoreData,
     settlement: hookFreeSettlement,
     apply: hookFreeApply,
@@ -220,8 +212,7 @@ const hookFreePlan: CommitPlan = {
     errors: hookFreeErrors,
     report: undefined,
     flushReport: undefined,
-    beginCommit: undefined,
-    endCommit: undefined,
+    boundary: undefined,
 }
 
 /**
@@ -245,12 +236,12 @@ export const commitHookFreeAtoms = (
     if (hookFreeBusy) {
         // Nested hook-free commit: the statics are mid-flight for the outer
         // commit, so this (rare) shape pays the per-commit plan allocation.
-        const settlement = {
-            kind: "update" as const,
-            atoms: [] as Atom<any>[],
-            settle: settleCommit,
-            flags: SETTLE_DEFAULT,
-        }
+        const settlement = updateSettlement(
+            data,
+            [] as Atom<any>[],
+            settleCommit,
+            SETTLE_DEFAULT,
+        )
         runCommitPlan({
             data,
             settlement,
@@ -274,9 +265,7 @@ export const commitHookFreeAtoms = (
             errors: createCommitErrors(),
             report: sink,
             flushReport: sink ? () => flushChangeSink(sink) : undefined,
-            beginCommit:
-                commitEndRegistry.count === 0 ? undefined : beginCommit,
-            endCommit: commitEndRegistry.count === 0 ? undefined : endCommit,
+            boundary: activeCommitBoundary(),
         })
         return
     }
@@ -289,9 +278,7 @@ export const commitHookFreeAtoms = (
     hookFreePlan.report = sink
     hookFreePlan.flushReport =
         sink === undefined ? undefined : hookFreeFlushReport
-    const withBoundary = commitEndRegistry.count !== 0
-    hookFreePlan.beginCommit = withBoundary ? beginCommit : undefined
-    hookFreePlan.endCommit = withBoundary ? endCommit : undefined
+    hookFreePlan.boundary = activeCommitBoundary()
     try {
         runCommitPlan(hookFreePlan)
     } finally {
@@ -304,8 +291,7 @@ export const commitHookFreeAtoms = (
         hookFreePlan.data = undefined as unknown as StoreData
         hookFreePlan.report = undefined
         hookFreePlan.flushReport = undefined
-        hookFreePlan.beginCommit = undefined
-        hookFreePlan.endCommit = undefined
+        hookFreePlan.boundary = undefined
         hookFreeErrors.hasError = false
         hookFreeErrors.firstError = undefined
     }

--- a/packages/valdres/src/lib/storeTreeRuntime.ts
+++ b/packages/valdres/src/lib/storeTreeRuntime.ts
@@ -19,8 +19,9 @@ import type { StoreData } from "../types/StoreData"
  *   root                     lib/createStoreData.ts (construction only)
  *   revision / revisionEnabled / trackedRevisions
  *                            lib/stateRevisions.ts, lib/setValueInData.ts
- *   commitDepth              lib/onCommitEnd.ts (beginCommit/endCommit only —
- *                            disposal must never reset it; a scope disposed
+ *   commitDepth / commitDidWork
+ *                            lib/onCommitEnd.ts (beginCommit/endCommit only —
+ *                            disposal must never reset either; a scope disposed
  *                            mid-commit would drive the live tree negative)
  *   commitEndListeners       lib/onCommitEnd.ts, plus root-only teardown in
  *                            lib/disposeStoreData.ts
@@ -50,6 +51,14 @@ export type StoreTreeRuntime = {
      *  Listeners fire when the OUTERMOST boundary closes, so writes performed
      *  by a subscriber coalesce into one notification. */
     commitDepth: number
+    /** Whether anything inside the currently open boundary chain actually
+     *  committed. A boundary whose write phase runs INSIDE it (reset, a
+     *  transaction commit) has to open before it can know, so it reports the
+     *  answer on close instead; a no-op then closes silently. Nested boundaries
+     *  record their own work here, so a subscriber writing during delivery
+     *  still produces exactly one notification. Reset when the outermost
+     *  boundary closes. */
+    commitDidWork: boolean
     /** Commit-end listeners for the whole tree: a listener registered through
      *  any store fires for a commit originating in any store of that tree.
      *  Undefined until the first listener and reset to undefined when the last
@@ -65,5 +74,6 @@ export const createStoreTreeRuntime = (root: StoreData): StoreTreeRuntime => ({
     revisionEnabled: false,
     trackedRevisions: undefined,
     commitDepth: 0,
+    commitDidWork: false,
     commitEndListeners: undefined,
 })

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -36,6 +36,12 @@ import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
 import type { StoreTreeRuntime } from "./storeTreeRuntime"
 import { runCommitPlan } from "./commitEngine"
 import { createCommitErrors } from "./commitErrors"
+import {
+    forestSettlement,
+    globalEffects,
+    singleStoreForest,
+    workGroup,
+} from "./commitPlans"
 import { BULK_WITH_EFFECTS_SILENT } from "./commitIntents"
 import {
     applyGlobalSets,
@@ -664,6 +670,11 @@ export class TransactionContext {
         // boundaries (see settleCommit's wrapper); nested inside this one
         // they just move the depth counter. With no listener anywhere this is a
         // single counter read, so the Bencher-gated txn hot path is unchanged.
+        //
+        // This boundary is opened before the write phase can tell whether the
+        // overlay changes anything, so it closes with `didWork: false` and lets
+        // the nested boundary of whatever actually settles decide. An all-equal
+        // commit settles nothing, opens no inner boundary, and notifies nobody.
         let commitEndTree: StoreTreeRuntime | undefined
         if (commitEndRegistry.count !== 0)
             commitEndTree = beginCommit(this._data)
@@ -702,7 +713,7 @@ export class TransactionContext {
             // On failure, listener errors are swallowed so they never mask the
             // commit's own error; the writes were applied either way, so
             // listeners still fire.
-            if (commitEndTree) endCommit(commitEndTree, !succeeded)
+            if (commitEndTree) endCommit(commitEndTree, !succeeded, !succeeded)
         }
     }
 
@@ -747,44 +758,41 @@ export class TransactionContext {
                 "collect",
                 onSets,
             )
-            const deleted = draft.deletes?.size ? [...draft.deletes] : undefined
+            const deleted = draft.deletes?.size
+                ? workGroup([...draft.deletes])
+                : undefined
             if (draft.deletes?.size) {
                 deleteAtomFamilyAtoms(draft.deletes, this._data)
             }
             const unsetAtoms = draft.unsets?.size
-                ? applyUnsets(draft.unsets, this._data)
-                : []
+                ? workGroup(applyUnsets(draft.unsets, this._data))
+                : undefined
 
             const errors = createCommitErrors()
             // Global peers are writes too: apply them all while still in the
             // write phase. An empty map means every peer was value-equal — a
             // local plan handles that exactly like no globals at all.
             const globalSets = collectGlobalOnSets(onSets)
+            const entries = singleStoreForest(
+                this._data,
+                updatedAtoms,
+                deleted,
+                unsetAtoms,
+            )
             runCommitPlan({
                 data: this._data,
-                globalEffects: globalSets
-                    ? {
-                          sets: globalSets,
-                          source: "set",
-                          updates: undefined,
-                          apply: applyGlobalSets,
-                      }
-                    : undefined,
-                settlement: {
-                    kind: "forest",
-                    entries: [
-                        {
-                            data: this._data,
-                            updatedAtoms,
-                            deleted,
-                            unsetAtoms:
-                                unsetAtoms.length > 0 ? unsetAtoms : undefined,
-                            children: undefined,
-                        },
-                    ],
-                    globalUpdates: undefined,
-                    settle: settleCommitForest,
-                },
+                settlement: forestSettlement(
+                    this._data,
+                    entries,
+                    globalSets &&
+                        globalEffects(
+                            this._data,
+                            globalSets,
+                            "set",
+                            applyGlobalSets,
+                        ),
+                    settleCommitForest,
+                ),
                 onSets,
                 errors,
                 report: sink,
@@ -824,12 +832,14 @@ export class TransactionContext {
             )
             if (txn._draft.deletes?.size) {
                 deleteAtomFamilyAtoms(txn._draft.deletes, entry.data)
-                entry.deleted = [...txn._draft.deletes]
+                entry.deleted = workGroup([...txn._draft.deletes])
             }
             if (txn._draft.unsets?.size) {
                 // Detach shadows in the write phase so every store's values are
                 // final before any propagation pass reads through the chain.
-                entry.unsetAtoms = applyUnsets(txn._draft.unsets, entry.data)
+                entry.unsetAtoms = workGroup(
+                    applyUnsets(txn._draft.unsets, entry.data),
+                )
             }
         }
 
@@ -860,20 +870,18 @@ export class TransactionContext {
         }
         runCommitPlan({
             data: this._data,
-            globalEffects: globalSets
-                ? {
-                      sets: globalSets,
-                      source: "set",
-                      updates: undefined,
-                      apply: applyGlobalSets,
-                  }
-                : undefined,
-            settlement: {
-                kind: "forest",
-                entries: plan,
-                globalUpdates: undefined,
-                settle: settleCommitForest,
-            },
+            settlement: forestSettlement(
+                this._data,
+                plan,
+                globalSets &&
+                    globalEffects(
+                        this._data,
+                        globalSets,
+                        "set",
+                        applyGlobalSets,
+                    ),
+                settleCommitForest,
+            ),
             onSets,
             errors,
             report: sink,

--- a/packages/valdres/src/lib/unsetValue.ts
+++ b/packages/valdres/src/lib/unsetValue.ts
@@ -5,6 +5,7 @@ import { runCommitPlan } from "./commitEngine"
 import { cacheState } from "./cacheState"
 import { createCommitErrors } from "./commitErrors"
 import { SETTLE_INIT_ONLY, SETTLE_UNSET } from "./commitIntents"
+import { NO_ON_SETS, updateSettlement } from "./commitPlans"
 import { getState } from "./getState"
 import {
     refreshInheritedDependencyBranch,
@@ -15,7 +16,7 @@ import {
     hasChangeListener,
     reportUnsetAtom,
 } from "./notifyChangeListeners"
-import { beginCommit, commitEndRegistry, endCommit } from "./onCommitEnd"
+import { activeCommitBoundary } from "./onCommitEnd"
 import { untrackNamedAtom } from "./namedStateIndex"
 import { settleCommit } from "./propagateUpdatedAtoms"
 import { noteStateValueChanged } from "./stateRevisions"
@@ -133,32 +134,47 @@ export const unsetValue = <V>(atom: Atom<V>, data: StoreData): void => {
     const changeSink = hasChangeListener(data)
         ? createChangeSink(undefined, "unset")
         : undefined
+    const settlement = updateSettlement(
+        data,
+        [atom],
+        settleCommit,
+        SETTLE_UNSET,
+    )
+    const afterSettle = () => reDelegateScopeSubscriptions(atom, data)
+    const boundary = activeCommitBoundary()
+    // Historical direct-unset behavior short-circuits cleanup/onChange if
+    // reporting or propagation itself throws.
+    if (changeSink === undefined) {
+        // Nothing listening: the removal record has no delivery target, so the
+        // plan carries no report preparation either.
+        runCommitPlan({
+            data,
+            settlement,
+            onSets: NO_ON_SETS,
+            errors: createCommitErrors(),
+            report: undefined,
+            afterSettle,
+            boundary,
+            continueAfterError: false,
+        })
+        return
+    }
     runCommitPlan({
         data,
-        settlement: {
-            kind: "update",
-            atoms: [atom],
-            settle: settleCommit,
-            flags: SETTLE_UNSET,
-        },
-        onSets: [],
+        settlement,
+        onSets: NO_ON_SETS,
         errors: createCommitErrors(),
         report: changeSink,
-        beforeSettle: changeSink
-            ? report =>
-                  reportUnsetAtom(
-                      atom,
-                      data,
-                      effectiveValueAfterUnset(atom, data),
-                      report,
-                  )
-            : undefined,
-        afterSettle: () => reDelegateScopeSubscriptions(atom, data),
-        flushReport: changeSink ? () => flushChangeSink(changeSink) : undefined,
-        beginCommit: commitEndRegistry.count === 0 ? undefined : beginCommit,
-        endCommit: commitEndRegistry.count === 0 ? undefined : endCommit,
-        // Historical direct-unset behavior short-circuits cleanup/onChange if
-        // reporting or propagation itself throws.
+        beforeSettle: report =>
+            reportUnsetAtom(
+                atom,
+                data,
+                effectiveValueAfterUnset(atom, data),
+                report,
+            ),
+        afterSettle,
+        flushReport: () => flushChangeSink(changeSink),
+        boundary,
         continueAfterError: false,
     })
 }

--- a/packages/valdres/src/types/CommitForestSettleFn.ts
+++ b/packages/valdres/src/types/CommitForestSettleFn.ts
@@ -3,17 +3,24 @@ import type { StoreAtomUpdates } from "../lib/globalAtomFanOut"
 import type { ChangeReport } from "../lib/notifyChangeListeners"
 import type { Atom } from "./Atom"
 import type { AtomFamilyAtom } from "./AtomFamilyAtom"
+import type { NonEmpty } from "./NonEmpty"
 import type { StoreChangeSource } from "./StoreChangeSource"
 import type { StoreData } from "./StoreData"
 
 /** One store's finalized local slot in a multi-root commit forest. Global peer
  * updates are folded into the canonical node for the same StoreData by the
- * forest settlement before any graph work begins. */
+ * forest settlement before any graph work begins.
+ *
+ * `updatedAtoms` is always an array — the write phase's own result, empty when
+ * every write turned out value-equal. The cleanup groups are `NonEmpty` or
+ * absent, so "this store has delete/unset work" is one `!== undefined` test for
+ * both, instead of the per-group emptiness convention that made an empty
+ * `deleted` count as work while an empty `unsetAtoms` did not. */
 export type CommitForestEntry = {
     data: StoreData
     updatedAtoms: Atom<any>[]
-    deleted: AtomFamilyAtom<any, any>[] | undefined
-    unsetAtoms: Atom<any>[] | undefined
+    deleted: NonEmpty<AtomFamilyAtom<any, any>> | undefined
+    unsetAtoms: NonEmpty<Atom<any>> | undefined
     children: CommitForestEntry[] | undefined
 }
 

--- a/packages/valdres/src/types/CommitPlan.ts
+++ b/packages/valdres/src/types/CommitPlan.ts
@@ -20,14 +20,14 @@ import type {
 } from "./CommitForestSettleFn"
 import type { StoreChangeSource } from "./StoreChangeSource"
 
-type UpdateSettlement = {
+export type UpdateSettlement = {
     kind: "update"
     atoms: Atom<any>[]
     settle: SettleFn
     flags: SettleFlags
 }
 
-type DeleteSettlement = {
+export type DeleteSettlement = {
     kind: "delete"
     atoms: AtomFamilyAtom<any, any>[]
     settle: (
@@ -38,44 +38,87 @@ type DeleteSettlement = {
     ) => void
 }
 
-type SelectorSettlement = {
+export type SelectorSettlement = {
     kind: "selector"
     selector: Selector<any>
     settle: SelectorSettleFn
 }
 
+/** Apply every ordered global descriptor to its peers, returning the per-store
+ *  atom groups the settlement must fold in. */
+export type GlobalEffectsApply = (
+    sets: DeferredGlobalSet[],
+    errors: CommitErrors,
+) => StoreAtomUpdates
+
+/** Ordered global fan-out for one commit: the finalized atom/value/origin
+ *  descriptors, the metadata attached to the resulting peer reports, and the
+ *  application primitive. A plan that discovers its globals during its own
+ *  write phase passes the queue it will fill. */
+export type PlannedGlobalEffects = {
+    sets: DeferredGlobalSet[]
+    source: StoreChangeSource
+    apply: GlobalEffectsApply
+}
+
 /** A multi-root commit forest: every physical store appears in one canonical
  *  sparse tree node and settles exactly once against local, inherited, and
- *  global trigger groups. `globalUpdates` is populated by the engine after it
- *  applies the plan's ordered global effects. A single-store transaction with
- *  cleanup mutations is the degenerate one-entry, one-root case: its
- *  update/delete/unset writes are trigger GROUPS on one node, not passes. */
-type CommitForestSettlement = {
+ *  global trigger groups. A single-store transaction with cleanup mutations is
+ *  the degenerate one-entry, one-root case: its update/delete/unset writes are
+ *  trigger GROUPS on one node, not passes.
+ *
+ *  Global fan-out belongs to the forest and only to the forest — a commit whose
+ *  peers span other stores is by definition multi-store. The two variants below
+ *  make that the only expressible arrangement: without `global` there are no
+ *  peer `globalUpdates` to fold in, and with it the engine populates them from
+ *  `global.apply` before any hook or graph settlement runs. */
+export type LocalForestSettlement = {
     kind: "forest"
     entries: CommitForestEntry[]
+    global: undefined
+    globalUpdates: undefined
+    settle: CommitForestSettleFn
+}
+
+export type GlobalForestSettlement = {
+    kind: "forest"
+    entries: CommitForestEntry[]
+    global: PlannedGlobalEffects
+    /** Phase-two result, populated by the engine before hooks run. */
     globalUpdates: StoreAtomUpdates | undefined
     settle: CommitForestSettleFn
 }
 
-type NoSettlement = {
-    kind: "none"
+export type CommitForestSettlement =
+    | LocalForestSettlement
+    | GlobalForestSettlement
+
+export type NoSettlement = {
+    readonly kind: "none"
 }
 
-type CommitSettlement =
+export type CommitSettlement =
     | UpdateSettlement
     | DeleteSettlement
     | SelectorSettlement
     | CommitForestSettlement
     | NoSettlement
 
-export type PlannedGlobalEffects = {
-    /** Ordered, finalized atom/value/origin descriptors. */
-    sets: DeferredGlobalSet[]
-    /** Metadata attached to peer reports from these effects. */
-    source: StoreChangeSource
-    /** Phase-two result populated by the engine before hooks run. */
-    updates: StoreAtomUpdates | undefined
-    apply: (sets: DeferredGlobalSet[], errors: CommitErrors) => StoreAtomUpdates
+/** The outer commit boundary of a standalone local operation, as ONE
+ *  capability: `begin` and `end` are inseparable, so a plan cannot open a
+ *  boundary it never closes (or promise to close one it never opened). The
+ *  token is the store TREE, which owns the depth counter and listeners.
+ *
+ *  `end` takes `didWork` because a boundary that wraps its own write phase
+ *  cannot know at `begin` whether the commit will produce anything; a false
+ *  answer closes the boundary without announcing a commit. */
+export type CommitBoundary = {
+    begin: (data: StoreData) => StoreTreeRuntime
+    end: (
+        tree: StoreTreeRuntime,
+        swallowErrors: boolean,
+        didWork: boolean,
+    ) => void
 }
 
 /**
@@ -101,17 +144,20 @@ export type PlannedGlobalEffects = {
  * settlement spans more than one trigger group — a cross-scope transaction, a
  * commit with global peers, or a single-store transaction mixing updates with
  * deletes/unsets — models its affected stores through the `forest` settlement
- * (global peer updates ride the settlement so the whole commit stays one
+ * (global peer updates ride the settlement, so the whole commit stays one
  * plan). Ordinary direct global writes, cleanup, reset, async resolution,
  * revalidation, and resetSelf all use the same forest owner when they affect
  * multiple stores.
+ *
+ * Plans are deliberately MUTABLE: the hot shapes reuse one module-static plan
+ * graph per commit, and the engine writes phase-two results back into the
+ * settlement. Legality is therefore enforced by construction (see
+ * `lib/commitPlans.ts`) and re-checked by the dev-only `assertPlanLegal`, not
+ * by freezing.
  */
-export type CommitPlan = {
+type CommitPlanShared = {
     data: StoreData
     settlement: CommitSettlement
-    /** Ordered global fan-out effects, applied by the engine after local values
-     *  are final and before any hook or graph settlement. */
-    globalEffects?: PlannedGlobalEffects
     /** Final stale/cancel/dispose admission check. A false result is a total
      *  no-op: no boundary, apply, hook, settlement, report, or cleanup runs. */
     admit?: () => boolean
@@ -122,18 +168,12 @@ export type CommitPlan = {
     onSets: DeferredOnSet[]
     /** First-error accumulator threaded through phases 3–8; phase 9 rethrows. */
     errors: CommitErrors
-    /** Phase-6 delivery target (undefined = no onChange listener anywhere). */
-    report: ChangeReport | undefined
-    /** Operation-specific report preparation, executed by the shared engine. */
-    beforeSettle?: (report: ChangeReport) => void
     /** Phase-8 cleanup, executed only after successful settlement. */
     afterSettle?: () => void
     /** Flush a report sink after settlement/cleanup. */
     flushReport?: () => void
-    /** Optional outer commit boundary for standalone local operations. The
-     *  token is the store TREE, which owns the depth counter and listeners. */
-    beginCommit?: (data: StoreData) => StoreTreeRuntime
-    endCommit?: (tree: StoreTreeRuntime, swallowErrors: boolean) => void
+    /** Optional paired outer commit boundary for standalone local operations. */
+    boundary?: CommitBoundary
     /** Final lifecycle work that must occur after commit-end boundaries close
      *  but before the first captured error is rethrown (global resetSelf). */
     afterCommit?: () => void
@@ -141,3 +181,22 @@ export type CommitPlan = {
      *  no hooks use false to retain their historical short-circuit behavior. */
     continueAfterError?: boolean
 }
+
+/** The ordinary plan: it may or may not have an onChange delivery target, and
+ *  it never prepares its own record. */
+export type UnreportedCommitPlan = CommitPlanShared & {
+    /** Phase-6 delivery target (undefined = no onChange listener anywhere). */
+    report: ChangeReport | undefined
+    beforeSettle?: undefined
+}
+
+/** A plan whose operation contributes its own change record before settlement.
+ *  `beforeSettle` receives the report, so the delivery target is REQUIRED — an
+ *  optional one would silently discard the preparation. */
+export type ReportingCommitPlan = CommitPlanShared & {
+    report: ChangeReport
+    /** Operation-specific report preparation, executed by the shared engine. */
+    beforeSettle: (report: ChangeReport) => void
+}
+
+export type CommitPlan = UnreportedCommitPlan | ReportingCommitPlan

--- a/packages/valdres/src/types/NonEmpty.ts
+++ b/packages/valdres/src/types/NonEmpty.ts
@@ -1,0 +1,6 @@
+/** A list that carries at least one member. Commit work groups use it so "no
+ *  work" has exactly ONE representation — `undefined`. An empty array can no
+ *  longer masquerade as a group that must be settled, which is what made
+ *  `deleted: []` and `unsetAtoms: []` behave differently for the same
+ *  emptiness. */
+export type NonEmpty<T> = [T, ...T[]]

--- a/packages/valdres/test/build.test.ts
+++ b/packages/valdres/test/build.test.ts
@@ -28,6 +28,28 @@ describe("build output", () => {
         )
     })
 
+    // Companion guard for the engine self-checks — `assertPlanLegal` and the
+    // `commitPlanAllocations` counter. Both observe invariants and costs only
+    // valdres's own code can affect, so they are compiled OUT of the published
+    // bundle rather than shipped behind a runtime flag: build.ts defines
+    // `process.env.VALDRES_ENGINE_SELF_CHECKS` as "off" and the branches fold
+    // to constants a consumer's bundler drops. If that define were ever lost,
+    // the dist would ship both graphs AND unguarded `process.env` reads that
+    // throw on module load in raw browser ESM — so assert every half here,
+    // where a source test cannot see them.
+    test("compiles out the engine self-checks", async () => {
+        const { outdir, ...inMemory } = buildOptions
+        const result = await Bun.build(inMemory)
+        expect(result.success).toBe(true)
+        const code = (
+            await Promise.all(result.outputs.map(output => output.text()))
+        ).join("\n")
+        expect(code).not.toContain("VALDRES_ENGINE_SELF_CHECKS")
+        expect(code).toContain("if (!IS_PROD && false)")
+        expect(code).not.toContain("illegal CommitPlan")
+        expect(code).not.toContain("commitPlanAllocations")
+    })
+
     test("public and adapter entrypoints share one transaction runtime", async () => {
         const { outdir, ...inMemory } = buildOptions
         const result = await Bun.build(inMemory)

--- a/packages/valdres/test/oracle/stateMachine.trace.test.ts
+++ b/packages/valdres/test/oracle/stateMachine.trace.test.ts
@@ -61,18 +61,16 @@ const genStep = (rng: { int: (bound: number) => number }): Step => {
     return { kind: "txn", writes }
 }
 
-/** Assert the invariants that hold on any commit given whether it changed state
- *  and whether the op is a transaction (a txn commits even with no change). */
-const assertStructuralInvariants = (
-    rec: Recorder,
-    changed: boolean,
-    isTxn: boolean,
-) => {
+/** Assert the invariants that hold on any commit, given whether it changed
+ *  state. The op KIND does not enter into it: a direct `set` and a `txn` that
+ *  both write only values the store already holds are equally no-ops, and
+ *  neither commits. */
+const assertStructuralInvariants = (rec: Recorder, changed: boolean) => {
     const events = rec.events
     const commitEnds = events.filter(e => e === "commitEnd")
 
-    if (!changed && !isTxn) {
-        // A no-op direct set does not commit at all.
+    if (!changed) {
+        // Nothing changed, so nothing committed — no boundary, no listener.
         expect(events).toEqual([])
         return
     }
@@ -128,7 +126,7 @@ const runSeed = (seed: number, steps: number) => {
         }
 
         const changed = model.some((v, i) => v !== before[i])
-        assertStructuralInvariants(rec, changed, op.kind === "txn")
+        assertStructuralInvariants(rec, changed)
 
         // Value equivalence: atoms and the derived selector match the model.
         for (let i = 0; i < N; i++) {

--- a/packages/valdres/test/oracle/transactionsSingleStore.trace.test.ts
+++ b/packages/valdres/test/oracle/transactionsSingleStore.trace.test.ts
@@ -60,7 +60,7 @@ const cases: TraceCase<Ctx>[] = [
         },
     },
     {
-        name: "no-op txn (all writes equal) — commits (commitEnd) but reports no change",
+        name: "no-op txn (all writes equal) — does not commit at all",
         build: rec => {
             const s = store()
             const a = tracedAtom(rec, "a", 1)
@@ -78,10 +78,12 @@ const cases: TraceCase<Ctx>[] = [
                 set(states.a, 1) // unchanged
                 set(states.b, 2) // unchanged
             }),
-        // Asymmetry worth pinning: a no-op direct `set` does NOT commit, but a
-        // `txn` opens a commit boundary unconditionally, so commitEnd still
-        // fires once — while no atom changed, so no subscribers and no onChange.
-        trace: ["commitEnd"],
+        // Symmetry worth pinning: a `txn` whose every write is value-equal is
+        // no more a commit than a no-op direct `set`. Its boundary has to be
+        // opened before the write phase can tell, but it closes without
+        // announcing anything — no onSet, no subscriber, no onChange, no
+        // commitEnd.
+        trace: [],
         assert: ({ changes }) => expect(changes).toHaveLength(0),
     },
     {

--- a/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
+++ b/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
@@ -60,6 +60,17 @@ one side of a PR comparison.
 - `commitPlanRuns`: admitted `runCommitPlan` executions. Every single-store
   transaction commit shape (ordinary, hooked, cleanup) must execute exactly one
   plan; scalar direct writes correctly report zero.
+- `commitPlanAllocations`: plan-graph containers — settlements, forest entries
+  and entry lists, global effects, descriptor queues — built through
+  `lib/commitPlans.ts` inside the window. A scalar write (no plan at all), a
+  hooked direct write, and a hook-free transaction commit all report zero: the
+  hook-free bulk shape reuses one module-static plan graph. A direct global
+  write reports exactly `6` — ONE `[atom, value, origin]` descriptor and ONE
+  queue, shared by the ordered global sets and the deferred onSet queue because
+  they describe the same write, plus the forest entry, its list, the global
+  effects, and the settlement. A plan object built as an inline literal at a
+  call site is outside this count. Like `assertPlanLegal`, this counter is an
+  engine self-check and is compiled out of the published bundle.
 
 The collector is an internal optional `StoreData` field. It is attached only for
 one synchronous test/benchmark window, inherited by scopes created during that

--- a/scripts/size-baseline.json
+++ b/scripts/size-baseline.json
@@ -1,42 +1,42 @@
 {
     "dist": {
-        "raw": 287155,
-        "gzip": 53123
+        "raw": 285797,
+        "gzip": 53203
     },
     "distFiles": {
         "adapter-internals/v1.js": {
             "raw": 1015,
-            "gzip": 420
+            "gzip": 417
         },
-        "chunk-nz3eh9tm.js": {
-            "raw": 213459,
-            "gzip": 37613
+        "chunk-pwppbtvj.js": {
+            "raw": 212701,
+            "gzip": 37771
         },
         "index.js": {
-            "raw": 72681,
-            "gzip": 15090
+            "raw": 72081,
+            "gzip": 15015
         }
     },
     "packed": {
-        "raw": 486473,
-        "gzip": 109302
+        "raw": 493321,
+        "gzip": 111782
     },
     "fixtures": {
         "atom": {
-            "raw": 100841,
-            "gzip": 30178
+            "raw": 99848,
+            "gzip": 30348
         },
         "atom-selector-store": {
-            "raw": 101110,
-            "gzip": 30296
+            "raw": 100117,
+            "gzip": 30462
         },
         "all-exports": {
-            "raw": 112940,
-            "gzip": 33891
+            "raw": 111947,
+            "gzip": 34067
         },
         "adapter-internals": {
-            "raw": 80027,
-            "gzip": 23735
+            "raw": 78475,
+            "gzip": 23617
         }
     }
 }


### PR DESCRIPTION
`CommitPlan` documented four rules its type did not enforce, and a direct global write allocated two identical `[atom, value, origin]` triples describing the same write. This makes the illegal states unrepresentable, stops the duplication, and fixes a related `onCommitEnd` inconsistency.

## Legality, now structural

| Was | Now |
|---|---|
| `beginCommit?` + `endCommit?`, independently optional | one `boundary?: CommitBoundary` capability; `activeCommitBoundary()` hands out the module-static pair |
| `plan.globalEffects` + a hopefully-forest settlement | `global` lives **on** the forest settlement as its discriminant; `PlannedGlobalEffects.updates` (a dead mirror of `globalUpdates`) is gone |
| `beforeSettle` guarded at runtime by `&& plan.report` | `ReportingCommitPlan` requires the report it prepares; the runtime guard is deleted |
| `deleted: T[] \| undefined` / `unsetAtoms: T[] \| undefined` | `NonEmpty<T> \| undefined` — which fixes the asymmetry where an empty `deleted` counted as settlement work but an empty `unsetAtoms` did not |

New leaf `src/lib/commitPlans.ts` holds a typed constructor per legal shape (the forest literal was duplicated at eight call sites) plus `assertPlanLegal`. `settle`/`apply` stay injected, so it did **not** join the core SCC — the import-cycle baseline is untouched.

## `onCommitEnd` no longer fires for a commit that produced nothing

A boundary that wraps its own write phase — `reset`, a transaction commit — has to open before it can tell whether anything will change, so it now reports the answer on *close* (`endCommit(tree, swallowErrors, didWork)`), and the tree stays silent when nothing anywhere in the chain committed.

This aligns two shapes with the rest of the API: a `txn` whose every write is value-equal, and a `reset` of an atom already holding its default, are now as quiet as the no-op `set` and no-op `unset` that already were. Nested work still coalesces — a subscriber or `onSet` hook writing during delivery records on the tree and produces exactly one notification.

Two trace oracles pinned the old asymmetry (`transactionsSingleStore` "no-op txn" expected `["commitEnd"]`; `stateMachine` had an `isTxn` escape hatch). Both now require zero events, and five public `store.onCommitEnd` tests cover the new contract in both directions.

## Also

- Settlement work is evaluated **once** per `runCommitPlan` instead of three times — it is final as soon as `apply` and fan-out have run, and one answer gates report preparation, settlement, and cleanup.
- New `commitPlanAllocations` counter gates plan-graph cost per shape: 0 for scalar writes, hooked direct writes, and hook-free transaction commits; 6 for a direct global write (down from 9, via the shared descriptor).
- Both engine self-checks — `assertPlanLegal` and `commitPlanAllocations` — are **compiled out** of the published bundle. A `CommitPlan` is never built by user code, so `build.ts` defines `process.env.VALDRES_ENGINE_SELF_CHECKS` as `"off"` and a consumer's bundler drops both graphs as dead code. `test/build.test.ts` guards the fold.

## What is deliberately not here

A module-static plan graph would take the global write from six objects to four. It measured at **164 gzip bytes (~0.55% of a consumer's `atom` bundle)** plus a reentrancy guard and a seven-field restore, to save two objects on a path that already fans out to N stores and runs user hooks. The bytes lose. The shapes that *do* reuse a static plan — the scalar write (no plan at all) and the hook-free bulk commit — are the ones where per-commit construction would actually show up.

## Verification

- valdres 1198 tests, 33 monorepo packages, both typecheck lanes, trace oracles, retained-memory suites, import-cycle baseline, `gen-readmes --check`, `docs:build` — all green.
- `commitPlan.types.test.ts` proves each illegal plan shape fails to compile; `commitPlans.test.ts` covers every invariant at runtime.
- **Size:** every consumer fixture passes the gate against the **unchanged** baseline — gzip +0.52% to +0.56%, raw −0.9% to −1.9%. The baseline is regenerated only because the packed-tarball measure grew 2.3%, all of it `.d.ts` declarations.
- **Benchmarks:** min-of-3 paired against `origin/main` flagged three >5% movers; min-of-5 resampling collapsed all of them to ≤+3.7% on untouched paths (`sub + unsub` −0.06%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)