### PR TITLE
ci: add a report-only paired benchmark decision model

### DIFF
--- a/.github/workflows/bencher-pr.yml
+++ b/.github/workflows/bencher-pr.yml
@@ -80,23 +80,45 @@ jobs:
             # measurements run in their own process so Promise-heavy warm-up
             # cannot alter Bun's JIT profile for the standard synchronous suite.
             #
-            # Each runtime gets three base/PR pairs in alternating B-P, P-B, B-P
-            # order. Every suite invocation is a fresh process. The converter
-            # gates the SMALLEST of each benchmark's three paired PR/base ratios,
-            # which controls order, thermal, GC, scheduler, and JIT-tier skew.
+            # Measurements come in balanced B-P-P-B blocks. Each block yields two
+            # pairs — (base@1, head@2) and (head@1, base@2) — so head is measured
+            # before base exactly as often as after. A monotonic drift across the
+            # block (thermal, a noisy neighbour ramping, page-cache warming)
+            # enters the two pairs with opposite sign and cancels in the paired
+            # log-ratio, instead of masquerading as a regression the way a
+            # fixed base-then-head order does.
+            #
+            # A round is two blocks = four pairs. Round 1 always runs; rounds 2
+            # and 3 run only for lanes whose PROTECTED benchmarks came back
+            # inconclusive, which is the bounded ladder described in
+            # scripts/PAIRED_DECISION_MODEL.md. The cap is absolute — an
+            # unresolved lane is reported as such rather than retried forever.
+            #
+            # Round 1's first three pairs are additionally written to the
+            # un-prefixed NDJSON files, which are the ONLY input to the shipped
+            # catastrophic gate below. That is exactly the three-pair B-P, P-B,
+            # B-P sequence the gate has always seen, so neither the extra
+            # balancing pair nor any ladder round can dilute its min-of-ratios
+            # statistic.
             #
             # BENCH_VALDRES_ONLY skips the jotai/map reference measurements — the
             # gate is valdres-only, so measuring them here is wasted time. The
             # copied benchmark harness gives both worktrees identical support for
             # this flag and the versioned observation schema.
-            - name: Run interleaved base/PR benchmarks (Bun + Node, 3×)
+            - name: Run balanced base/head blocks with the rerun ladder
+              env:
+                  BENCH_MAX_ROUNDS: "3"
               run: |
                   set -euo pipefail
                   rm -f \
                     /tmp/base_bun.ndjson \
                     /tmp/base_node.ndjson \
                     /tmp/pr_bun.ndjson \
-                    /tmp/pr_node.ndjson
+                    /tmp/pr_node.ndjson \
+                    /tmp/all_base_bun.ndjson \
+                    /tmp/all_base_node.ndjson \
+                    /tmp/all_pr_bun.ndjson \
+                    /tmp/all_pr_node.ndjson
 
                   run_suite() {
                     local pair="$1"
@@ -104,16 +126,17 @@ jobs:
                     local suite="$3"
                     local side="$4"
                     local order="$5"
+                    local gate="$6"
                     local checkout
                     local output
                     local result
 
                     if [[ "$side" == "base" ]]; then
                       checkout="/tmp/base/packages/valdres"
-                      output="/tmp/base_${runtime}.ndjson"
+                      output="base_${runtime}"
                     else
                       checkout="${GITHUB_WORKSPACE}/packages/valdres"
-                      output="/tmp/pr_${runtime}.ndjson"
+                      output="pr_${runtime}"
                     fi
 
                     if [[ "$runtime" == "bun" ]]; then
@@ -124,7 +147,7 @@ jobs:
 
                     (
                       cd "$checkout"
-                      export BENCH_PAIR_ID="${pair}-${runtime}-${suite}"
+                      export BENCH_PAIR_ID="$pair"
                       export BENCH_SIDE="$side"
                       export BENCH_ORDER="$order"
                       export BENCH_SUITE="$suite"
@@ -144,26 +167,87 @@ jobs:
                         BENCH_VALDRES_ONLY=1 NODE_ENV=production \
                           npx vitest run --config vitest.async-bench.config.ts
                       fi
-                      cat "$result" >> "$output"
+                      cat "$result" >> "/tmp/all_${output}.ndjson"
+                      if [[ "$gate" == "1" ]]; then
+                        cat "$result" >> "/tmp/${output}.ndjson"
+                      fi
                     )
                   }
 
-                  for pair in 1 2 3; do
-                    if [[ "$pair" == "2" ]]; then
-                      pair_order=(head base)
-                    else
-                      pair_order=(base head)
-                    fi
+                  # One balanced block: base, head, head, base. Two pairs, `a`
+                  # measured base-first and `b` head-first. Each pair is fed to
+                  # the legacy gate only when its gate flag is 1.
+                  run_block() {
+                    local round="$1" block="$2" runtime="$3" suite="$4"
+                    local gate_a="$5" gate_b="$6"
+                    local a="r${round}b${block}a-${runtime}-${suite}"
+                    local b="r${round}b${block}b-${runtime}-${suite}"
+                    run_suite "$a" "$runtime" "$suite" base 1 "$gate_a"
+                    run_suite "$a" "$runtime" "$suite" head 2 "$gate_a"
+                    run_suite "$b" "$runtime" "$suite" head 1 "$gate_b"
+                    run_suite "$b" "$runtime" "$suite" base 2 "$gate_b"
+                  }
 
-                    for runtime in bun node; do
-                      for suite in standard async; do
-                        order=0
-                        for side in "${pair_order[@]}"; do
-                          order=$((order + 1))
-                          run_suite "$pair" "$runtime" "$suite" "$side" "$order"
-                        done
-                      done
+                  # A round is two blocks = four pairs. In round 1 the FIRST
+                  # THREE pairs — b1a, b1b, b2a — also feed the legacy gate,
+                  # which reproduces its original B-P, P-B, B-P sequence
+                  # exactly. The fourth pair is report-only. Handing the gate a
+                  # fourth ratio would strictly weaken it: min([1.7,1.7,1.7]) is
+                  # 1.7x and blocks, while min([1.7,1.7,1.7,1.0]) is 1.0x and
+                  # passes on the very same three measurements.
+                  run_round() {
+                    local round="$1" runtime="$2" suite="$3"
+                    local gate=0
+                    if [[ "$round" == "1" ]]; then gate=1; fi
+                    run_block "$round" 1 "$runtime" "$suite" "$gate" "$gate"
+                    run_block "$round" 2 "$runtime" "$suite" "$gate" 0
+                  }
+
+                  # The model is report-only, and this step runs under
+                  # `set -euo pipefail` BEFORE the gate steps. An unguarded
+                  # failure here would therefore not just publish nothing — it
+                  # would fail the job and skip the catastrophic gate entirely,
+                  # letting a bug in advisory tooling disable the real check.
+                  # So the analysis is explicitly non-fatal, and the lanes file
+                  # is truncated first: a crashed analysis requests NO reruns
+                  # rather than replaying the previous round's lanes.
+                  analyze() {
+                    : > /tmp/rerun-lanes
+                    if ! BENCH_ROUND="$1" \
+                      BENCH_PAIRED_BASE_BUN=/tmp/all_base_bun.ndjson \
+                      BENCH_PAIRED_HEAD_BUN=/tmp/all_pr_bun.ndjson \
+                      BENCH_PAIRED_BASE_NODE=/tmp/all_base_node.ndjson \
+                      BENCH_PAIRED_HEAD_NODE=/tmp/all_pr_node.ndjson \
+                      BENCH_REPORT_JSON=/tmp/paired-report.json \
+                      BENCH_REPORT_MD=/tmp/paired-report.md \
+                      BENCH_RERUN_LANES_FILE=/tmp/rerun-lanes \
+                        bun run scripts/bench-paired-report.ts > /dev/null; then
+                      echo "::warning::Paired decision report failed for round $1 — continuing, this model does not gate"
+                    fi
+                  }
+
+                  for runtime in bun node; do
+                    for suite in standard async; do
+                      run_round 1 "$runtime" "$suite"
                     done
+                  done
+
+                  # Exactly one analysis per completed round. Arithmetic rather
+                  # than `seq`: BSD seq counts DOWN for `seq 2 1`, so a
+                  # BENCH_MAX_ROUNDS of 1 would silently run rounds 2 and 1 for
+                  # anyone driving this outside GNU coreutils.
+                  completed=1
+                  analyze "$completed"
+                  while [[ "$completed" -lt "$BENCH_MAX_ROUNDS" ]]; do
+                    lanes="$(cat /tmp/rerun-lanes)"
+                    if [[ -z "$lanes" ]]; then break; fi
+                    round=$((completed + 1))
+                    echo "::notice::Round ${round}: adding pairs for ${lanes}"
+                    for lane in $lanes; do
+                      run_round "$round" "${lane%%:*}" "${lane##*:}"
+                    done
+                    completed="$round"
+                    analyze "$completed"
                   done
 
             # Convert both sides with the PR-checkout script. The copied harness
@@ -173,6 +257,12 @@ jobs:
             # median scaled by the smallest of the three paired PR/base ratios.
             # That lets Bencher apply its percentage threshold to the paired
             # statistic directly.
+            #
+            # This is the CATASTROPHIC GATE and it is deliberately unchanged
+            # while the paired decision model is calibrated — same three pairs,
+            # same execution orders, same statistic, same +50% boundary, same
+            # fail-closed conversion. Neither the extra balancing pair nor any
+            # ladder round reaches it.
             # BENCH_EXCLUDE_REFS drops the jotai/map reference sides: they can't
             # regress from a valdres change, so gating them only adds noise
             # (every false positive we saw was a reference bench). They're still
@@ -199,9 +289,26 @@ jobs:
                   BENCH_OUT_NODE=/tmp/pr_node_results.json \
                     bun run scripts/bench-to-bmf.ts
 
+            # Report-only. Publishes the paired decision model's verdicts to the
+            # job summary and never affects the job's result — the gate above and
+            # the one below are the only blocking checks. Ten or so merges of
+            # these reports are what the blocking thresholds will be argued from;
+            # see scripts/PAIRED_DECISION_MODEL.md for the calibration protocol.
+            - name: Publish paired decision report
+              if: always()
+              continue-on-error: true
+              run: |
+                  if [[ ! -f /tmp/paired-report.md ]]; then
+                    echo "_No paired decision report was produced for this run._" \
+                      > /tmp/paired-report.md
+                  fi
+                  cat /tmp/paired-report.md >> "$GITHUB_STEP_SUMMARY"
+
             # Keep compact identity + dispersion diagnostics available when a
             # benchmark flakes or the converter fails closed. Raw Mitata sample
-            # arrays are never serialized into these files.
+            # arrays are never serialized into these files. The all_* files carry
+            # every ladder round; the un-prefixed ones are the gate's round-1
+            # inputs. paired-report.json is the decision record for calibration.
             - name: Upload benchmark observations
               if: always()
               continue-on-error: true
@@ -213,6 +320,12 @@ jobs:
                       /tmp/base_node.ndjson
                       /tmp/pr_bun.ndjson
                       /tmp/pr_node.ndjson
+                      /tmp/all_base_bun.ndjson
+                      /tmp/all_base_node.ndjson
+                      /tmp/all_pr_bun.ndjson
+                      /tmp/all_pr_node.ndjson
+                      /tmp/paired-report.json
+                      /tmp/paired-report.md
                   if-no-files-found: warn
                   retention-days: 14
 
@@ -240,7 +353,7 @@ jobs:
             # Percentage test: alert if a benchmark is >50% slower than the base
             # measurement on THIS runner. Variance-independent and immune to the
             # cross-runner global-slowdown that flaked the old t-test gate. The
-            # minimum of three paired ratios above filters runner interference
+            # minimum of round 1's three paired ratios filters runner interference
             # and accounts for order effects, so +50% is a trustworthy boundary
             # on both lanes. Interference is one-directional (a stall only ever
             # makes a sample slower), so the smallest ratio is the least

