### PR TITLE
ci: keep bun.lock in sync on release + frozen-lockfile gate

### DIFF
--- a/.github/workflows/bench-table.yml
+++ b/.github/workflows/bench-table.yml
@@ -38,7 +38,7 @@ jobs:
                   ref: main
             - uses: oven-sh/setup-bun@v2
               with:
-                  bun-version: 1.3.13
+                  bun-version: 1.3.14
             - name: Regenerate README benchmark table
               run: bun run scripts/gen-bench-table.ts
             - name: Regenerate docs benchmark summary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
               with:
                   node-version: "24.16"
             - name: Install
-              run: bun install
+              run: bun install --frozen-lockfile
             - name: Require changeset
               if: github.event_name == 'pull_request'
               run: bunx changeset status --since=origin/main
@@ -183,7 +183,7 @@ jobs:
                   bun-version: 1.3.13
 
             - name: Install dependencies
-              run: bun install
+              run: bun install --frozen-lockfile
 
             - name: Build all packages
               run: bun run build
@@ -203,7 +203,7 @@ jobs:
             - name: Create Release Pull Request or Publish
               uses: changesets/action@v1
               with:
-                  version: bunx changeset version
+                  version: bun run version-packages
                   publish: bash scripts/ci-publish.sh
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,9 @@ jobs:
 
             - uses: oven-sh/setup-bun@v2
               with:
-                  bun-version: 1.3.13
+                  # Match the test job / Bencher runners so the frozen-lockfile
+                  # gate sees identical lockfile behavior across both lanes.
+                  bun-version: 1.3.14
 
             - name: Install dependencies
               run: bun install --frozen-lockfile

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: oven-sh/setup-bun@v2
               with:
-                  bun-version: 1.3.13
+                  bun-version: 1.3.14
             - name: Install
               run: bun install --frozen-lockfile
             - name: Build docs site

--- a/.github/workflows/gen-readmes.yml
+++ b/.github/workflows/gen-readmes.yml
@@ -32,7 +32,7 @@ jobs:
                   ref: main
             - uses: oven-sh/setup-bun@v2
               with:
-                  bun-version: 1.3.13
+                  bun-version: 1.3.14
             - run: bun install --frozen-lockfile
             - name: Regenerate package READMEs
               run: bun run scripts/gen-readmes.ts

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/checkout@v6
             - uses: oven-sh/setup-bun@v2
               with:
-                  bun-version: 1.3.13
+                  bun-version: 1.3.14
             - name: Install
               run: bun install --frozen-lockfile
             - name: Build Docs