--- a/scripts/PAIRED_DECISION_MODEL.md
+++ b/scripts/PAIRED_DECISION_MODEL.md
@@ -1,0 +1,377 @@
+# Paired benchmark decision model
+
+Status: **report-only**. This model publishes verdicts to the PR job summary and
+does not gate. The blocking check is still the `min(head/base)` +50% Bencher
+threshold in `.github/workflows/bencher-pr.yml`.
+
+## Why replace `min(head/base)`
+
+The shipped gate takes the smallest of a benchmark's paired head/base ratios.
+That is a deliberate one-sided filter — runner interference only ever makes a
+sample slower, so the smallest ratio is the least contaminated one — and it
+fixed a real flake problem (#268). What it cannot do is express confidence.
+
+Its failure case is on record: one CI job measured `set(atom, value)` at base
+131/131/131 ns against head 351/351/131 ns. Two of three pairs were 2.7x slow.
+`min` reports **0% change**, because one clean pair is enough to clear it. The
+statistic has no way to say "these three pairs disagree with each other".
+
+The consequences compound:
+
+- A benchmark that is never alerted on is indistinguishable from one that was
+  demonstrated healthy. Absence of an alert is not evidence.
+- Sensitivity is bounded by the noisiest pair, so the boundary has to sit at
+  +50% — far above the regressions worth catching.
+- Adding benchmarks or runtimes silently raises the chance that some row clears
+  by luck, and nothing accounts for it.
+
+## The model
+
+### Measurement protocol
+
+Measurements come in balanced **B-P-P-B blocks**. Each block yields two pairs:
+`(base@1, head@2)` and `(head@1, base@2)`. Head is measured before base exactly
+as often as after, so a monotonic drift across the block — thermal, a noisy
+neighbour ramping up, page cache warming — enters the two pairs with opposite
+sign and cancels in the paired log-ratio. Under the old fixed base-then-head
+order, that drift was indistinguishable from a regression.
+
+One **round** is two blocks, i.e. four pairs per lane, where a lane is one
+(runtime, suite) combination.
+
+### Statistic
+
+For each benchmark, per pair: `r_i = ln(head_i) - ln(base_i)`.
+
+Logs make the statistic symmetric (a 2x regression and a 2x speedup are ±ln 2)
+and turn the multiplicative runner-wide slowdown that motivated relative CB into
+an additive term that pairing removes.
+
+- **Location**: Hodges-Lehmann, the median of the Walsh averages. Chosen by
+  measurement, not assumption — `robust-estimators.test.ts` compares it against
+  the mean, the median and a 20% trimmed mean on the two properties that matter.
+  One stalled pair in four moves the mean by >20% and HL by <3%; on clean data
+  HL scatters less than the median and within 15% of the mean. A 20% trimmed
+  mean trims _nothing_ at four values, so it is the mean exactly where
+  robustness is needed most. HL is the only candidate that wins on both counts.
+- **Dispersion**: the Winsorized (Yuen) standard error, which collapses to
+  `s/sqrt(n)` when the trim count rounds to zero, floored at 0.5% of a
+  log-ratio. The floor matters: four pairs agreeing to the nanosecond do not
+  mean the measurement is exact, only that the timer, the JIT tier and the batch
+  size all held still. Without it, identical samples manufacture unbounded
+  confidence.
+- **Interval**: an exact Student-t tail on the incomplete beta. No bootstrap, no
+  RNG, no clock — a verdict is reproducible from the uploaded NDJSON alone.
+
+### Three outcomes
+
+Every comparison is tested against one relative budget (+10%) in both
+directions:
+
+| outcome         | meaning                                           |
+| :-------------- | :------------------------------------------------ |
+| `regression`    | the effect is above budget, at the adjusted level |
+| `within-budget` | the effect is demonstrably below budget           |
+| `inconclusive`  | the data cannot separate the two                  |
+
+"No alert" and "demonstrated healthy" stop being the same answer. `inconclusive`
+is a first-class result, not a failure — it is what drives the rerun ladder.
+
+A comparison whose log-ratios split into two clusters separated by one dominant
+gap is flagged **bimodal** and never receives a verdict, because no single
+number summarises two process states. The historical 131/351 vector lands here:
+reported as `+109%, bimodal, inconclusive` instead of `0%`.
+
+The bimodality test is a minority _share_, never an absolute count. Two deviant
+pairs out of three are two process states; the same two out of twelve are two
+stalls the robust estimator already absorbs. An absolute threshold would latch,
+and a lane contaminated in round 1 could never be cleared by rerunning.
+
+### Protected set and the timing floor
+
+`lib/bench-protected-set.ts` holds eleven decision-bearing benchmarks, one
+aggregated workload per subsystem. Everything else is informational — measured,
+plotted, reported, never blocking.
+
+Independently, any comparison whose base measurement is below **1000 ns** is
+demoted to informational whatever the set says. A +10% budget on a 131 ns
+operation lands inside the JIT-tier and timer noise; that is not a threshold
+anyone can defend. Each demoted operation maps to the aggregated equivalent that
+exercises the same hot path thousands of times per sample — `store.get(atom)` to
+`get 1000 atoms`, `sub + unsub` to
+`subscribe + unsubscribe 100 shared selector pairs`, and so on. The map is
+enforced by a test that fails if an aggregate is renamed out from under it, so
+demotion cannot quietly become a blind spot.
+
+The same floor applies to the **blocking** converter, not just this report.
+`BENCH_EXCLUDE_TINY` previously consulted only a hand-curated name list, which
+had drifted: `set(atom, value)` (~110 ns), `set(atom, curr => curr+1)`,
+`set(atom) with 10 subs`, `sub + unsub` and `createStore` were all
+sub-microsecond and all still blocking — and the first two are exactly the rows
+that flaked the gate on unrelated PRs. The floor closes that gap and stays
+closed as benchmarks are added. In the paired path the floor is evaluated once,
+from the **base** side, so a small operation whose head crosses 1000 ns cannot
+produce a base/head name-set mismatch and fail the conversion closed on a real
+finding. A test asserts every mapped raw operation is absent from the blocking
+BMF.
+
+Deterministic operation **counters** would guard these hot paths with no timing
+noise at all. That needs instrumentation in valdres core rather than CI tooling,
+so it is deliberately left to a follow-up.
+
+### Multiple comparisons
+
+p-values are Benjamini-Hochberg adjusted for false discovery rate at 0.05,
+separately within the protected and informational families, and separately per
+direction. The family spans benchmarks _and_ runtimes: 11 benchmarks x 2
+runtimes = 22 protected comparisons.
+
+Keeping the protected set small is what makes this affordable. FDR control
+across 22 comparisons leaves usable power at four to twelve pairs; control
+across all ~120 comparisons in the suite would not.
+
+### The rerun ladder
+
+After each round, any lane holding an inconclusive **protected** comparison gets
+another round of pairs, to a hard cap of 3 rounds (12 pairs). The cap is
+absolute: an unresolved lane is reported as "still inconclusive at the round
+cap", never retried forever.
+
+The Yuen degrees of freedom go 3 → 5 → 7 across the rungs, which is why a round
+is four pairs and not two — at n=6 the degrees of freedom are still 3 and the
+extra pairs buy almost nothing.
+
+Only lanes with protected benchmarks can trigger a rerun. The async suite holds
+none, so it always runs exactly one round.
+
+"Report-only" is enforced in the workflow, not just intended. The analysis step
+runs under `set -euo pipefail` and sits **before** the gate steps, so an
+unguarded throw in this tooling would fail the job and skip the catastrophic
+gate — advisory code taking down the real check. `analyze()` is therefore
+explicitly non-fatal, and it truncates the rerun-lanes file before running so a
+crashed analysis requests **no** reruns rather than replaying the previous
+round's lanes. The publish step tolerates the report never having been written.
+
+The analyzer runs once per round but writes **files only** — it never appends to
+the job summary. Otherwise a three-round job would publish stale round-1 and
+round-2 verdicts above the final one. The workflow's publish step appends the
+last written markdown exactly once.
+
+### What the catastrophic gate sees
+
+The shipped `min(head/base)` +50% gate is preserved exactly, and "exactly" is
+load-bearing. It reads only **round 1's first three pairs** — `b1a`, `b1b`,
+`b2a` — which is the same three-pair B-P, P-B, B-P sequence it has always had.
+Round 1's fourth pair and every ladder round go to the report alone.
+
+Handing it a fourth pair would strictly weaken it, because `min` is monotone
+decreasing in the number of pairs: `min([1.7, 1.7, 1.7])` is 1.7× and blocks,
+while `min([1.7, 1.7, 1.7, 1.0])` is 1.0× and passes on the very same three
+measurements. An earlier revision of this work did exactly that and described it
+as "marginally more permissive". It was not marginal, and preserving a backstop
+means preserving it.
+
+## Operating characteristics
+
+Generated from the model, one true effect embedded in a family of 22. The
+assertions in `lib/paired-decision.test.ts` lock the load-bearing rows.
+
+**Pair-to-pair jitter ±1%**
+
+| true effect | 4 pairs (round 1) | 8 pairs (round 2) | 12 pairs (round 3) |
+| :---------- | :---------------- | :---------------- | :----------------- |
+| -30%        | within budget     | within budget     | within budget      |
+| +0%         | within budget     | within budget     | within budget      |
+| +5%         | within budget     | within budget     | within budget      |
+| +10%        | inconclusive      | inconclusive      | inconclusive       |
+| +15%        | regression        | regression        | regression         |
+| +20%        | regression        | regression        | regression         |
+| +50%        | regression        | regression        | regression         |
+
+**Pair-to-pair jitter ±3%**
+
+| true effect | 4 pairs (round 1) | 8 pairs (round 2) | 12 pairs (round 3) |
+| :---------- | :---------------- | :---------------- | :----------------- |
+| -30%        | within budget     | within budget     | within budget      |
+| +0%         | within budget     | within budget     | within budget      |
+| +5%         | inconclusive      | within budget     | within budget      |
+| +10%        | inconclusive      | inconclusive      | inconclusive       |
+| +15%        | inconclusive      | inconclusive      | regression         |
+| +20%        | inconclusive      | regression        | regression         |
+| +50%        | regression        | regression        | regression         |
+
+**Pair-to-pair jitter ±6%**
+
+| true effect | 4 pairs (round 1) | 8 pairs (round 2) | 12 pairs (round 3) |
+| :---------- | :---------------- | :---------------- | :----------------- |
+| -30%        | within budget     | within budget     | within budget      |
+| +0%         | inconclusive      | within budget     | within budget      |
+| +5%         | inconclusive      | inconclusive      | inconclusive       |
+| +10%        | inconclusive      | inconclusive      | inconclusive       |
+| +15%        | inconclusive      | inconclusive      | inconclusive       |
+| +20%        | inconclusive      | inconclusive      | regression         |
+| +50%        | regression        | regression        | regression         |
+
+### False positives
+
+Measured where it is actually hard: with the true effect sitting exactly **on**
+the +10% budget, so every `regression` verdict is a false one. The ladder is
+simulated faithfully — twelve pairs drawn once per row, round `r` analysing the
+first `4r` of them — so the nested looks are included in the rate. 400 trials of
+a 22-row family.
+
+| jitter | false regressions (per comparison) | jobs with ≥1 false block |
+| :----- | ---------------------------------: | -----------------------: |
+| ±1%    |                             0.00 % |                    0.0 % |
+| ±3%    |                             0.08 % |                    1.5 % |
+| ±6%    |                             0.28 % |                    5.3 % |
+| ±12%   |                             0.32 % |                    5.8 % |
+
+`paired-decision.test.ts` asserts these bounds, so the table cannot drift away
+from the code.
+
+Note what this is **not**: an earlier version of this table measured at effect
+`0`, ten points away from the boundary, and reported 0% everywhere. That is an
+easy null and it proves nothing. The numbers above are the honest ones.
+
+Per-comparison type-I error runs 15–60× **below** the nominal 5% FDR. The FDR
+level is therefore an upper design target, not an exact guarantee — see "Known
+approximations" below.
+
+### False negatives
+
+Read the tables downward, not across. The honest summary:
+
+- **+50% is always caught**, at the minimum pair count, at every jitter level.
+  This is the range the current +50% gate claims, and the model matches it
+  without the 131/351 blind spot.
+- **+20% needs a quiet runner or one ladder round.**
+- **+15% needs the full ladder at ±3% jitter and is not reachable at ±6%.**
+- **+10% is never called**, because it _is_ the budget. Refusing to separate an
+  effect from the boundary it sits on is correct, not a miss.
+- **A +5% regression is invisible.** The model does not claim otherwise.
+
+The binding constraint below ~15% is the 0.5% standard-error floor combined with
+four to twelve pairs. Buying more sensitivity means more pairs (linear CI cost)
+or quieter measurement, not a different estimator.
+
+### Known approximations
+
+Stated plainly, because the model's output looks more exact than it is.
+
+**The test statistic is not exactly t-distributed.** It pairs a Hodges-Lehmann
+location with a Winsorized (Yuen) standard error shaped for a trimmed mean, plus
+an efficiency correction, and reads the tail off a Student-t. That combination
+is an approximation at 4–12 pairs, not an identity. So the 0.05 FDR is a design
+target, and the measured type-I error above — 0.00–0.32% at the boundary — is
+the number that should be trusted. It is conservative, by 15–60×.
+
+**Why not exact permutation inference instead.** A paired sign-flip test on `n`
+pairs cannot produce a one-sided p-value below `2^-n`, and BH across the 22-row
+protected family needs the smallest p to clear `0.05 / 22 = 2.3e-3`:
+
+| pairs | smallest attainable p | can it ever call a regression? |
+| ----: | --------------------: | :----------------------------- |
+|     4 |                6.3e-2 | no                             |
+|     6 |                1.6e-2 | no                             |
+|     8 |                3.9e-3 | no                             |
+|    12 |                2.4e-4 | yes                            |
+
+Exact inference would make rounds 1 and 2 structurally incapable of reporting a
+regression of _any_ size — a 10× slowdown at four pairs would be `inconclusive`.
+That trade buys exactness in a regime where the approximation is already
+conservative, and pays for it with the model's entire early-detection ability.
+`paired-decision.test.ts` locks this arithmetic, so if the protected family ever
+shrinks enough to change the answer, the choice gets revisited.
+
+**Sequential looks.** The ladder analyses after each round and stops when
+nothing is inconclusive, which is optional stopping and inflates type-I error in
+principle. Measured, the inflation is nil — a false call is driven by the drawn
+pairs and persists across looks:
+
+| jitter | fixed n=4 | fixed n=12 | ladder (3 looks) |
+| :----- | --------: | ---------: | ---------------: |
+| ±3%    |    0.01 % |     0.08 % |           0.08 % |
+| ±6%    |    0.17 % |     0.28 % |           0.28 % |
+| ±12%   |    0.19 % |     0.32 % |           0.32 % |
+
+The ladder is indistinguishable from a fixed terminal sample size. Two
+alternatives were measured and rejected:
+
+- **Alpha-spending (`α/3` across looks)** cuts the boundary error to 0.00–0.07%
+  but costs 15–30 points of detection at +15% and +20%, and drops +15% detection
+  at ±1% jitter from 84% to 1%. Not worth it against an error rate already far
+  below nominal — but it is the lever to pull first if calibration shows real
+  jitter at or above ±6%.
+- **Confirm-on-regression** (continue the ladder while any row reads
+  `regression`, so blocking calls only happen at terminal `n`) measured
+  _identical_ type-I error, while costing power and forcing all three rounds
+  every time. No benefit.
+
+These are decisions made against measurements, and the measurements are cheap to
+rerun. If real-world jitter turns out worse than ±6%, revisit them in that
+order.
+
+### Runtime cost
+
+Counted in suite invocations, which is the only part that is not
+runner-dependent:
+
+|                                         | invocations |
+| :-------------------------------------- | ----------: |
+| previous (3 alternating pairs)          |          24 |
+| round 1 (2 balanced blocks x 4 lanes)   |          32 |
+| each ladder round (standard lanes only) |          16 |
+| worst case (cap reached)                |          64 |
+
+So a quiet PR costs ~33% more benchmark time than before, and a fully
+inconclusive one costs ~2.7x. If PR latency becomes the binding constraint, the
+round cap is the first knob to turn — it is a single env value in the workflow.
+
+Wall-clock is deliberately not quoted here; read it off the first calibration
+runs rather than trusting an estimate.
+
+## Calibration protocol
+
+Run report-only for **approximately ten merges** before proposing blocking
+thresholds. Each PR job uploads `paired-report.json` in the
+`benchmark-observations` artifact; that is the decision record.
+
+For each merge, collect:
+
+1. **Outcome mix on the protected set.** How many rows land `within-budget` on a
+   PR that changed nothing relevant? If that is not the large majority, the
+   budget or the pair count is wrong.
+2. **Ladder engagement.** How often does round 2 or 3 fire, and for which lanes?
+   Persistent engagement on one benchmark means that benchmark is too noisy to
+   protect and belongs in the informational set.
+3. **Rows that reach the cap still inconclusive.** These are the model's real
+   cost. A benchmark that never resolves is not gateable at any threshold.
+4. **Disagreements with the catastrophic gate.** Both run on every PR. A `min`
+   alert with a `within-budget` verdict, or a `regression` verdict the gate
+   missed, is the most informative event available — record both directions.
+5. **Observed pair-to-pair jitter** per protected benchmark, from `logRatios` in
+   the JSON. This is what selects the correct row in the tables above, and it is
+   currently the least-known input to the whole design.
+
+Only after that evidence exists should the blocking proposal be written. It
+needs to state the budget, which benchmarks block, and the expected false-block
+rate per 100 PRs derived from the collected reports — not from the synthetic
+corpus.
+
+Do not enable blocking and adjust the budget in the same change.
+
+## Notes for future work
+
+**Mitata batch size.** The model does not tune it. If adaptive batch sizing is
+ever added, the batch size must be a _positive multiple of Mitata's unroll
+factor_ — a value that rounds to zero timed calls per batch yields a meaningless
+sample rather than an error. Until then, each pair reports the batch size Mitata
+chose on both sides, and a materially different choice between base and head is
+surfaced as a `batch-size-shift` flag. That flag is reported and never decisive:
+Mitata derives batch size from measured duration, so a genuine regression can
+legitimately move it, and suppressing a finding on that basis would hide exactly
+what is being looked for.
+
+**Counters.** See the protected-set section — deterministic operation counts
+would guard the nanosecond hot paths with no timing noise at all.

--- a/scripts/bench-paired-report.test.ts
+++ b/scripts/bench-paired-report.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test"
+import { buildComparisons, renderReport } from "./bench-paired-report"
+import { decidePairedRun } from "./lib/paired-decision"
+import type { BenchmarkObservation } from "./lib/read-bench-results"
+
+function observation(
+    benchmark: string,
+    p50: number,
+    overrides: Partial<BenchmarkObservation> = {},
+): BenchmarkObservation {
+    const side = overrides.side ?? "base"
+    return {
+        schemaVersion: 2,
+        kind: "latency",
+        unit: "ns",
+        benchmark,
+        pairId: "p1",
+        side,
+        order: side === "base" ? 1 : 2,
+        runtime: "bun",
+        suite: "standard",
+        runId: `${side}-${overrides.pairId ?? "p1"}`,
+        processId: 1,
+        p25: p50 * 0.8,
+        p50,
+        p75: p50 * 1.2,
+        p99: p50 * 1.5,
+        ticks: 1000,
+        sampleCount: 100,
+        ...overrides,
+    }
+}
+
+function paired(
+    benchmark: string,
+    values: Array<[number, number]>,
+    overrides: Partial<BenchmarkObservation> = {},
+) {
+    const base: BenchmarkObservation[] = []
+    const head: BenchmarkObservation[] = []
+    values.forEach(([baseNs, headNs], index) => {
+        const pairId = `p${index}`
+        base.push(
+            observation(benchmark, baseNs, {
+                ...overrides,
+                pairId,
+                side: "base",
+            }),
+        )
+        head.push(
+            observation(benchmark, headNs, {
+                ...overrides,
+                pairId,
+                side: "head",
+            }),
+        )
+    })
+    return { base, head }
+}
+
+describe("buildComparisons", () => {
+    test("pairs by explicit identity, not by file position", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_100],
+            [10_000, 10_050],
+            [10_000, 9_950],
+            [10_000, 10_020],
+        ])
+        const [comparison] = buildComparisons(base, [...head].reverse())
+        expect(comparison.samples).toHaveLength(4)
+        expect(comparison.family).toBe("protected")
+        for (const sample of comparison.samples) {
+            expect(sample.baseNs).toBe(10_000)
+        }
+    })
+
+    test("records a missing side instead of throwing", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_100],
+            [10_000, 10_050],
+            [10_000, 9_950],
+        ])
+        const [comparison] = buildComparisons(base, head.slice(0, 2))
+        expect(comparison.samples).toHaveLength(2)
+        expect(comparison.unpairedBase).toBe(1)
+        expect(comparison.unpairedHead).toBe(0)
+    })
+
+    test("demotes a sub-microsecond benchmark to informational", () => {
+        const { base, head } = paired("set(atom, value) / valdres", [
+            [131, 351],
+            [131, 351],
+            [131, 131],
+        ])
+        const [comparison] = buildComparisons(base, head)
+        expect(comparison.family).toBe("informational")
+        expect(comparison.subMicrosecond).toBe(true)
+    })
+
+    test("renders a comparison that lost every pair without NaN", () => {
+        const { base } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_000],
+            [10_000, 10_000],
+        ])
+        const decisions = decidePairedRun(buildComparisons(base, []))
+        expect(decisions[0].pairs).toBe(0)
+        const markdown = renderReport(decisions, {
+            round: 1,
+            maxRounds: 3,
+            rerunLanes: [],
+        })
+        expect(markdown).not.toContain("NaN")
+    })
+
+    test("keeps runtimes and suites as separate comparisons", () => {
+        const bun = paired("get 1000 atoms / valdres", [[10_000, 10_000]])
+        const node = paired("get 1000 atoms / valdres", [[20_000, 20_000]], {
+            runtime: "node",
+        })
+        const comparisons = buildComparisons(
+            [...bun.base, ...node.base],
+            [...bun.head, ...node.head],
+        )
+        expect(comparisons).toHaveLength(2)
+        expect(comparisons.map(c => c.runtime).sort()).toEqual(["bun", "node"])
+    })
+
+    test("carries Mitata's batch size through for the regime diagnostic", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_000],
+        ])
+        const [comparison] = buildComparisons(base, head)
+        expect(comparison.samples[0].baseBatchSize).toBe(10)
+        expect(comparison.samples[0].headBatchSize).toBe(10)
+    })
+
+    test("the historical stall vector survives to the report as a flag", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [131_000, 351_000],
+            [131_000, 351_000],
+            [131_000, 131_000],
+        ])
+        const [decision] = decidePairedRun(buildComparisons(base, head))
+        expect(decision.flags).toContain("bimodal")
+        expect(decision.outcome).toBe("inconclusive")
+    })
+})
+
+describe("renderReport", () => {
+    test("states that it does not gate and names the surviving gate", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_000],
+            [10_000, 10_010],
+            [10_000, 9_990],
+            [10_000, 10_005],
+        ])
+        const markdown = renderReport(
+            decidePairedRun(buildComparisons(base, head)),
+            { round: 1, maxRounds: 3, rerunLanes: [] },
+        )
+        expect(markdown).toContain("report-only")
+        expect(markdown).toContain("min(head/base)")
+        expect(markdown).toContain("get 1000 atoms / valdres")
+        expect(markdown).toContain("within-budget")
+    })
+
+    test("names the lanes it is asking to rerun", () => {
+        const { base, head } = paired("get 1000 atoms / valdres", [
+            [10_000, 10_000],
+        ])
+        const markdown = renderReport(
+            decidePairedRun(buildComparisons(base, head)),
+            { round: 2, maxRounds: 3, rerunLanes: ["bun:standard"] },
+        )
+        expect(markdown).toContain("bun:standard")
+        expect(markdown).toContain("round **2/3**")
+    })
+})

--- a/scripts/bench-paired-report.ts
+++ b/scripts/bench-paired-report.ts
@@ -1,0 +1,326 @@
+/**
+ * Report-only paired benchmark analysis.
+ *
+ * Reads the base and head observation NDJSON for both runtimes, pairs them by
+ * explicit pair identity, runs the decision model in scripts/lib/paired-decision.ts,
+ * and writes a markdown report plus a machine-readable JSON artifact. It never
+ * fails the job: the shipped `min(head/base)` +50% Bencher gate remains the only
+ * blocking check while this model is calibrated against real merges.
+ *
+ * Its one side effect on CI control flow is the rerun-lanes file, which asks the
+ * workflow to append more pairs to lanes whose PROTECTED benchmarks came back
+ * inconclusive — bounded by BENCH_MAX_ROUNDS. It writes files only; the
+ * workflow decides what reaches the job summary.
+ *
+ *   BENCH_PAIRED_BASE_BUN / _NODE   base observations (required, per runtime)
+ *   BENCH_PAIRED_HEAD_BUN / _NODE   head observations (required, per runtime)
+ *   BENCH_REPORT_JSON               JSON artifact path
+ *   BENCH_REPORT_MD                 markdown path the publish step appends
+ *   BENCH_ROUND / BENCH_MAX_ROUNDS  position in the rerun ladder
+ */
+import { writeFileSync } from "fs"
+import {
+    isProtected,
+    isSubMicrosecond,
+    TIMING_FLOOR_NS,
+} from "./lib/bench-protected-set"
+import { median } from "./lib/median"
+import {
+    DEFAULT_PAIRED_POLICY,
+    decidePairedRun,
+    lanesNeedingRerun,
+    type PairedComparison,
+    type PairedDecision,
+    type PairedSample,
+} from "./lib/paired-decision"
+import {
+    BENCHMARK_RESULT_SCHEMA_VERSION,
+    readBenchResults,
+    type BenchmarkObservation,
+    type BenchResult,
+} from "./lib/read-bench-results"
+
+function requireObservations(
+    results: BenchResult[],
+    source: string,
+): BenchmarkObservation[] {
+    if (
+        results.some(
+            result =>
+                !("schemaVersion" in result) ||
+                result.schemaVersion !== BENCHMARK_RESULT_SCHEMA_VERSION,
+        )
+    ) {
+        throw new Error(
+            `${source}: paired analysis requires schemaVersion ${BENCHMARK_RESULT_SCHEMA_VERSION} observations`,
+        )
+    }
+    return results as BenchmarkObservation[]
+}
+
+function batchSize(observation: BenchmarkObservation): number {
+    return observation.ticks / observation.sampleCount
+}
+
+/**
+ * Group observations into per-benchmark comparisons. Unlike the strict gate
+ * converter this tolerates a missing side: a dropped pair is recorded and the
+ * remaining pairs are analysed, because losing one process block should widen
+ * the interval rather than fail the whole report.
+ */
+export function buildComparisons(
+    baseObservations: BenchmarkObservation[],
+    headObservations: BenchmarkObservation[],
+): PairedComparison[] {
+    type Slot = { base?: BenchmarkObservation; head?: BenchmarkObservation }
+    const groups = new Map<
+        string,
+        {
+            benchmark: string
+            runtime: string
+            suite: string
+            pairs: Map<string, Slot>
+        }
+    >()
+
+    for (const observation of [...baseObservations, ...headObservations]) {
+        const key = [
+            observation.benchmark,
+            observation.runtime,
+            observation.suite,
+        ].join("\u0000")
+        let group = groups.get(key)
+        if (!group) {
+            group = {
+                benchmark: observation.benchmark,
+                runtime: observation.runtime,
+                suite: observation.suite,
+                pairs: new Map(),
+            }
+            groups.set(key, group)
+        }
+        const slot = group.pairs.get(observation.pairId) ?? {}
+        if (slot[observation.side] !== undefined) {
+            console.warn(
+                `Duplicate ${observation.side} observation for ${observation.benchmark} in pair ${observation.pairId} — keeping the first`,
+            )
+        } else {
+            slot[observation.side] = observation
+        }
+        group.pairs.set(observation.pairId, slot)
+    }
+
+    const comparisons: PairedComparison[] = []
+    for (const group of groups.values()) {
+        const samples: PairedSample[] = []
+        let unpairedBase = 0
+        let unpairedHead = 0
+        for (const [pairId, slot] of group.pairs) {
+            if (slot.base && slot.head) {
+                samples.push({
+                    pairId,
+                    baseNs: slot.base.p50,
+                    headNs: slot.head.p50,
+                    baseBatchSize: batchSize(slot.base),
+                    headBatchSize: batchSize(slot.head),
+                })
+            } else if (slot.base) unpairedBase++
+            else unpairedHead++
+        }
+        if (samples.length === 0 && unpairedBase + unpairedHead === 0) continue
+
+        const baseCenter =
+            samples.length > 0
+                ? median(samples.map(sample => sample.baseNs))
+                : Number.POSITIVE_INFINITY
+        comparisons.push({
+            benchmark: group.benchmark,
+            runtime: group.runtime,
+            suite: group.suite,
+            family: isProtected(group.benchmark, baseCenter)
+                ? "protected"
+                : "informational",
+            samples,
+            unpairedBase,
+            unpairedHead,
+            subMicrosecond: isSubMicrosecond(baseCenter),
+        })
+    }
+
+    return comparisons.sort(
+        (a, b) =>
+            a.benchmark.localeCompare(b.benchmark) ||
+            a.runtime.localeCompare(b.runtime),
+    )
+}
+
+const OUTCOME_MARK = {
+    regression: "🔴",
+    "within-budget": "🟢",
+    inconclusive: "⚪",
+} as const
+
+function pct(value: number): string {
+    // A comparison can lose every pair — one side crashed, or the benchmark is
+    // new on head — and then there is no estimate to render.
+    if (!Number.isFinite(value)) return "—"
+    return `${value >= 0 ? "+" : ""}${(value * 100).toFixed(1)}%`
+}
+
+function row(decision: PairedDecision): string {
+    const interval = decision.intervalPct
+        ? `${pct(decision.intervalPct[0])} … ${pct(decision.intervalPct[1])}`
+        : "—"
+    const q =
+        decision.outcome === "regression"
+            ? decision.regressionQ
+            : decision.withinBudgetQ
+    const flags = decision.flags.length > 0 ? decision.flags.join(", ") : ""
+    return `| ${OUTCOME_MARK[decision.outcome]} ${decision.outcome} | \`${decision.benchmark}\` | ${decision.runtime} | ${decision.pairs} | ${pct(decision.estimatePct)} | ${interval} | ${Number.isFinite(q) ? q.toExponential(1) : "—"} | ${flags} |`
+}
+
+const TABLE_HEAD = [
+    "| outcome | benchmark | runtime | pairs | estimate | 90% interval | q | flags |",
+    "|:--|:--|:--|--:|--:|:--|--:|:--|",
+].join("\n")
+
+export function renderReport(
+    decisions: PairedDecision[],
+    context: { round: number; maxRounds: number; rerunLanes: string[] },
+): string {
+    const protectedRows = decisions.filter(d => d.family === "protected")
+    const informational = decisions.filter(d => d.family === "informational")
+    const tally = (rows: PairedDecision[]) => {
+        const counts = { regression: 0, "within-budget": 0, inconclusive: 0 }
+        for (const decision of rows) counts[decision.outcome]++
+        return counts
+    }
+    const counts = tally(protectedRows)
+    const budget = `${(DEFAULT_PAIRED_POLICY.budgetPct * 100).toFixed(0)}%`
+
+    const lines = [
+        "## Paired benchmark decision model (report-only)",
+        "",
+        `Budget **+${budget}**, FDR **${DEFAULT_PAIRED_POLICY.falseDiscoveryRate}**, estimator **${DEFAULT_PAIRED_POLICY.estimator}**, round **${context.round}/${context.maxRounds}**.`,
+        "",
+        `Protected: ${counts.regression} regression, ${counts["within-budget"]} within budget, ${counts.inconclusive} inconclusive.`,
+        "",
+        "This model does not gate. The blocking check remains the `min(head/base)`",
+        "+50% catastrophic gate. See `scripts/PAIRED_DECISION_MODEL.md`.",
+        "",
+        "### Protected",
+        "",
+        TABLE_HEAD,
+        ...protectedRows.map(row),
+    ]
+
+    const stalled = decisions.filter(
+        decision =>
+            decision.family === "protected" &&
+            decision.outcome === "inconclusive",
+    )
+    if (context.rerunLanes.length > 0) {
+        lines.push(
+            "",
+            `Requesting more pairs for: ${context.rerunLanes.map(lane => `\`${lane}\``).join(", ")}.`,
+        )
+    } else if (stalled.length > 0) {
+        lines.push(
+            "",
+            `Still inconclusive at the round cap: ${stalled.map(d => `\`${d.benchmark}\` (${d.runtime})`).join(", ")}.`,
+        )
+    }
+
+    const notable = informational.filter(
+        decision =>
+            decision.outcome === "regression" ||
+            decision.flags.includes("bimodal"),
+    )
+    lines.push(
+        "",
+        "### Informational",
+        "",
+        `${informational.length} comparisons, not decision-bearing (below the ${TIMING_FLOOR_NS}ns timing floor, a reference implementation, or outside the protected set).`,
+        "",
+    )
+    if (notable.length > 0) {
+        lines.push(
+            "Flagged for attention:",
+            "",
+            TABLE_HEAD,
+            ...notable.map(row),
+        )
+    } else {
+        lines.push("Nothing flagged.")
+    }
+
+    return lines.join("\n") + "\n"
+}
+
+function positiveIntEnv(name: string, fallback: number): number {
+    const raw = process.env[name]
+    if (raw === undefined || raw === "") return fallback
+    const value = Number(raw)
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`${name} must be a positive integer, received ${raw}`)
+    }
+    return value
+}
+
+if (import.meta.main) {
+    const lanes = [
+        {
+            base: process.env.BENCH_PAIRED_BASE_BUN,
+            head: process.env.BENCH_PAIRED_HEAD_BUN,
+        },
+        {
+            base: process.env.BENCH_PAIRED_BASE_NODE,
+            head: process.env.BENCH_PAIRED_HEAD_NODE,
+        },
+    ]
+
+    const baseObservations: BenchmarkObservation[] = []
+    const headObservations: BenchmarkObservation[] = []
+    for (const lane of lanes) {
+        if (!lane.base || !lane.head) continue
+        baseObservations.push(
+            ...requireObservations(readBenchResults(lane.base), lane.base),
+        )
+        headObservations.push(
+            ...requireObservations(readBenchResults(lane.head), lane.head),
+        )
+    }
+
+    const round = positiveIntEnv("BENCH_ROUND", 1)
+    const maxRounds = positiveIntEnv("BENCH_MAX_ROUNDS", 3)
+    const decisions = decidePairedRun(
+        buildComparisons(baseObservations, headObservations),
+    )
+    // The ladder stops at the cap even with work outstanding; an unbounded
+    // rerun loop is a worse failure than an inconclusive report.
+    const rerunLanes = round < maxRounds ? lanesNeedingRerun(decisions) : []
+    const markdown = renderReport(decisions, { round, maxRounds, rerunLanes })
+
+    const jsonPath = process.env.BENCH_REPORT_JSON
+    if (jsonPath) {
+        writeFileSync(
+            jsonPath,
+            JSON.stringify(
+                { round, maxRounds, policy: DEFAULT_PAIRED_POLICY, decisions },
+                null,
+                2,
+            ),
+        )
+    }
+    const mdPath = process.env.BENCH_REPORT_MD
+    if (mdPath) writeFileSync(mdPath, markdown)
+    // The ladder driver in bencher-pr.yml reads this between rounds. Always
+    // written, so a stale file from the previous round can never be re-read.
+    const lanesPath = process.env.BENCH_RERUN_LANES_FILE
+    if (lanesPath) writeFileSync(lanesPath, rerunLanes.join(" "))
+    // Deliberately NOT appended to GITHUB_STEP_SUMMARY here. The ladder runs
+    // this once per round, so appending would leave the summary holding stale
+    // round-1 and round-2 verdicts above the final one. The workflow's publish
+    // step appends the last written markdown exactly once.
+    console.log(markdown)
+}

--- a/scripts/bench-to-bmf.test.ts
+++ b/scripts/bench-to-bmf.test.ts
@@ -140,10 +140,12 @@ describe("bench-to-bmf", () => {
     })
 
     test("preserves PR filtering without requiring normalization", () => {
+        // Latencies are realistic: `get 1000 atoms` is ~9.4µs, the rest are the
+        // nanosecond-scale raw operations the gate must not block on.
         const bmf = toBmf(
             [
-                latency("get 1000 atoms / valdres", 100),
-                latency("get 1000 atoms / jotai", 200),
+                latency("get 1000 atoms / valdres", 9_400),
+                latency("get 1000 atoms / jotai", 573_700),
                 latency("store.get(atom) / valdres", 20),
                 latency("atomFamily(id) / valdres", 150),
                 latency("selectorFamily(id) / valdres", 300),
@@ -152,8 +154,52 @@ describe("bench-to-bmf", () => {
         )
 
         expect(bmf).toEqual({
-            "get 1000 atoms / valdres": { latency: { value: 100 } },
+            "get 1000 atoms / valdres": { latency: { value: 9_400 } },
         })
+    })
+
+    test("excludeTiny blocks nothing below the timing floor", () => {
+        // The hand-curated UNGATEABLE_OPS list omitted these; every one is a
+        // sub-microsecond raw operation, and `set(atom, value)` / `sub + unsub`
+        // are the rows that historically flaked the gate on unrelated PRs.
+        const tiny = [
+            latency("set(atom, value) / valdres", 110),
+            latency("set(atom, curr => curr+1) / valdres", 99),
+            latency("set(atom) with 10 subs / valdres", 141),
+            latency("sub + unsub / valdres", 249),
+            latency("createStore / valdres", 286),
+        ]
+        const bmf = toBmf(
+            [...tiny, latency("set 1000 atoms / valdres", 73_400)],
+            {
+                excludeRefs: true,
+                excludeTiny: true,
+            },
+        )
+
+        expect(Object.keys(bmf)).toEqual(["set 1000 atoms / valdres"])
+    })
+
+    test("a sub-microsecond op stays out of the paired gate even when head crosses the floor", () => {
+        // Base 900ns, head 1.8µs. Deciding the floor per side would keep the
+        // head row, drop the base row, and fail the conversion closed.
+        const bmf = toPairedBmf(
+            [
+                observation("set(atom, value) / valdres", 900, {
+                    pairId: "p1",
+                    side: "base",
+                }),
+            ],
+            [
+                observation("set(atom, value) / valdres", 1_800, {
+                    pairId: "p1",
+                    side: "head",
+                }),
+            ],
+            { excludeRefs: true, excludeTiny: true },
+        )
+
+        expect(bmf).toEqual({})
     })
 
     test("validates schema version and rejects raw Mitata samples", () => {

--- a/scripts/bench-to-bmf.ts
+++ b/scripts/bench-to-bmf.ts
@@ -20,6 +20,8 @@
  */
 import { writeFileSync } from "fs"
 import { join } from "path"
+import { isSubMicrosecond } from "./lib/bench-protected-set"
+import { isReference, opName } from "./lib/benchmark-names"
 import {
     BENCHMARK_RESULT_SCHEMA_VERSION,
     benchmarkName,
@@ -216,25 +218,11 @@ function validatePairedObservations(
 const ROOT = join(import.meta.dir, "..")
 const PERF_DIR = join(ROOT, "packages/valdres/test/performance")
 
-// A compare() benchmark is named "<op> / <impl>"; the reference sides are any
-// impl other than valdres (jotai, map, recoil, …). Standalone valdres benches
-// (e.g. "scope: set atom, …") have no " / <impl>" suffix.
-function isReference(name: string): boolean {
-    const m = name.match(/ \/ ([^/]+)$/)
-    return m !== null && m[1] !== "valdres"
-}
-
-// The "<op>" part of a benchmark name, dropping any " / <impl>" suffix.
-function opName(name: string): string {
-    const m = name.match(/^(.*) \/ [^/]+$/)
-    return m ? m[1] : name
-}
-
 // Operations too small to gate reliably. Their +50% relative boundary is only
 // nanoseconds to low hundreds of nanoseconds — below the CI runner's JIT and
 // measurement noise even after median-of-3. They remain measured and plotted
 // by the base lane.
-const UNGATEABLE_OPS = new Set([
+export const UNGATEABLE_OPS = new Set([
     "atom(1)", // ~2ns
     "selector(fn)", // ~5ns
     "atomFamily(id)", // ~100-250ns; constructor JIT tier varies by ~100ns
@@ -247,6 +235,21 @@ const UNGATEABLE_OPS = new Set([
     // whose aggregated window is stable enough for a percentage boundary.
     "store.get(atom)",
 ])
+
+/**
+ * Whether a benchmark is too small to gate, given its MEASURED base latency.
+ *
+ * The name list above is hand-curated and was incomplete: `set(atom, value)`
+ * (~110ns), `set(atom, curr => curr+1)`, `set(atom) with 10 subs`,
+ * `sub + unsub` and `createStore` are all sub-microsecond yet were still
+ * blocking — the first two are precisely the rows that flaked the gate on
+ * unrelated PRs. The measured floor closes that gap and stays closed as
+ * benchmarks are added, while the list keeps excluding named operations that
+ * happen to measure above the floor on a slower runtime.
+ */
+function isUngateable(name: string, latencyNs: number): boolean {
+    return UNGATEABLE_OPS.has(opName(name)) || isSubMicrosecond(latencyNs)
+}
 
 // Versioned because changing the control set changes the scale of every metric.
 // If a control ever needs replacing, create a v2 measure instead of silently
@@ -321,7 +324,7 @@ export function toBmf(results: BenchResult[], options: BmfOptions = {}): Bmf {
     const bmf: Bmf = {}
     for (const [name, latency] of latencies) {
         if (excludeRefs && isReference(name)) continue
-        if (excludeTiny && UNGATEABLE_OPS.has(opName(name))) continue
+        if (excludeTiny && isUngateable(name, latency)) continue
 
         const measures: Record<string, Metric> = { latency: { value: latency } }
         // Raw latency remains available for every benchmark and for the public
@@ -368,8 +371,14 @@ export function toPairedBmf(
     const observations = validatePairedObservations([baseResults, headResults])
     const explicitBase = observations.filter(result => result.side === "base")
     const explicitHead = observations.filter(result => result.side === "head")
-    const baseBmf = toBmf(explicitBase, options)
-    const headBmf = toBmf(explicitHead, options)
+    // The timing floor is applied ONCE, from the base side, after both sides are
+    // built. Letting each side decide independently would drop a benchmark whose
+    // base sits below the floor and whose head crosses it — exactly what a large
+    // regression on a small operation looks like — and the name-set mismatch
+    // below would then fail the conversion closed on a real finding.
+    const sideOptions = { ...options, excludeTiny: false }
+    const baseBmf = toBmf(explicitBase, sideOptions)
+    const headBmf = toBmf(explicitHead, sideOptions)
     const baseNames = Object.keys(baseBmf)
     const headNames = Object.keys(headBmf)
     const missingFromHead = baseNames.filter(name => !(name in headBmf))
@@ -401,6 +410,12 @@ export function toPairedBmf(
     }
     const paired: Bmf = {}
     for (const name of baseNames) {
+        if (
+            options.excludeTiny &&
+            isUngateable(name, baseBmf[name].latency.value)
+        ) {
+            continue
+        }
         const benchmarkPairs = [...pairs.values()].filter(
             pair => pair.base?.benchmark === name,
         ) as Array<{

--- a/scripts/benchmark-workflow.test.ts
+++ b/scripts/benchmark-workflow.test.ts
@@ -9,11 +9,95 @@ const workflow = readFileSync(
 
 describe("Bencher PR workflow", () => {
     test("uses the schema's base/head side vocabulary", () => {
-        expect(workflow).toContain("pair_order=(head base)")
-        expect(workflow).toContain("pair_order=(base head)")
         expect(workflow).toContain('export BENCH_SIDE="$side"')
         expect(workflow).not.toContain("pair_order=(pr base)")
         expect(workflow).not.toContain("pair_order=(base pr)")
+    })
+
+    test("measures in balanced B-P-P-B blocks", () => {
+        const block = workflow.match(/run_block\(\) \{[\s\S]*?\n\s*\}/)
+        expect(block).not.toBeNull()
+        const sides = [
+            ...block![0].matchAll(/"\$suite" (base|head) (\d)/g),
+        ].map(match => `${match[1]}@${match[2]}`)
+        // Wall-clock order base, head, head, base — and within each pair the
+        // two sides take execution slots 1 and 2 in opposite order, which is
+        // what cancels a linear drift across the block.
+        expect(sides).toEqual(["base@1", "head@2", "head@1", "base@2"])
+    })
+
+    test("feeds the catastrophic gate exactly three pairs, as before", () => {
+        // `min` is monotone decreasing in pair count, so an extra pair can only
+        // weaken the gate: min([1.7,1.7,1.7]) blocks, min([1.7,1.7,1.7,1.0])
+        // passes. Round 1 gates blocks 1a+1b and 2a only; 2b and every ladder
+        // round are report-only.
+        const round = workflow.match(/run_round\(\) \{[\s\S]*?\n\s*\}/)
+        expect(round).not.toBeNull()
+        expect(round![0]).toContain(
+            'run_block "$round" 1 "$runtime" "$suite" "$gate" "$gate"',
+        )
+        expect(round![0]).toContain(
+            'run_block "$round" 2 "$runtime" "$suite" "$gate" 0',
+        )
+        expect(round![0]).toContain('if [[ "$round" == "1" ]]; then gate=1; fi')
+    })
+
+    test("keeps ladder rounds out of the catastrophic gate's inputs", () => {
+        // The gate reads /tmp/{base,pr}_*.ndjson, written only when a pair's
+        // gate flag is set; every round accumulates into /tmp/all_*.ndjson.
+        expect(workflow).toContain('if [[ "$gate" == "1" ]]; then')
+        expect(workflow).toContain(
+            'cat "$result" >> "/tmp/all_${output}.ndjson"',
+        )
+        expect(workflow).toContain("BENCH_NDJSON_BUN=/tmp/base_bun.ndjson")
+        expect(workflow).toContain("--threshold-upper-boundary 0.5")
+    })
+
+    test("the job summary is appended exactly once, by the workflow", () => {
+        expect(workflow.match(/GITHUB_STEP_SUMMARY/g)).toHaveLength(1)
+        expect(workflow).toContain(
+            'cat /tmp/paired-report.md >> "$GITHUB_STEP_SUMMARY"',
+        )
+    })
+
+    test("bounds the rerun ladder", () => {
+        expect(workflow).toContain('BENCH_MAX_ROUNDS: "3"')
+        expect(workflow).toContain(
+            'while [[ "$completed" -lt "$BENCH_MAX_ROUNDS" ]]',
+        )
+        expect(workflow).toContain("BENCH_RERUN_LANES_FILE=/tmp/rerun-lanes")
+    })
+
+    test("the ladder does not use seq to build its round range", () => {
+        // BSD `seq 2 1` counts DOWN rather than yielding an empty range, so a
+        // BENCH_MAX_ROUNDS of 1 would silently execute rounds 2 and 1 for
+        // anyone driving this outside GNU coreutils.
+        expect(workflow).not.toContain("$(seq")
+    })
+
+    test("a failed analysis cannot fail the job or skip the real gate", () => {
+        // This step runs under `set -euo pipefail` BEFORE the gate steps, so an
+        // unguarded throw in report-only tooling would take the catastrophic
+        // gate down with it.
+        const analyze = workflow.match(/analyze\(\) \{[\s\S]*?\n\s*\}\n/)
+        expect(analyze).not.toBeNull()
+        expect(analyze![0]).toContain("if ! BENCH_ROUND=")
+        expect(analyze![0]).toContain(
+            "::warning::Paired decision report failed",
+        )
+        // Truncated first, so a crashed analysis requests no reruns rather than
+        // replaying the previous round's lanes.
+        expect(analyze![0]).toContain(": > /tmp/rerun-lanes")
+    })
+
+    test("the paired report cannot fail the job", () => {
+        const step = workflow.match(
+            /- name: Publish paired decision report[\s\S]*?\n\n/,
+        )
+        expect(step).not.toBeNull()
+        expect(step![0]).toContain("continue-on-error: true")
+        // Tolerates the report never having been written.
+        expect(step![0]).toContain("if [[ ! -f /tmp/paired-report.md ]]")
     })
 
     test("copies the schema and retains compact observations", () => {
@@ -21,5 +105,6 @@ describe("Bencher PR workflow", () => {
         expect(workflow).toContain("actions/upload-artifact@v4")
         expect(workflow).toContain("/tmp/base_bun.ndjson")
         expect(workflow).toContain("/tmp/pr_node.ndjson")
+        expect(workflow).toContain("/tmp/paired-report.json")
     })
 })

--- a/scripts/lib/bench-protected-set.test.ts
+++ b/scripts/lib/bench-protected-set.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import { readdirSync, readFileSync } from "fs"
+import { join } from "path"
+import { toBmf, UNGATEABLE_OPS } from "../bench-to-bmf"
+import {
+    AGGREGATED_EQUIVALENTS,
+    isProtected,
+    isSubMicrosecond,
+    PROTECTED_OPS,
+    TIMING_FLOOR_NS,
+} from "./bench-protected-set"
+
+const PERF_DIR = join(
+    import.meta.dir,
+    "../../packages/valdres/test/performance",
+)
+const SUITE_SOURCE = readdirSync(PERF_DIR)
+    .filter(file => file.endsWith(".bench.ts") || file.endsWith(".timing.ts"))
+    .map(file => readFileSync(join(PERF_DIR, file), "utf8"))
+    .join("\n")
+
+describe("protected set", () => {
+    test("stays small enough for the FDR adjustment to have power", () => {
+        // 11 benchmarks x 2 runtimes = 22 comparisons; see the characterisation
+        // matrix in paired-decision.test.ts for what that buys at each rung.
+        expect(PROTECTED_OPS.size).toBeLessThanOrEqual(12)
+    })
+
+    test("every protected benchmark still exists in the suite", () => {
+        const missing = [...PROTECTED_OPS].filter(
+            op => !SUITE_SOURCE.includes(op),
+        )
+        expect(missing).toEqual([])
+    })
+
+    test("membership requires clearing the timing floor", () => {
+        expect(isProtected("get 1000 atoms / valdres", 9_400)).toBe(true)
+        expect(isProtected("get 1000 atoms / valdres", 900)).toBe(false)
+        expect(isProtected("get 1000 atoms / jotai", 9_400)).toBe(false)
+        expect(isProtected("set(atom, value) / valdres", 50_000)).toBe(false)
+    })
+
+    test("the floor is what demotes nanosecond operations", () => {
+        expect(isSubMicrosecond(131)).toBe(true)
+        expect(isSubMicrosecond(TIMING_FLOOR_NS)).toBe(false)
+    })
+})
+
+describe("aggregated equivalents", () => {
+    test("every op excluded from the shipped gate has a documented equivalent", () => {
+        const undocumented = [...UNGATEABLE_OPS].filter(
+            op => !(op in AGGREGATED_EQUIVALENTS),
+        )
+        expect(undocumented).toEqual([])
+    })
+
+    test("every named equivalent is itself a protected benchmark", () => {
+        const dangling = Object.entries(AGGREGATED_EQUIVALENTS)
+            .filter(([, aggregate]) => aggregate !== null)
+            .filter(([, aggregate]) => !PROTECTED_OPS.has(aggregate!))
+        expect(dangling).toEqual([])
+    })
+
+    test("every mapped operation still exists in the suite", () => {
+        const missing = Object.keys(AGGREGATED_EQUIVALENTS).filter(
+            op => !SUITE_SOURCE.includes(op),
+        )
+        expect(missing).toEqual([])
+    })
+
+    test("no mapped raw operation can reach the blocking BMF", () => {
+        // Every operation the map calls tiny, measured at its real latency,
+        // must be filtered out of the gate's conversion — the map claiming
+        // coverage is only honest if the raw row is genuinely nonblocking.
+        const measured: Record<string, number> = {
+            "atom(1)": 2,
+            "store.get(atom)": 30,
+            "set(atom, value)": 110,
+            "set(atom, curr => curr+1)": 99,
+            "set(atom) with 10 subs": 141,
+            "sub + unsub": 249,
+            "selector(fn)": 6,
+            "selectorFamily(id)": 205,
+            "selectorFamily(string) cache hit": 31,
+            "atomFamily(id)": 195,
+            "atomFamily(id) cache hit": 13,
+            "atomFamily(string) cache hit": 22,
+            createStore: 286,
+        }
+        expect(Object.keys(measured).sort()).toEqual(
+            Object.keys(AGGREGATED_EQUIVALENTS).sort(),
+        )
+
+        const bmf = toBmf(
+            Object.entries(measured).map(([op, ns]) => ({
+                kind: "latency" as const,
+                name: `${op} / valdres`,
+                ns,
+            })),
+            { excludeRefs: true, excludeTiny: true },
+        )
+        expect(Object.keys(bmf)).toEqual([])
+    })
+
+    test("the nanosecond hot paths named in the flake reports are covered", () => {
+        // `set(atom, value)` and `sub + unsub` are the rows that repeatedly
+        // flaked the shipped gate; both are demoted here and both keep coverage.
+        expect(AGGREGATED_EQUIVALENTS["set(atom, value)"]).toBe(
+            "set 1000 atoms",
+        )
+        expect(AGGREGATED_EQUIVALENTS["sub + unsub"]).toBe(
+            "subscribe + unsubscribe 100 shared selector pairs",
+        )
+        expect(AGGREGATED_EQUIVALENTS["store.get(atom)"]).toBe("get 1000 atoms")
+    })
+})

--- a/scripts/lib/bench-protected-set.ts
+++ b/scripts/lib/bench-protected-set.ts
@@ -1,0 +1,88 @@
+/**
+ * Which benchmarks carry decisions.
+ *
+ * Two rules pick the protected family, and both exist to keep it small:
+ *
+ *  - Explicit membership. The set below is one benchmark per subsystem, chosen
+ *    to be the aggregated workload that a regression in that subsystem has to
+ *    pass through. Everything else in the suite stays informational — measured,
+ *    plotted, reported, never blocking. A small family is also what keeps the
+ *    FDR adjustment in paired-decision.ts affordable at four to twelve pairs.
+ *
+ *  - A timing floor. A raw operation measured in nanoseconds cannot be gated on
+ *    a CI runner: the +10% budget lands inside the JIT-tier and timer noise, and
+ *    the observed failure mode is exactly that (`set(atom, value)` reading
+ *    131/351/131 ns within one job). Those operations are demoted to
+ *    informational automatically, whatever the set says, and their hot path is
+ *    covered by an aggregated equivalent that runs the same code thousands of
+ *    times per sample.
+ */
+import { isReference, opName } from "./benchmark-names"
+
+/** Below this, a single-operation p50 is noise-dominated on a CI runner. */
+export const TIMING_FLOOR_NS = 1_000
+
+/**
+ * One decision-bearing workload per subsystem. Every entry is micro- to
+ * millisecond scale on both runtimes, so the budget sits well clear of the
+ * timing floor.
+ */
+export const PROTECTED_OPS = new Set([
+    "atom lifecycle (create+100get+100set)",
+    "get 1000 atoms",
+    "set 1000 atoms",
+    "set + read 100 selectors",
+    "set + read 100 selectorFamily entries",
+    "atomFamily: txn update 5,000 existing members",
+    "txn: cross-atom 1000 selectors, with subs",
+    "txn: large asymmetric DAG (1000 leaves × 50 chain)",
+    "subscribe + unsubscribe 100 shared selector pairs",
+    "architecture: live graph fan-out 100",
+    "scope: set atom, 1000 scopes (no shadow)",
+])
+
+/**
+ * Where each sub-microsecond operation's hot path is actually gated. The value
+ * is the protected aggregate that exercises the same code, or `null` when the
+ * operation has no aggregated equivalent and is knowingly unguarded.
+ *
+ * This map is the standing argument that demoting tiny benchmarks does not
+ * create a blind spot, and the test beside it fails if an aggregate is renamed
+ * out from under an entry.
+ */
+export const AGGREGATED_EQUIVALENTS: Record<string, string | null> = {
+    "atom(1)": "atom lifecycle (create+100get+100set)",
+    "store.get(atom)": "get 1000 atoms",
+    "set(atom, value)": "set 1000 atoms",
+    "set(atom, curr => curr+1)": "atom lifecycle (create+100get+100set)",
+    "set(atom) with 10 subs": "architecture: live graph fan-out 100",
+    "sub + unsub": "subscribe + unsubscribe 100 shared selector pairs",
+    "selector(fn)": "set + read 100 selectors",
+    "selectorFamily(id)": "set + read 100 selectorFamily entries",
+    "selectorFamily(string) cache hit": "set + read 100 selectorFamily entries",
+    "atomFamily(id)": "atomFamily: txn update 5,000 existing members",
+    "atomFamily(id) cache hit": "atomFamily: txn update 5,000 existing members",
+    "atomFamily(string) cache hit":
+        "atomFamily: txn update 5,000 existing members",
+    // Store construction is not part of any aggregated workload — every other
+    // benchmark builds its store outside the measured region. A regression here
+    // shows up on the base lane's plot, not in the PR decision.
+    createStore: null,
+}
+
+/**
+ * A benchmark is protected when it is a valdres-owned member of the set AND its
+ * base measurement clears the timing floor.
+ */
+export function isProtected(benchmark: string, baseNs: number): boolean {
+    return (
+        !isReference(benchmark) &&
+        PROTECTED_OPS.has(opName(benchmark)) &&
+        baseNs >= TIMING_FLOOR_NS
+    )
+}
+
+/** True when the base measurement is too small to decide on directly. */
+export function isSubMicrosecond(baseNs: number): boolean {
+    return baseNs < TIMING_FLOOR_NS
+}

--- a/scripts/lib/benchmark-names.ts
+++ b/scripts/lib/benchmark-names.ts
@@ -1,0 +1,17 @@
+/**
+ * Benchmark naming rules shared by the BMF converter and the paired decision
+ * report. A `compare()` benchmark is named "<op> / <impl>"; a standalone
+ * `measureOne()` benchmark is just "<op>".
+ */
+
+/** True for the competitor / native-floor side of a `compare()` benchmark. */
+export function isReference(name: string): boolean {
+    const match = name.match(/ \/ ([^/]+)$/)
+    return match !== null && match[1] !== "valdres"
+}
+
+/** The "<op>" part of a benchmark name, dropping any " / <impl>" suffix. */
+export function opName(name: string): string {
+    const match = name.match(/^(.*) \/ [^/]+$/)
+    return match ? match[1] : name
+}

--- a/scripts/lib/paired-decision.test.ts
+++ b/scripts/lib/paired-decision.test.ts
@@ -1,0 +1,635 @@
+/**
+ * The synthetic corpus for the paired decision model.
+ *
+ * Every case is a hand-built base/head vector with a known truth, so this file
+ * doubles as the model's false-positive / false-negative characterisation. The
+ * numbers are deterministic — noise comes from a fixed LCG, never Math.random —
+ * so a failure here is a real behaviour change, not a reroll.
+ */
+import { describe, expect, test } from "bun:test"
+import {
+    DEFAULT_PAIRED_POLICY,
+    decidePairedRun,
+    detectBimodality,
+    lanesNeedingRerun,
+    type PairedComparison,
+    type PairedDecision,
+    type PairedPolicy,
+} from "./paired-decision"
+
+/** Deterministic uniform noise in [-1, 1). */
+function lcg(seed: number): () => number {
+    let state = seed >>> 0
+    return () => {
+        state = (state * 1664525 + 1013904223) >>> 0
+        return (state / 0x100000000) * 2 - 1
+    }
+}
+
+const BASE_NS = 50_000
+
+interface CaseOptions {
+    benchmark?: string
+    family?: "protected" | "informational"
+    /** True relative effect, e.g. 0.5 for a genuine 50% regression. */
+    effect?: number
+    /** Relative jitter applied independently to each measurement. */
+    jitter?: number
+    pairs?: number
+    seed?: number
+    /** Multiplier applied to specific pair indexes on one side. */
+    contaminate?: { side: "base" | "head"; pairs: number[]; factor: number }
+    /** Explicit head/base multipliers, one per pair; overrides effect+jitter. */
+    ratios?: number[]
+    dropHeadPairs?: number[]
+    dropBasePairs?: number[]
+}
+
+function comparison(options: CaseOptions = {}): PairedComparison {
+    const {
+        benchmark = "get 1000 atoms / valdres",
+        family = "protected",
+        effect = 0,
+        jitter = 0.01,
+        pairs = 4,
+        seed = 12345,
+        contaminate,
+        ratios,
+        dropHeadPairs = [],
+        dropBasePairs = [],
+    } = options
+    const noise = lcg(seed)
+    const samples = []
+    let unpairedBase = 0
+    let unpairedHead = 0
+
+    const count = ratios ? ratios.length : pairs
+    for (let i = 0; i < count; i++) {
+        let baseNs = BASE_NS * (1 + jitter * noise())
+        let headNs = ratios
+            ? baseNs * ratios[i]
+            : BASE_NS * (1 + effect) * (1 + jitter * noise())
+        if (contaminate?.pairs.includes(i)) {
+            if (contaminate.side === "base") baseNs *= contaminate.factor
+            else headNs *= contaminate.factor
+        }
+        if (dropHeadPairs.includes(i)) {
+            unpairedBase++
+            continue
+        }
+        if (dropBasePairs.includes(i)) {
+            unpairedHead++
+            continue
+        }
+        samples.push({ pairId: `p${i}`, baseNs, headNs })
+    }
+
+    return {
+        benchmark,
+        runtime: "bun",
+        suite: "standard",
+        family,
+        samples,
+        unpairedBase,
+        unpairedHead,
+    }
+}
+
+function decide(
+    options: CaseOptions = {},
+    policy: PairedPolicy = DEFAULT_PAIRED_POLICY,
+): PairedDecision {
+    return decidePairedRun([comparison(options)], policy)[0]
+}
+
+describe("outcomes", () => {
+    test("a clean no-op is demonstrated within budget", () => {
+        const decision = decide({ effect: 0, jitter: 0.01, pairs: 8 })
+        expect(decision.outcome).toBe("within-budget")
+        expect(Math.abs(decision.estimatePct)).toBeLessThan(0.02)
+    })
+
+    test("a genuine 50% regression is called at the minimum pair count", () => {
+        const decision = decide({ effect: 0.5, pairs: 4 })
+        expect(decision.outcome).toBe("regression")
+        expect(decision.estimatePct).toBeGreaterThan(0.45)
+        expect(decision.estimatePct).toBeLessThan(0.55)
+    })
+
+    test("a genuine 15% regression is called on a quiet runner", () => {
+        const decision = decide({ effect: 0.15, pairs: 4, jitter: 0.01 })
+        expect(decision.outcome).toBe("regression")
+    })
+
+    test("a genuine 10% regression sits on the budget and stays undecided", () => {
+        // The budget IS +10%, so this is the boundary. Refusing to call it
+        // either way is the correct answer, not a miss — and no pair count
+        // changes that, because the effect and the boundary coincide.
+        expect(decide({ effect: 0.1, pairs: 4 }).outcome).toBe("inconclusive")
+        expect(decide({ effect: 0.1, pairs: 12 }).outcome).toBe("inconclusive")
+    })
+
+    test("a genuine improvement is within budget and reported negative", () => {
+        const decision = decide({ effect: -0.3, pairs: 4 })
+        expect(decision.outcome).toBe("within-budget")
+        expect(decision.estimatePct).toBeLessThan(-0.25)
+    })
+})
+
+describe("contamination", () => {
+    test("one stalled head pair does not become a regression", () => {
+        const decision = decide({
+            effect: 0,
+            pairs: 4,
+            contaminate: { side: "head", pairs: [2], factor: 2.5 },
+        })
+        expect(decision.outcome).toBe("inconclusive")
+        // The robust estimator absorbs the stall; only the interval widens.
+        expect(Math.abs(decision.estimatePct)).toBeLessThan(0.03)
+    })
+
+    test("one stalled base pair does not become an improvement", () => {
+        const decision = decide({
+            effect: 0,
+            pairs: 4,
+            contaminate: { side: "base", pairs: [1], factor: 2.5 },
+        })
+        expect(decision.outcome).toBe("inconclusive")
+        expect(Math.abs(decision.estimatePct)).toBeLessThan(0.03)
+    })
+
+    test("a stall on top of a real regression degrades to inconclusive, never to clean", () => {
+        const decision = decide({
+            effect: 0.5,
+            pairs: 4,
+            contaminate: { side: "head", pairs: [3], factor: 2 },
+        })
+        expect(decision.outcome).not.toBe("within-budget")
+        expect(decision.estimatePct).toBeGreaterThan(0.4)
+    })
+
+    test("the ladder recovers a regression that a stall obscured at four pairs", () => {
+        const contaminate = {
+            side: "head" as const,
+            pairs: [3],
+            factor: 2,
+        }
+        expect(decide({ effect: 0.5, pairs: 4, contaminate }).outcome).toBe(
+            "inconclusive",
+        )
+        expect(decide({ effect: 0.5, pairs: 8, contaminate }).outcome).toBe(
+            "regression",
+        )
+    })
+})
+
+describe("bimodal process states", () => {
+    // The measurement that motivated this whole model: base 131/131/131 ns
+    // against head 351/351/131 ns in one CI job. `min(head/base)` reports it as
+    // 0% because one pair happened to be clean.
+    const HISTORICAL = { base: [131, 131, 131], head: [351, 351, 131] }
+
+    test("the historical 131/351 vector is flagged, not converted to 0%", () => {
+        const decision = decide({
+            ratios: HISTORICAL.head.map((h, i) => h / HISTORICAL.base[i]),
+            jitter: 0,
+        })
+        expect(decision.flags).toContain("bimodal")
+        expect(decision.outcome).toBe("inconclusive")
+        // The old statistic's answer was exactly 0%. Anything near it is the bug.
+        expect(decision.estimatePct).toBeGreaterThan(0.5)
+    })
+
+    test("min(head/base) is what the model replaces", () => {
+        const ratios = HISTORICAL.head.map((h, i) => h / HISTORICAL.base[i])
+        expect(Math.min(...ratios)).toBe(1)
+    })
+
+    test("two process states split evenly are flagged bimodal", () => {
+        const decision = decide({
+            ratios: [1.0, 1.0, 1.45, 1.45, 1.0, 1.45],
+            jitter: 0.002,
+        })
+        expect(decision.flags).toContain("bimodal")
+        expect(decision.outcome).toBe("inconclusive")
+    })
+
+    test("the flag clears once the ladder outvotes the contaminated pairs", () => {
+        // Two stalled pairs out of four are two process states; the same two
+        // out of twelve are two stalls the robust estimator absorbs. If the
+        // guard latched on an absolute count instead, a lane contaminated in
+        // round 1 could never be cleared and the ladder would burn every round.
+        const stalls = [1.6, 1.6]
+        const clean = (count: number) => Array<number>(count).fill(1)
+        const four = decide({ ratios: [...stalls, ...clean(2)], jitter: 0.002 })
+        const twelve = decide({
+            ratios: [...stalls, ...clean(10)],
+            jitter: 0.002,
+        })
+        expect(four.flags).toContain("bimodal")
+        expect(four.outcome).toBe("inconclusive")
+        expect(twelve.flags).not.toContain("bimodal")
+        expect(twelve.outcome).toBe("within-budget")
+    })
+
+    test("a single deviant pair is an outlier, not a process state", () => {
+        const diagnostic = detectBimodality(
+            [0, 0, 0, Math.log(2.5)],
+            DEFAULT_PAIRED_POLICY,
+        )
+        expect(diagnostic.bimodal).toBe(false)
+        expect(diagnostic.minorityCount).toBe(1)
+    })
+
+    test("a tight cluster pair is not bimodal", () => {
+        const decision = decide({ effect: 0.5, pairs: 8, jitter: 0.01 })
+        expect(decision.flags).not.toContain("bimodal")
+    })
+})
+
+describe("ordering and drift", () => {
+    // A B-P-P-B block pairs (base@1, head@2) and (head@1, base@2), so a linear
+    // drift across the block enters the two pairs with opposite sign.
+    function driftBlock(effect: number, driftPerSlot: number) {
+        const slots = [0, 1, 2, 3].map(i => 1 + driftPerSlot * i)
+        return [
+            {
+                base: BASE_NS * slots[0],
+                head: BASE_NS * (1 + effect) * slots[1],
+            },
+            {
+                base: BASE_NS * slots[3],
+                head: BASE_NS * (1 + effect) * slots[2],
+            },
+        ]
+    }
+
+    test("balanced blocks cancel a linear drift", () => {
+        const block = driftBlock(0, 0.04)
+        const decision = decidePairedRun([
+            {
+                benchmark: "get 1000 atoms / valdres",
+                runtime: "bun",
+                suite: "standard",
+                family: "protected",
+                samples: [...driftBlock(0, 0.04), ...block].map((p, i) => ({
+                    pairId: `p${i}`,
+                    baseNs: p.base,
+                    headNs: p.head,
+                })),
+                unpairedBase: 0,
+                unpairedHead: 0,
+            },
+        ])[0]
+        expect(Math.abs(decision.estimatePct)).toBeLessThan(0.005)
+        expect(decision.outcome).toBe("within-budget")
+    })
+
+    test("unbalanced base-then-head pairing biases the same drift upward", () => {
+        // Every pair measures head one slot later than base, so the drift is
+        // indistinguishable from a regression. This is what balancing buys.
+        const decision = decide({
+            ratios: [1.04, 1.04, 1.04, 1.04],
+            jitter: 0,
+        })
+        expect(decision.estimatePct).toBeGreaterThan(0.03)
+    })
+
+    test("alternating drift averages out and never reads as a regression", () => {
+        const decision = decide({ ratios: [1.05, 0.95, 1.05, 0.95], jitter: 0 })
+        expect(decision.outcome).not.toBe("regression")
+        expect(Math.abs(decision.estimatePct)).toBeLessThan(0.005)
+    })
+})
+
+describe("missing pairs", () => {
+    test("dropped head observations are recorded and the rest analysed", () => {
+        const decision = decide({ effect: 0.5, pairs: 6, dropHeadPairs: [1] })
+        expect(decision.pairs).toBe(5)
+        expect(decision.unpairedBase).toBe(1)
+        expect(decision.flags).toContain("unpaired-observations")
+        expect(decision.outcome).toBe("regression")
+    })
+
+    test("too few surviving pairs decide nothing", () => {
+        const decision = decide({
+            effect: 0.5,
+            pairs: 4,
+            dropHeadPairs: [0, 1],
+        })
+        expect(decision.outcome).toBe("inconclusive")
+        expect(decision.flags).toContain("insufficient-pairs")
+    })
+
+    test("a comparison with no surviving pairs is inconclusive, not a crash", () => {
+        const decision = decide({ pairs: 2, dropBasePairs: [0, 1] })
+        expect(decision.pairs).toBe(0)
+        expect(decision.outcome).toBe("inconclusive")
+    })
+})
+
+describe("multiple comparisons", () => {
+    function suite(count: number, regressed: number[]): PairedComparison[] {
+        return Array.from({ length: count }, (_, i) =>
+            comparison({
+                benchmark: `bench ${i} / valdres`,
+                effect: regressed.includes(i) ? 0.5 : 0,
+                pairs: 6,
+                seed: 1000 + i,
+            }),
+        )
+    }
+
+    test("one true regression among many null comparisons is found", () => {
+        const decisions = decidePairedRun(suite(24, [7]))
+        const regressions = decisions.filter(d => d.outcome === "regression")
+        expect(regressions).toHaveLength(1)
+        expect(regressions[0].benchmark).toBe("bench 7 / valdres")
+    })
+
+    test("no null comparison is called a regression across the family", () => {
+        const decisions = decidePairedRun(suite(40, []))
+        expect(decisions.filter(d => d.outcome === "regression")).toHaveLength(
+            0,
+        )
+        expect(
+            decisions.filter(d => d.outcome === "within-budget").length,
+        ).toBeGreaterThan(30)
+    })
+
+    test("adjustment is per family, so informational rows cannot dilute protected ones", () => {
+        const protectedRows = suite(4, [1]).map(c => ({
+            ...c,
+            family: "protected" as const,
+        }))
+        const informational = suite(60, []).map(c => ({
+            ...c,
+            benchmark: `${c.benchmark} info`,
+            family: "informational" as const,
+        }))
+        const decisions = decidePairedRun([...protectedRows, ...informational])
+        const hit = decisions.find(d => d.benchmark === "bench 1 / valdres")!
+        expect(hit.outcome).toBe("regression")
+        expect(hit.family).toBe("protected")
+    })
+
+    test("q-values grow with family size", () => {
+        const small = decidePairedRun(suite(4, [0]))[0]
+        const large = decidePairedRun(suite(60, [0]))[0]
+        expect(large.regressionQ).toBeGreaterThan(small.regressionQ)
+    })
+})
+
+/**
+ * Operating characteristics under a realistic family (22 protected comparisons
+ * = 11 benchmarks x 2 runtimes) with one true effect embedded in nulls. The
+ * matrix these assertions summarise is reproduced in
+ * scripts/PAIRED_DECISION_MODEL.md.
+ */
+describe("characterisation", () => {
+    const FAMILY = 22
+
+    function family(effect: number, jitter: number, pairs: number) {
+        return [
+            comparison({
+                benchmark: "target / valdres",
+                effect,
+                jitter,
+                pairs,
+                seed: 7,
+            }),
+            ...Array.from({ length: FAMILY - 1 }, (_, i) =>
+                comparison({
+                    benchmark: `null ${i} / valdres`,
+                    effect: 0,
+                    jitter,
+                    pairs,
+                    seed: 100 + i,
+                }),
+            ),
+        ]
+    }
+
+    function target(effect: number, jitter: number, pairs: number) {
+        return decidePairedRun(family(effect, jitter, pairs))[0].outcome
+    }
+
+    // The ladder's real steps: one round is two B-P-P-B blocks = 4 pairs, and
+    // the Yuen degrees of freedom go 3 -> 5 -> 7 across them.
+    const LADDER = [4, 8, 12]
+
+    test("no false regression on a quiet or a noisy runner", () => {
+        for (const jitter of [0.01, 0.03, 0.06]) {
+            for (const pairs of LADDER) {
+                const decisions = decidePairedRun(family(0, jitter, pairs))
+                expect(
+                    decisions.filter(d => d.outcome === "regression"),
+                ).toHaveLength(0)
+            }
+        }
+    })
+
+    test("a catastrophic 50% regression is caught at every rung and jitter", () => {
+        for (const jitter of [0.01, 0.03, 0.06]) {
+            for (const pairs of LADDER) {
+                expect(target(0.5, jitter, pairs)).toBe("regression")
+            }
+        }
+    })
+
+    test("a genuine improvement is never mistaken for a regression", () => {
+        for (const jitter of [0.01, 0.03, 0.06]) {
+            for (const pairs of LADDER) {
+                expect(target(-0.3, jitter, pairs)).toBe("within-budget")
+            }
+        }
+    })
+
+    test("detection improves monotonically as the ladder adds pairs", () => {
+        // At +3% jitter a 15% regression needs the full ladder; a 20% one
+        // resolves a rung earlier. Neither is ever called backwards.
+        expect(LADDER.map(pairs => target(0.15, 0.03, pairs))).toEqual([
+            "inconclusive",
+            "inconclusive",
+            "regression",
+        ])
+        expect(LADDER.map(pairs => target(0.2, 0.03, pairs))).toEqual([
+            "inconclusive",
+            "regression",
+            "regression",
+        ])
+    })
+
+    test("a noisy runner degrades to inconclusive, never to a wrong call", () => {
+        const decisions = decidePairedRun(family(0, 0.12, 4))
+        expect(decisions.filter(d => d.outcome === "regression")).toHaveLength(
+            0,
+        )
+        // With this much noise the model should also decline to certify.
+        expect(
+            decisions.filter(d => d.outcome === "inconclusive").length,
+        ).toBeGreaterThan(0)
+    })
+
+    /**
+     * Type-I error measured where it is actually hard: with the true effect
+     * sitting exactly ON the +10% budget, so every `regression` verdict is a
+     * false one. Testing at effect 0 instead — 10 points away from the
+     * boundary — reports 0% everywhere and proves nothing.
+     *
+     * The ladder is simulated faithfully: twelve pairs are drawn once per row
+     * and round r analyses the first 4r of them, so the looks are nested the
+     * way the workflow's reruns are. The rates asserted here are the ones
+     * quoted in PAIRED_DECISION_MODEL.md.
+     */
+    describe("type-I error at the budget boundary", () => {
+        const TRIALS = 200
+
+        function boundaryTrial(seed: number, jitter: number) {
+            const rows = Array.from({ length: FAMILY }, (_, i) => {
+                const noise = lcg(seed * 7919 + i * 131)
+                return Array.from({ length: 12 }, (_, p) => ({
+                    pairId: `p${p}`,
+                    baseNs: BASE_NS * (1 + jitter * noise()),
+                    headNs:
+                        BASE_NS *
+                        (1 + DEFAULT_PAIRED_POLICY.budgetPct) *
+                        (1 + jitter * noise()),
+                }))
+            })
+            let decisions: PairedDecision[] = []
+            for (const round of [1, 2, 3]) {
+                decisions = decidePairedRun(
+                    rows.map((samples, i) => ({
+                        benchmark: `b${i} / valdres`,
+                        runtime: "bun",
+                        suite: "standard",
+                        family: "protected" as const,
+                        samples: samples.slice(0, round * 4),
+                        unpairedBase: 0,
+                        unpairedHead: 0,
+                    })),
+                )
+                if (lanesNeedingRerun(decisions).length === 0) break
+            }
+            return decisions
+        }
+
+        function falseRegressionRate(jitter: number) {
+            let falseCalls = 0
+            let comparisons = 0
+            let jobs = 0
+            for (let seed = 1; seed <= TRIALS; seed++) {
+                let hit = false
+                for (const decision of boundaryTrial(seed, jitter)) {
+                    comparisons++
+                    if (decision.outcome === "regression") {
+                        falseCalls++
+                        hit = true
+                    }
+                }
+                if (hit) jobs++
+            }
+            return {
+                perComparison: falseCalls / comparisons,
+                perJob: jobs / TRIALS,
+            }
+        }
+
+        test("stays far below the nominal 5% FDR at every jitter level", () => {
+            for (const jitter of [0.01, 0.03, 0.06, 0.12]) {
+                const { perComparison } = falseRegressionRate(jitter)
+                expect(perComparison).toBeLessThan(
+                    DEFAULT_PAIRED_POLICY.falseDiscoveryRate,
+                )
+                // Conservative by more than an order of magnitude, which is the
+                // evidence that the studentized approximation is not inflating
+                // error rates for this design. Tighten if this ever drifts up.
+                expect(perComparison).toBeLessThan(0.005)
+            }
+        })
+
+        test("a quiet runner produces no false blocks at all", () => {
+            expect(falseRegressionRate(0.01).perComparison).toBe(0)
+        })
+
+        test("exact sign-flip inference is not viable at these pair counts", () => {
+            // Records why the model studentizes instead of using an exact
+            // permutation test. A paired sign-flip test on n pairs cannot
+            // produce a one-sided p below 2^-n, and BH over the protected
+            // family needs the smallest p to clear q/m. At four and eight pairs
+            // no measurement, however extreme, could ever be called — the
+            // ladder's first two rungs would be structurally blind.
+            const m = FAMILY
+            const threshold = DEFAULT_PAIRED_POLICY.falseDiscoveryRate / m
+            expect(2 ** -4).toBeGreaterThan(threshold)
+            expect(2 ** -8).toBeGreaterThan(threshold)
+            expect(2 ** -12).toBeLessThan(threshold)
+        })
+
+        test("per-job false-block rate is bounded on a noisy runner", () => {
+            // The number an engineer feels: fraction of PR jobs where at least
+            // one protected row is falsely called. This is the headline input
+            // to any future blocking decision.
+            expect(falseRegressionRate(0.06).perJob).toBeLessThan(0.1)
+            expect(falseRegressionRate(0.12).perJob).toBeLessThan(0.1)
+        })
+    })
+})
+
+describe("rerun ladder", () => {
+    test("only inconclusive protected lanes are requested", () => {
+        const decisions = decidePairedRun([
+            comparison({ effect: 0, pairs: 8 }),
+            {
+                ...comparison({
+                    benchmark: "set 1000 atoms / valdres",
+                    ratios: [1.0, 1.45, 1.0, 1.45, 1.0, 1.45],
+                    jitter: 0.002,
+                }),
+                suite: "async",
+            },
+            {
+                ...comparison({
+                    benchmark: "tiny / valdres",
+                    ratios: [1.0, 1.45, 1.0, 1.45],
+                    jitter: 0.002,
+                    family: "informational",
+                }),
+                runtime: "node",
+            },
+        ])
+        expect(lanesNeedingRerun(decisions)).toEqual(["bun:async"])
+    })
+
+    test("a fully decided run requests nothing", () => {
+        const decisions = decidePairedRun([comparison({ effect: 0, pairs: 8 })])
+        expect(lanesNeedingRerun(decisions)).toEqual([])
+    })
+})
+
+describe("guards", () => {
+    test("a batch-size shift is reported but does not suppress the verdict", () => {
+        const base = comparison({ effect: 0.5, pairs: 6 })
+        const decision = decidePairedRun([
+            {
+                ...base,
+                samples: base.samples.map((sample, i) => ({
+                    ...sample,
+                    baseBatchSize: 1024,
+                    headBatchSize: i === 0 ? 128 : 1024,
+                })),
+            },
+        ])[0]
+        expect(decision.flags).toContain("batch-size-shift")
+        expect(decision.outcome).toBe("regression")
+    })
+
+    test("identical samples cannot manufacture unbounded confidence", () => {
+        const decision = decide({ ratios: [1.2, 1.2, 1.2, 1.2], jitter: 0 })
+        expect(decision.standardErrorLn).toBeGreaterThanOrEqual(
+            DEFAULT_PAIRED_POLICY.minStandardErrorLn,
+        )
+        expect(decision.outcome).toBe("regression")
+    })
+})

--- a/scripts/lib/paired-decision.ts
+++ b/scripts/lib/paired-decision.ts
@@ -1,0 +1,395 @@
+/**
+ * The paired benchmark decision model.
+ *
+ * The shipped PR gate reduces each benchmark to `min(head/base)` over three
+ * pairs and alerts above +50%. `min` is a deliberate one-sided filter for
+ * runner interference, but it has no notion of confidence: it silently converts
+ * a base 131/131/131 vs head 351/351/131 measurement — two of three pairs 2.7x
+ * slow — into "0% change", because one clean pair is enough to clear it. That
+ * gate is retained as the catastrophic backstop; this model is what replaces it
+ * once calibrated.
+ *
+ * The model works on paired log-ratios r_i = ln(head_i) - ln(base_i):
+ *
+ *   1. Logs make the statistic symmetric (a 2x regression and a 2x improvement
+ *      are +/- ln 2) and turn the multiplicative runner-wide slowdown that
+ *      motivated relative CB into an additive term that pairing cancels.
+ *   2. Location is a robust estimator (default Hodges-Lehmann) so a single
+ *      stalled pair cannot carry the verdict.
+ *   3. Dispersion is the Winsorized (Yuen) standard error with a resolution
+ *      floor, giving an exact Student-t tail rather than a resampled interval —
+ *      the whole report is reproducible from the uploaded NDJSON.
+ *   4. Every comparison is tested against a single relative budget in BOTH
+ *      directions, yielding three outcomes: `regression` (the effect is above
+ *      budget), `within-budget` (the effect is demonstrably below it), and
+ *      `inconclusive` (the data cannot separate the two). "No alert" and
+ *      "demonstrated fine" stop being the same answer.
+ *   5. p-values are FDR-adjusted within their family, so the answer does not
+ *      degrade as benchmarks and runtimes are added.
+ *
+ * `inconclusive` is a first-class result, not a failure: it is what drives the
+ * bounded rerun ladder for protected benchmarks.
+ */
+import {
+    HODGES_LEHMANN_SE_INFLATION,
+    LOCATION_ESTIMATORS,
+    benjaminiHochberg,
+    studentTQuantile,
+    studentTUpperTail,
+    trimCount,
+    trimmedDegreesOfFreedom,
+    winsorizedStandardError,
+    type LocationEstimatorName,
+} from "./robust-estimators"
+
+export type PairedOutcome = "regression" | "within-budget" | "inconclusive"
+
+/**
+ * `protected` comparisons carry decisions and drive the rerun ladder;
+ * `informational` ones are reported but never blocking. The families are also
+ * the multiple-comparison families, which is why the protected set is kept
+ * small: FDR adjustment across ~20 protected comparisons leaves usable power at
+ * four to twelve pairs, while adjustment across all ~120 would not.
+ */
+export type DecisionFamily = "protected" | "informational"
+
+export type DecisionFlag =
+    | "bimodal"
+    | "insufficient-pairs"
+    | "unpaired-observations"
+    | "batch-size-shift"
+    | "sub-microsecond"
+
+export interface PairedSample {
+    pairId: string
+    baseNs: number
+    headNs: number
+    /** ticks / sampleCount — Mitata's chosen batch size, when known. */
+    baseBatchSize?: number
+    headBatchSize?: number
+}
+
+export interface PairedComparison {
+    benchmark: string
+    runtime: string
+    suite: string
+    family: DecisionFamily
+    samples: PairedSample[]
+    /** Observations that never found a partner, by side. */
+    unpairedBase: number
+    unpairedHead: number
+    /** Set when the comparison was demoted for being below the timing floor. */
+    subMicrosecond?: boolean
+}
+
+export interface PairedPolicy {
+    /** Relative slowdown the project is willing to absorb, e.g. 0.1 = +10%. */
+    budgetPct: number
+    /** Benjamini-Hochberg level, applied per family per direction. */
+    falseDiscoveryRate: number
+    /** Below this many usable pairs nothing is decided. */
+    minPairs: number
+    /** Symmetric trim fraction for the Winsorized standard error. */
+    trimFraction: number
+    /**
+     * Floor on the standard error, as a log-ratio. Four pairs that happen to
+     * agree to the last nanosecond do not mean the measurement is exact — they
+     * mean the timer, the JIT tier and the batch size all held still. This
+     * encodes the residual measurement resolution so that identical samples
+     * cannot manufacture unbounded confidence.
+     */
+    minStandardErrorLn: number
+    /** A gap smaller than this is never evidence of two process states. */
+    bimodalMinGapLn: number
+    /** How far the largest gap must dominate the next largest. */
+    bimodalGapDominance: number
+    /** Floor for the "next largest gap" so a zero-gap run cannot divide by 0. */
+    bimodalGapFloorLn: number
+    /**
+     * Minority-cluster SHARE that counts as a second process state.
+     *
+     * Deliberately a fraction and not an absolute count: two deviant pairs out
+     * of three are two process states, while two out of twelve are two stalls
+     * that the robust estimator already absorbs. An absolute threshold would
+     * latch — a lane contaminated early could never be cleared by rerunning,
+     * so the ladder would burn every round and still report nothing.
+     */
+    bimodalMinorityFraction: number
+    /** |ln(headBatch/baseBatch)| above this is reported as a regime change. */
+    batchShiftLn: number
+    estimator: LocationEstimatorName
+}
+
+export const DEFAULT_PAIRED_POLICY: PairedPolicy = {
+    budgetPct: 0.1,
+    falseDiscoveryRate: 0.05,
+    minPairs: 4,
+    trimFraction: 0.2,
+    minStandardErrorLn: Math.log(1.005),
+    bimodalMinGapLn: Math.log(1.2),
+    bimodalGapDominance: 3,
+    bimodalGapFloorLn: Math.log(1.03),
+    bimodalMinorityFraction: 1 / 3,
+    batchShiftLn: Math.log(2),
+    estimator: "hodges-lehmann",
+}
+
+export interface BimodalityDiagnostic {
+    bimodal: boolean
+    /** Largest gap between consecutive sorted log-ratios. */
+    gapLn: number
+    /** Size of the smaller of the two clusters the gap separates. */
+    minorityCount: number
+}
+
+/**
+ * Two process states show up as two tight clusters of log-ratios separated by
+ * one dominant gap — the shape of the 131/131/131 vs 351/351/131 measurement.
+ * No location estimator should be trusted to summarise that with a single
+ * number, so it is flagged and the comparison is left inconclusive.
+ */
+export function detectBimodality(
+    logRatios: number[],
+    policy: PairedPolicy,
+): BimodalityDiagnostic {
+    if (logRatios.length < 2) {
+        return { bimodal: false, gapLn: 0, minorityCount: 0 }
+    }
+    const sorted = [...logRatios].sort((a, b) => a - b)
+    const gaps = sorted
+        .slice(1)
+        .map((value, index) => ({ gap: value - sorted[index], index }))
+    const largest = gaps.reduce((best, gap) =>
+        gap.gap > best.gap ? gap : best,
+    )
+    const runnerUp = gaps
+        .filter(gap => gap !== largest)
+        .reduce((best, gap) => Math.max(best, gap.gap), 0)
+
+    const lowCount = largest.index + 1
+    const minorityCount = Math.min(lowCount, sorted.length - lowCount)
+    const minorityIsCluster =
+        minorityCount / sorted.length >= policy.bimodalMinorityFraction
+
+    const bimodal =
+        largest.gap >= policy.bimodalMinGapLn &&
+        largest.gap >=
+            policy.bimodalGapDominance *
+                Math.max(runnerUp, policy.bimodalGapFloorLn) &&
+        minorityIsCluster
+
+    return { bimodal, gapLn: largest.gap, minorityCount }
+}
+
+export interface PairedDecision {
+    benchmark: string
+    runtime: string
+    suite: string
+    family: DecisionFamily
+    outcome: PairedOutcome
+    flags: DecisionFlag[]
+    pairs: number
+    unpairedBase: number
+    unpairedHead: number
+    estimateLn: number
+    /** exp(estimateLn) - 1, i.e. the relative change. */
+    estimatePct: number
+    standardErrorLn: number
+    degreesOfFreedom: number
+    /** Unadjusted two-sided 90% interval on the relative change, for reading. */
+    intervalPct: [number, number] | null
+    regressionP: number
+    withinBudgetP: number
+    regressionQ: number
+    withinBudgetQ: number
+    logRatios: number[]
+}
+
+interface Summary {
+    comparison: PairedComparison
+    flags: DecisionFlag[]
+    logRatios: number[]
+    estimateLn: number
+    standardErrorLn: number
+    degreesOfFreedom: number
+    intervalPct: [number, number] | null
+    regressionP: number
+    withinBudgetP: number
+    decidable: boolean
+}
+
+function summarize(
+    comparison: PairedComparison,
+    policy: PairedPolicy,
+): Summary {
+    const flags: DecisionFlag[] = []
+    if (comparison.subMicrosecond) flags.push("sub-microsecond")
+    if (comparison.unpairedBase > 0 || comparison.unpairedHead > 0) {
+        flags.push("unpaired-observations")
+    }
+
+    const logRatios = comparison.samples.map(sample =>
+        Math.log(sample.headNs / sample.baseNs),
+    )
+    const batchShifts = comparison.samples
+        .filter(
+            sample =>
+                sample.baseBatchSize !== undefined &&
+                sample.headBatchSize !== undefined,
+        )
+        .map(sample =>
+            Math.abs(Math.log(sample.headBatchSize! / sample.baseBatchSize!)),
+        )
+    // Reported, never decisive. Mitata picks a batch size from the measured
+    // duration, so a genuine regression can legitimately move it; suppressing a
+    // finding on that basis would hide the very thing being looked for.
+    if (batchShifts.some(shift => shift > policy.batchShiftLn)) {
+        flags.push("batch-size-shift")
+    }
+
+    const n = logRatios.length
+    const g = trimCount(n, policy.trimFraction)
+    const degreesOfFreedom = trimmedDegreesOfFreedom(n, g)
+    const bimodality = detectBimodality(logRatios, policy)
+    if (bimodality.bimodal) flags.push("bimodal")
+
+    const estimateLn =
+        n > 0 ? LOCATION_ESTIMATORS[policy.estimator](logRatios) : Number.NaN
+
+    if (n < policy.minPairs || degreesOfFreedom < 1) {
+        if (n < policy.minPairs) flags.push("insufficient-pairs")
+        return {
+            comparison,
+            flags,
+            logRatios,
+            estimateLn,
+            standardErrorLn: Number.NaN,
+            degreesOfFreedom,
+            intervalPct: null,
+            regressionP: 1,
+            withinBudgetP: 1,
+            decidable: false,
+        }
+    }
+
+    const inflation =
+        policy.estimator === "hodges-lehmann" ? HODGES_LEHMANN_SE_INFLATION : 1
+    const standardErrorLn = Math.max(
+        policy.minStandardErrorLn,
+        winsorizedStandardError(logRatios, g) * inflation,
+    )
+    const budgetLn = Math.log(1 + policy.budgetPct)
+    // Two one-sided tests against the same boundary. `regressionP` asks whether
+    // the effect is above budget; `withinBudgetP` asks whether it is below.
+    // They cannot both be small, so the three outcomes are mutually exclusive.
+    const regressionP = studentTUpperTail(
+        (estimateLn - budgetLn) / standardErrorLn,
+        degreesOfFreedom,
+    )
+    const withinBudgetP = studentTUpperTail(
+        (budgetLn - estimateLn) / standardErrorLn,
+        degreesOfFreedom,
+    )
+    const halfWidth = studentTQuantile(0.05, degreesOfFreedom) * standardErrorLn
+
+    return {
+        comparison,
+        flags,
+        logRatios,
+        estimateLn,
+        standardErrorLn,
+        degreesOfFreedom,
+        intervalPct: [
+            Math.expm1(estimateLn - halfWidth),
+            Math.expm1(estimateLn + halfWidth),
+        ],
+        regressionP,
+        withinBudgetP,
+        // A bimodal comparison is measured, not summarised: the point estimate
+        // and interval stay in the report so the shape is visible, but no
+        // verdict is drawn from them.
+        decidable: !bimodality.bimodal,
+    }
+}
+
+/**
+ * Decide a whole run. Multiple-comparison adjustment happens here rather than
+ * per comparison, because it depends on the family every comparison is in —
+ * benchmarks and runtimes together.
+ */
+export function decidePairedRun(
+    comparisons: PairedComparison[],
+    policy: PairedPolicy = DEFAULT_PAIRED_POLICY,
+): PairedDecision[] {
+    const summaries = comparisons.map(comparison =>
+        summarize(comparison, policy),
+    )
+
+    const qValues = new Map<Summary, { regression: number; within: number }>()
+    for (const family of ["protected", "informational"] as const) {
+        const inFamily = summaries.filter(
+            summary => summary.comparison.family === family,
+        )
+        const regressionQ = benjaminiHochberg(
+            inFamily.map(summary => summary.regressionP),
+        )
+        const withinQ = benjaminiHochberg(
+            inFamily.map(summary => summary.withinBudgetP),
+        )
+        inFamily.forEach((summary, index) =>
+            qValues.set(summary, {
+                regression: regressionQ[index],
+                within: withinQ[index],
+            }),
+        )
+    }
+
+    return summaries.map(summary => {
+        const q = qValues.get(summary)!
+        let outcome: PairedOutcome = "inconclusive"
+        if (summary.decidable) {
+            if (q.regression <= policy.falseDiscoveryRate)
+                outcome = "regression"
+            else if (q.within <= policy.falseDiscoveryRate) {
+                outcome = "within-budget"
+            }
+        }
+        return {
+            benchmark: summary.comparison.benchmark,
+            runtime: summary.comparison.runtime,
+            suite: summary.comparison.suite,
+            family: summary.comparison.family,
+            outcome,
+            flags: summary.flags,
+            pairs: summary.logRatios.length,
+            unpairedBase: summary.comparison.unpairedBase,
+            unpairedHead: summary.comparison.unpairedHead,
+            estimateLn: summary.estimateLn,
+            estimatePct: Math.expm1(summary.estimateLn),
+            standardErrorLn: summary.standardErrorLn,
+            degreesOfFreedom: summary.degreesOfFreedom,
+            intervalPct: summary.intervalPct,
+            regressionP: summary.regressionP,
+            withinBudgetP: summary.withinBudgetP,
+            regressionQ: q.regression,
+            withinBudgetQ: q.within,
+            logRatios: summary.logRatios,
+        }
+    })
+}
+
+/**
+ * Lanes (runtime + suite) holding at least one undecided protected comparison.
+ * Rerunning a lane appends pairs to every benchmark in it, which is the only
+ * granularity the suites can actually be re-executed at.
+ */
+export function lanesNeedingRerun(decisions: PairedDecision[]): string[] {
+    const lanes = new Set<string>()
+    for (const decision of decisions) {
+        if (decision.family !== "protected") continue
+        if (decision.outcome === "inconclusive") {
+            lanes.add(`${decision.runtime}:${decision.suite}`)
+        }
+    }
+    return [...lanes].sort()
+}

--- a/scripts/lib/robust-estimators.test.ts
+++ b/scripts/lib/robust-estimators.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, test } from "bun:test"
+import {
+    LOCATION_ESTIMATORS,
+    benjaminiHochberg,
+    hodgesLehmann,
+    mean,
+    studentTQuantile,
+    studentTUpperTail,
+    trimCount,
+    trimmedMean,
+    winsorize,
+    winsorizedStandardError,
+    type LocationEstimatorName,
+} from "./robust-estimators"
+
+describe("location estimators", () => {
+    test("Hodges-Lehmann is the median of the Walsh averages", () => {
+        expect(hodgesLehmann([1, 2, 3, 4])).toBe(2.5)
+        expect(hodgesLehmann([5])).toBe(5)
+        // (1+1)/2, (1+9)/2, (9+9)/2 -> [1, 5, 9]
+        expect(hodgesLehmann([1, 9])).toBe(5)
+    })
+
+    test("the trimmed mean drops whole observations per tail", () => {
+        expect(trimCount(4, 0.2)).toBe(0)
+        expect(trimCount(8, 0.2)).toBe(1)
+        expect(trimCount(12, 0.2)).toBe(2)
+        expect(trimmedMean([1, 2, 3, 4, 100], 0.2)).toBe(3)
+        expect(trimmedMean([1, 2, 3, 4], 0.2)).toBe(mean([1, 2, 3, 4]))
+    })
+
+    test("winsorizing replaces tails rather than removing them", () => {
+        expect(winsorize([1, 2, 3, 4, 100], 1)).toEqual([2, 2, 3, 4, 4])
+        expect(winsorize([3, 1, 2], 0)).toEqual([1, 2, 3])
+    })
+})
+
+describe("Yuen standard error", () => {
+    test("collapses to s/sqrt(n) when nothing is trimmed", () => {
+        const values = [1, 2, 3, 4, 8]
+        const center = mean(values)
+        const s = Math.sqrt(
+            values.reduce((sum, v) => sum + (v - center) ** 2, 0) /
+                (values.length - 1),
+        )
+        expect(winsorizedStandardError(values, 0)).toBeCloseTo(
+            s / Math.sqrt(values.length),
+            12,
+        )
+    })
+
+    test("trimming shrinks the effect of one wild value", () => {
+        const contaminated = [1, 1, 1, 1, 1, 1, 1, 40]
+        expect(winsorizedStandardError(contaminated, 1)).toBeLessThan(
+            winsorizedStandardError(contaminated, 0) / 10,
+        )
+    })
+
+    test("refuses to report a standard error it cannot compute", () => {
+        expect(() => winsorizedStandardError([1, 2, 3], 1)).toThrow(
+            "at least two untrimmed values",
+        )
+    })
+})
+
+describe("Student-t tail", () => {
+    test("matches published critical values", () => {
+        expect(studentTUpperTail(2.353, 3)).toBeCloseTo(0.05, 4)
+        expect(studentTUpperTail(3.182, 3)).toBeCloseTo(0.025, 4)
+        expect(studentTUpperTail(2.015, 5)).toBeCloseTo(0.05, 4)
+        expect(studentTUpperTail(1.96, 100000)).toBeCloseTo(0.025, 4)
+    })
+
+    test("is symmetric about zero", () => {
+        expect(studentTUpperTail(0, 7)).toBeCloseTo(0.5, 12)
+        expect(studentTUpperTail(-1.5, 7)).toBeCloseTo(
+            1 - studentTUpperTail(1.5, 7),
+            12,
+        )
+    })
+
+    test("the quantile inverts the tail", () => {
+        for (const df of [1, 3, 5, 7, 30]) {
+            for (const tail of [0.05, 0.01, 0.0025]) {
+                expect(
+                    studentTUpperTail(studentTQuantile(tail, df), df),
+                ).toBeCloseTo(tail, 8)
+            }
+        }
+    })
+})
+
+describe("Benjamini-Hochberg", () => {
+    test("returns adjusted p-values in input order", () => {
+        const adjusted = benjaminiHochberg([0.04, 0.01, 0.03, 0.02, 0.05])
+        expect(adjusted).toEqual([0.05, 0.05, 0.05, 0.05, 0.05])
+    })
+
+    test("is monotone and bounded by 1", () => {
+        const adjusted = benjaminiHochberg([0.001, 0.5, 0.9, 0.95])
+        expect(adjusted[0]).toBeCloseTo(0.004, 12)
+        expect(adjusted.every(q => q <= 1)).toBe(true)
+        expect(adjusted[1]).toBeLessThanOrEqual(adjusted[2])
+    })
+
+    test("a lone comparison is unadjusted", () => {
+        expect(benjaminiHochberg([0.013])).toEqual([0.013])
+    })
+
+    test("handles an empty family", () => {
+        expect(benjaminiHochberg([])).toEqual([])
+    })
+})
+
+/**
+ * Why the model defaults to Hodges-Lehmann.
+ *
+ * The choice is between three candidates on the two properties that decide a
+ * benchmark verdict: how far the estimate moves when one pair is contaminated
+ * (a CI stall only ever makes a sample slower, so this bias is one-directional
+ * and accumulates against us), and how much it scatters on clean data (which
+ * sets how many pairs the rerun ladder has to buy). The assertions below are
+ * the measurement, not a restatement of the conclusion.
+ */
+describe("estimator selection", () => {
+    function lcg(seed: number): () => number {
+        let state = seed >>> 0
+        return () => {
+            state = (state * 1664525 + 1013904223) >>> 0
+            return (state / 0x100000000) * 2 - 1
+        }
+    }
+
+    const NAMES: LocationEstimatorName[] = [
+        "mean",
+        "median",
+        "hodges-lehmann",
+        "trimmed-mean-20",
+    ]
+
+    /** RMSE of each estimator against a known truth over many seeds. */
+    function rmse(
+        pairs: number,
+        jitter: number,
+        contaminate: number | null,
+    ): Record<LocationEstimatorName, number> {
+        const totals = Object.fromEntries(
+            NAMES.map(name => [name, 0]),
+        ) as Record<LocationEstimatorName, number>
+        const trials = 400
+        for (let seed = 1; seed <= trials; seed++) {
+            const noise = lcg(seed * 7919)
+            const values = Array.from({ length: pairs }, () => jitter * noise())
+            if (contaminate !== null) values[pairs - 1] += Math.log(contaminate)
+            for (const name of NAMES) {
+                totals[name] += LOCATION_ESTIMATORS[name](values) ** 2
+            }
+        }
+        return Object.fromEntries(
+            NAMES.map(name => [name, Math.sqrt(totals[name] / trials)]),
+        ) as Record<LocationEstimatorName, number>
+    }
+
+    test("one stalled pair in four drags the mean far more than the robust estimators", () => {
+        const error = rmse(4, 0.02, 2.5)
+        expect(error.mean).toBeGreaterThan(0.2)
+        expect(error["hodges-lehmann"]).toBeLessThan(0.03)
+        expect(error.median).toBeLessThan(0.03)
+        // A 20% trim removes nothing at four values, so it IS the mean here —
+        // which is precisely why the model cannot default to it.
+        expect(error["trimmed-mean-20"]).toBeCloseTo(error.mean, 12)
+    })
+
+    test("on clean data Hodges-Lehmann scatters less than the median", () => {
+        const error = rmse(8, 0.03, null)
+        expect(error["hodges-lehmann"]).toBeLessThan(error.median)
+        // ...while staying close to the efficient-but-fragile mean.
+        expect(error["hodges-lehmann"]).toBeLessThan(error.mean * 1.15)
+    })
+
+    test("Hodges-Lehmann is the only candidate that wins on both counts", () => {
+        const contaminated = rmse(4, 0.02, 2.5)
+        const clean = rmse(8, 0.03, null)
+        const winners = NAMES.filter(
+            name =>
+                contaminated[name] <= contaminated["hodges-lehmann"] * 1.01 &&
+                clean[name] <= clean["hodges-lehmann"] * 1.01,
+        )
+        expect(winners).toEqual(["hodges-lehmann"])
+    })
+})

--- a/scripts/lib/robust-estimators.ts
+++ b/scripts/lib/robust-estimators.ts
@@ -1,0 +1,241 @@
+/**
+ * Deterministic robust statistics for the paired benchmark decision model
+ * (see scripts/lib/paired-decision.ts).
+ *
+ * Everything here is a pure function of its input array — no RNG, no clock — so
+ * a CI verdict can be reproduced exactly from the uploaded observation NDJSON.
+ * That rules out bootstrap intervals; the interval machinery below is the
+ * Winsorized (Yuen) standard error plus an exact Student-t tail, which needs no
+ * resampling.
+ */
+import { median } from "./median"
+
+export type LocationEstimator = (values: number[]) => number
+
+function requireValues(values: number[], caller: string): void {
+    if (values.length === 0) {
+        throw new Error(`${caller} requires at least one value`)
+    }
+    if (values.some(value => !Number.isFinite(value))) {
+        throw new Error(`${caller} requires finite values`)
+    }
+}
+
+/**
+ * Arithmetic mean. Kept as the non-robust reference in the estimator
+ * comparison: one contaminated pair moves it by 1/n of the contamination, which
+ * is exactly the failure mode the paired gate has to survive.
+ */
+export function mean(values: number[]): number {
+    requireValues(values, "mean")
+    return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+/**
+ * Hodges-Lehmann location: the median of the n(n+1)/2 Walsh averages
+ * (xi + xj)/2 for i <= j.
+ *
+ * Breakdown point ~29% and asymptotic efficiency 3/pi (~95.5%) against the mean
+ * at the normal. That combination is what this application needs: it absorbs a
+ * single stalled pair out of four while staying nearly as sharp as the mean on
+ * clean data, where the plain median gives up ~36% efficiency.
+ */
+export function hodgesLehmann(values: number[]): number {
+    requireValues(values, "hodgesLehmann")
+    const walsh: number[] = []
+    for (let i = 0; i < values.length; i++) {
+        for (let j = i; j < values.length; j++) {
+            walsh.push((values[i] + values[j]) / 2)
+        }
+    }
+    return median(walsh)
+}
+
+/**
+ * Hodges-Lehmann has variance pi/3 times the mean's at the normal, so reusing
+ * the mean-shaped Yuen standard error would understate it by ~2.3%. Inflating
+ * by sqrt(pi/3) keeps the interval honest on clean data; under contamination —
+ * the case that matters — the correction is swamped by how much less HL moves.
+ */
+export const HODGES_LEHMANN_SE_INFLATION = Math.sqrt(Math.PI / 3)
+
+/** Number of observations trimmed from EACH tail at the given fraction. */
+export function trimCount(count: number, trimFraction: number): number {
+    if (trimFraction < 0 || trimFraction >= 0.5) {
+        throw new Error("trimFraction must be in [0, 0.5)")
+    }
+    return Math.floor(trimFraction * count)
+}
+
+/** Symmetric trimmed mean; equals `mean` when the trim count rounds to zero. */
+export function trimmedMean(values: number[], trimFraction: number): number {
+    requireValues(values, "trimmedMean")
+    const g = trimCount(values.length, trimFraction)
+    const sorted = [...values].sort((a, b) => a - b)
+    return mean(sorted.slice(g, sorted.length - g))
+}
+
+/** Replace the g smallest and g largest values with their nearest survivor. */
+export function winsorize(values: number[], g: number): number[] {
+    requireValues(values, "winsorize")
+    const sorted = [...values].sort((a, b) => a - b)
+    if (g <= 0) return sorted
+    const low = sorted[g]
+    const high = sorted[sorted.length - 1 - g]
+    return sorted.map((value, index) =>
+        index < g ? low : index >= sorted.length - g ? high : value,
+    )
+}
+
+/**
+ * Yuen's standard error for a symmetrically trimmed location estimate:
+ *
+ *     SE = sqrt( SSD_winsorized / (h * (h - 1)) ),  h = n - 2g
+ *
+ * At g = 0 this collapses exactly to s / sqrt(n), so the small-n path (four
+ * pairs trims nothing at a 20% fraction) is the ordinary standard error and
+ * only larger pair counts pay for robustness.
+ */
+export function winsorizedStandardError(values: number[], g: number): number {
+    requireValues(values, "winsorizedStandardError")
+    const h = values.length - 2 * g
+    if (h < 2) {
+        throw new Error(
+            "winsorizedStandardError requires at least two untrimmed values",
+        )
+    }
+    const w = winsorize(values, g)
+    const center = mean(w)
+    const ssd = w.reduce((sum, value) => sum + (value - center) ** 2, 0)
+    return Math.sqrt(ssd / (h * (h - 1)))
+}
+
+/** Residual degrees of freedom for the Yuen standard error above. */
+export function trimmedDegreesOfFreedom(count: number, g: number): number {
+    return count - 2 * g - 1
+}
+
+// --- Student-t tail ---------------------------------------------------------
+// Implemented from the regularized incomplete beta so no probability table or
+// dependency is needed and the same code answers every (t, df) the ladder can
+// produce.
+
+const LANCZOS = [
+    676.5203681218851, -1259.1392167224028, 771.32342877765313,
+    -176.61502916214059, 12.507343278686905, -0.13857109526572012,
+    9.9843695780195716e-6, 1.5056327351493116e-7,
+]
+
+function lnGamma(x: number): number {
+    if (x < 0.5) {
+        return Math.log(Math.PI / Math.sin(Math.PI * x)) - lnGamma(1 - x)
+    }
+    const z = x - 1
+    let a = 0.99999999999980993
+    for (let i = 0; i < LANCZOS.length; i++) a += LANCZOS[i] / (z + i + 1)
+    const t = z + LANCZOS.length - 0.5
+    return (
+        0.5 * Math.log(2 * Math.PI) + (z + 0.5) * Math.log(t) - t + Math.log(a)
+    )
+}
+
+/** Lentz continued fraction for the incomplete beta (Numerical Recipes 6.4). */
+function betaContinuedFraction(a: number, b: number, x: number): number {
+    const tiny = 1e-30
+    const qab = a + b
+    const qap = a + 1
+    const qam = a - 1
+    let c = 1
+    let d = 1 - (qab * x) / qap
+    if (Math.abs(d) < tiny) d = tiny
+    d = 1 / d
+    let h = d
+    for (let m = 1; m <= 300; m++) {
+        const m2 = 2 * m
+        let aa = (m * (b - m) * x) / ((qam + m2) * (a + m2))
+        d = 1 + aa * d
+        if (Math.abs(d) < tiny) d = tiny
+        c = 1 + aa / c
+        if (Math.abs(c) < tiny) c = tiny
+        d = 1 / d
+        h *= d * c
+        aa = (-(a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
+        d = 1 + aa * d
+        if (Math.abs(d) < tiny) d = tiny
+        c = 1 + aa / c
+        if (Math.abs(c) < tiny) c = tiny
+        d = 1 / d
+        const delta = d * c
+        h *= delta
+        if (Math.abs(delta - 1) < 3e-16) break
+    }
+    return h
+}
+
+function regularizedIncompleteBeta(x: number, a: number, b: number): number {
+    if (x <= 0) return 0
+    if (x >= 1) return 1
+    const front =
+        lnGamma(a + b) -
+        lnGamma(a) -
+        lnGamma(b) +
+        a * Math.log(x) +
+        b * Math.log1p(-x)
+    return x < (a + 1) / (a + b + 2)
+        ? (Math.exp(front) * betaContinuedFraction(a, b, x)) / a
+        : 1 - (Math.exp(front) * betaContinuedFraction(b, a, 1 - x)) / b
+}
+
+/** P(T > t) for Student's t with `df` degrees of freedom. */
+export function studentTUpperTail(t: number, df: number): number {
+    if (df < 1) throw new Error("studentTUpperTail requires df >= 1")
+    if (!Number.isFinite(t)) return t > 0 ? 0 : 1
+    const tail = 0.5 * regularizedIncompleteBeta(df / (df + t * t), df / 2, 0.5)
+    return t >= 0 ? tail : 1 - tail
+}
+
+/** The t with P(T > t) = upperTail, by bisection on the monotone tail. */
+export function studentTQuantile(upperTail: number, df: number): number {
+    if (upperTail <= 0 || upperTail >= 1) {
+        throw new Error("studentTQuantile requires 0 < upperTail < 1")
+    }
+    let low = -1e6
+    let high = 1e6
+    for (let i = 0; i < 200; i++) {
+        const mid = (low + high) / 2
+        if (studentTUpperTail(mid, df) > upperTail) low = mid
+        else high = mid
+    }
+    return (low + high) / 2
+}
+
+/**
+ * Benjamini-Hochberg adjusted p-values (q-values), returned in input order.
+ * Controls the false discovery rate across the comparison family rather than
+ * the family-wise error rate: with tens of benchmarks per runtime, Bonferroni
+ * would need evidence no four-pair measurement can produce.
+ */
+export function benjaminiHochberg(pValues: number[]): number[] {
+    const m = pValues.length
+    if (m === 0) return []
+    const order = pValues
+        .map((p, index) => ({ p, index }))
+        .sort((a, b) => a.p - b.p)
+    const adjusted = new Array<number>(m)
+    let running = 1
+    for (let rank = m; rank >= 1; rank--) {
+        const { p, index } = order[rank - 1]
+        running = Math.min(running, (m / rank) * p)
+        adjusted[index] = Math.min(1, running)
+    }
+    return adjusted
+}
+
+export const LOCATION_ESTIMATORS = {
+    mean,
+    median,
+    "hodges-lehmann": hodgesLehmann,
+    "trimmed-mean-20": (values: number[]) => trimmedMean(values, 0.2),
+} satisfies Record<string, LocationEstimator>
+
+export type LocationEstimatorName = keyof typeof LOCATION_ESTIMATORS


### PR DESCRIPTION
Replaces `min(head/base)` as the *decision* statistic with a paired analysis, running **report-only**. The catastrophic gate keeps its exact three-pair input and remains the only blocking check.

## Why

`min` is a deliberate one-sided filter for runner interference (#268) and it fixed a real flake problem. What it cannot do is express confidence. The recorded failure: base `131/131/131` ns vs head `351/351/131` ns — two of three pairs 2.7× slow — is reported as **0% change**, because one clean pair clears it.

So "never alerted" and "demonstrated healthy" are the same answer, and sensitivity is bounded by the noisiest pair.

## The model

- **Balanced B-P-P-B blocks.** Each block yields `(base@1, head@2)` and `(head@1, base@2)`, so a linear drift across the block enters the two pairs with opposite sign and cancels rather than reading as a regression.
- **Paired log-ratios** → Hodges-Lehmann location → Winsorized (Yuen) SE with a 0.5% resolution floor → Student-t tail. No RNG, no clock: a verdict replays from the uploaded NDJSON.
- **Three outcomes** — `regression` / `within-budget` / `inconclusive` — against a +10% budget in both directions. Two clusters separated by a dominant gap are flagged **bimodal** and get no verdict; the historical vector lands there as `+109%, bimodal`, not `0%`.
- **Bounded rerun ladder.** Inconclusive protected lanes earn 4 more pairs, capped at 3 rounds. The bimodality test is a minority *share*, not an absolute count, so a lane contaminated early can actually be cleared by rerunning.
- **BH FDR** across benchmarks and runtimes, applied per family. The protected set is 11 aggregated workloads, one per subsystem — small on purpose, since that is what keeps the adjustment affordable at 4–12 pairs.

The estimator was chosen by measurement, not assumption — there is a bake-off against the mean, median and 20% trimmed mean in `robust-estimators.test.ts`.

## Gate preservation

The catastrophic gate reads **round 1's first three pairs only** — the same B-P, P-B, B-P sequence it has always had. `min` is monotone decreasing in pair count, so a fourth pair would strictly weaken it: `min([1.7,1.7,1.7])` blocks at 1.7×, `min([1.7,1.7,1.7,1.0])` passes at 1.0× on the very same three measurements.

## Sub-microsecond operations are nonblocking for real

`BENCH_EXCLUDE_TINY` consulted a hand-curated list that had drifted — `set(atom, value)` (~110 ns), `set(atom, curr => curr+1)`, `set(atom) with 10 subs`, `sub + unsub` and `createStore` were all still blocking, and the first two are precisely the rows that flaked the gate on unrelated PRs. A measured 1000 ns floor closes that and stays closed as benchmarks are added. In the paired path the floor is evaluated once from the **base** side, so a small operation whose head crosses the floor cannot cause a name-set mismatch and fail the conversion closed on a real finding.

## Honest limits

Type-I error is characterised **at the +10% budget boundary**, where every `regression` verdict is false, with the ladder's nested looks included — not at effect 0, which is an easy null that reports 0% and proves nothing.

| jitter | false regressions (per comparison) | jobs with ≥1 false block |
|:--|--:|--:|
| ±1% | 0.00 % | 0.0 % |
| ±3% | 0.08 % | 1.5 % |
| ±6% | 0.28 % | 5.3 % |
| ±12% | 0.32 % | 5.8 % |

Against a nominal 5% FDR — conservative by 15–60×. `paired-decision.test.ts` asserts these bounds so the documented table cannot drift from the code.

**The statistic is a studentized approximation and the docs now say so.** Exact sign-flip inference was measured and rejected: it cannot produce a p below `2^-n`, so under BH over 22 comparisons rounds 1 and 2 could never report a regression of *any* size — a 10× slowdown at four pairs would read `inconclusive`. Alpha-spending and confirm-on-regression were measured and rejected too, with numbers, in `scripts/PAIRED_DECISION_MODEL.md`.

Detection, at ±3% jitter: **+50% always**, +20% after one ladder round, +15% needs the full ladder, +10% never (it *is* the budget), +5% invisible.

**Runtime cost:** 32 suite invocations for a quiet PR vs 24 before; 64 worst case. The round cap is the first knob if PR latency bites.

## Calibration

Report-only for ~10 merges. `paired-report.json` ships in the `benchmark-observations` artifact as the decision record. The protocol — what to collect, and the rule that blocking and budget changes don't land together — is in `scripts/PAIRED_DECISION_MODEL.md`. The real unknown is actual per-runner jitter, which selects the row in the tables above.

## Verification

- 124 tests in `scripts/`, including a synthetic corpus covering slow head, slow base, alternating drift, bimodal process states, missing pairs, genuine 10/15/50% regressions, a genuine improvement, and simultaneous comparisons.
- Workflow YAML parsed and every `run:` block `bash -n` checked; the ladder driver executed end-to-end against a stubbed runner, confirming exactly three pairs reach the gate files and all rounds reach the report files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)