--- a/bun.lock
+++ b/bun.lock
@@ -76,9 +76,9 @@
     },
     "packages/@valdres-react/hotkeys": {
       "name": "@valdres-react/hotkeys",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.5",
       "dependencies": {
-        "@valdres/hotkeys": "^1.0.0-beta.3",
+        "@valdres/hotkeys": "^1.0.0-beta.5",
       },
       "devDependencies": {
         "@testing-library/react": "16.3.0",
@@ -89,13 +89,13 @@
       },
       "peerDependencies": {
         "react": ">=18",
-        "valdres": "^1.0.0-beta.7",
-        "valdres-react": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.17",
+        "valdres-react": "^1.0.0-beta.3",
       },
     },
     "packages/@valdres-react/jotai": {
       "name": "@valdres-react/jotai",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "dependencies": {
         "valdres-react": "0.2.0-pre.12",
       },
@@ -112,14 +112,14 @@
     },
     "packages/@valdres-react/panable": {
       "name": "@valdres-react/panable",
-      "version": "0.3.0-beta.0",
+      "version": "0.3.0-beta.1",
       "devDependencies": {
         "typescript": "5.9.2",
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
         "@valdres-react/draggable": "^0.3.0-beta.0",
-        "valdres-react": "^1.0.0-beta.1",
+        "valdres-react": "^1.0.0-beta.3",
       },
       "optionalPeers": [
         "@valdres-react/draggable",
@@ -127,7 +127,7 @@
     },
     "packages/@valdres-react/recoil": {
       "name": "@valdres-react/recoil",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "dependencies": {
         "valdres-react": "0.2.0-pre.28",
       },
@@ -142,19 +142,19 @@
     },
     "packages/@valdres/bandwidth": {
       "name": "@valdres/bandwidth",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@valdres/public-ip": "workspace:^",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-color-scheme": {
       "name": "@valdres/browser-color-scheme",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -167,12 +167,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-contrast": {
       "name": "@valdres/browser-contrast",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -185,12 +185,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-device-motion": {
       "name": "@valdres/browser-device-motion",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@react-three/drei": "10.7.7",
@@ -207,12 +207,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-device-orientation": {
       "name": "@valdres/browser-device-orientation",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@react-three/drei": "10.7.7",
@@ -229,12 +229,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-focus": {
       "name": "@valdres/browser-focus",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -247,12 +247,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-geolocation": {
       "name": "@valdres/browser-geolocation",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -260,23 +260,23 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-keyboard": {
       "name": "@valdres/browser-keyboard",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-online": {
       "name": "@valdres/browser-online",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -284,15 +284,15 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-presence": {
       "name": "@valdres/browser-presence",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "dependencies": {
-        "@valdres/browser-focus": "^1.0.0-beta.4",
-        "@valdres/browser-visibility": "^1.0.0-beta.4",
+        "@valdres/browser-focus": "^1.0.0-beta.6",
+        "@valdres/browser-visibility": "^1.0.0-beta.6",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -306,12 +306,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-reduced-data": {
       "name": "@valdres/browser-reduced-data",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -324,12 +324,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-reduced-motion": {
       "name": "@valdres/browser-reduced-motion",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -342,12 +342,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-reduced-transparency": {
       "name": "@valdres/browser-reduced-transparency",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -360,12 +360,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-screen": {
       "name": "@valdres/browser-screen",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -373,12 +373,12 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-screen-details": {
       "name": "@valdres/browser-screen-details",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -386,12 +386,12 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-visibility": {
       "name": "@valdres/browser-visibility",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "19.1.12",
@@ -404,12 +404,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/browser-window": {
       "name": "@valdres/browser-window",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -417,37 +417,37 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/color-mode": {
       "name": "@valdres/color-mode",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.5",
       "devDependencies": {
         "happy-dom": "18.0.1",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/hotkeys": {
       "name": "@valdres/hotkeys",
-      "version": "1.0.0-beta.3",
+      "version": "1.0.0-beta.5",
       "devDependencies": {
         "@valdres/browser-keyboard": "workspace:^",
         "typescript": "5.9.2",
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "@valdres/browser-keyboard": "^1.0.0-beta.4",
-        "valdres": "^1.0.0-beta.7",
+        "@valdres/browser-keyboard": "^1.0.0-beta.6",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/public-ip": {
       "name": "@valdres/public-ip",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@types/react": "18.3.8",
@@ -460,12 +460,12 @@
         "valdres-react": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/@valdres/redux-devtools": {
       "name": "@valdres/redux-devtools",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.4",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "happy-dom": "20.0.5",
@@ -473,7 +473,7 @@
         "valdres": "workspace:^",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/test": {
@@ -482,7 +482,7 @@
     },
     "packages/valdres": {
       "name": "valdres",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.17",
       "devDependencies": {
         "@testing-library/react": "16.3.0",
         "jotai": "2.20.2",
@@ -497,7 +497,7 @@
     },
     "packages/valdres-angular": {
       "name": "valdres-angular",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@angular/core": "19.2.0",
         "typescript": "5.9.2",
@@ -505,14 +505,14 @@
       },
       "peerDependencies": {
         "@angular/core": ">=17",
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/valdres-react": {
       "name": "valdres-react",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.3",
       "dependencies": {
-        "valdres": "^1.0.0-beta.1",
+        "valdres": "^1.0.0-beta.17",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
@@ -533,7 +533,7 @@
     },
     "packages/valdres-solid": {
       "name": "valdres-solid",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "solid-js": "1.9.5",
         "typescript": "5.9.2",
@@ -541,12 +541,12 @@
       },
       "peerDependencies": {
         "solid-js": ">=1.8",
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/valdres-svelte": {
       "name": "valdres-svelte",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@sveltejs/package": "^2.5.8",
@@ -560,12 +560,12 @@
       },
       "peerDependencies": {
         "svelte": ">=5.7",
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
       },
     },
     "packages/valdres-vue": {
       "name": "valdres-vue",
-      "version": "1.0.0-beta.4",
+      "version": "1.0.0-beta.6",
       "devDependencies": {
         "@happy-dom/global-registrator": "20.0.5",
         "@vue/test-utils": "2.4.6",
@@ -575,7 +575,7 @@
         "vue": "3.5.13",
       },
       "peerDependencies": {
-        "valdres": "^1.0.0-beta.7",
+        "valdres": "^1.0.0-beta.17",
         "vue": ">=3.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "test": "bun --filter '*' test",
         "test:ci": "bun --filter '*' test -- --reporter=junit --reporter-outfile=junit.xml",
         "changeset": "changeset",
-        "version-packages": "changeset version",
+        "version-packages": "changeset version && bun install",
         "release": "bash scripts/ci-publish.sh",
         "verify-publish": "bun run scripts/verify-publish.ts",
         "check-size": "bun run scripts/check-package-size.ts",


### PR DESCRIPTION
## Problem

`bun install` on a clean checkout dirties `bun.lock` — 64 lines of workspace-version churn. The committed lockfile's version mirror (e.g. `@valdres-react/hotkeys` `beta.3`) lags the actual `package.json` versions (`beta.5`).

**Root cause:** the release job's version step was `bunx changeset version`, which rewrites `package.json` version fields and internal dep ranges but **never touches `bun.lock`**. `changesets/action` then does `git add . && commit`, capturing the stale lockfile. Confirmed against #224 — it bumped `hotkeys` `beta.3 → beta.5` in `package.json` with `bun.lock` untouched. Every Version Packages PR since #253 (the last manual `bun install` commit) widened the gap.

## Fix

- **`version-packages` script** now runs `changeset version && bun install`, and the release job calls `bun run version-packages` — so the bot's Version Packages PR carries a refreshed lockfile inside the same commit.
- **`--frozen-lockfile`** on the PR and release install steps, so a stale/out-of-sync lockfile fails CI loudly instead of drifting silently.
- **One-time `bun.lock` resync** so `main` is clean immediately rather than waiting for the next release.

## Notes

- CI/tooling + lockfile only — no publishable package source changed, so `changeset status` passes with no changeset required.
- Verified locally: `bun install --frozen-lockfile` exits 0 against the resynced lockfile; the resync diff is purely `beta.N` version-mirror lines (no dependency-graph or registry-hash churn); `ci.yaml` parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)