### PR TITLE
docs(valdres): correct beta.18 release evidence

### DIFF
--- a/.changeset/scope-async-observer-gates.md
+++ b/.changeset/scope-async-observer-gates.md
@@ -1,2 +1,9 @@
 ---
+"valdres": patch
 ---
+
+Async atom settlements no longer take the heavier observer propagation and
+reporting path when the only `onChange` or `onCommitEnd` listeners are attached
+to unrelated store trees. An otherwise unobserved async atom now settles on the
+lightweight path, while listeners on the affected store tree still select the
+observer path as before.

--- a/.changeset/store-tree-runtime-sidecar.md
+++ b/.changeset/store-tree-runtime-sidecar.md
@@ -1,2 +1,8 @@
 ---
+"valdres": patch
 ---
+
+A throw during commit-forest settlement collection no longer leaves the commit
+depth above zero, which previously silenced all future `onCommitEnd` delivery.
+Multi-root commit boundaries now close even when an earlier root or listener
+throws, and the first error thrown is still the one propagated.

--- a/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
+++ b/packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md
@@ -104,7 +104,7 @@ passes, edge visits, enqueues, and dequeues.
 | Unchanged multi-seed closure, 200   |    2 |      2 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
 | Asymmetric DAG, depth 6             |    7 |      7 |       0 |      1 |      1 |         0 |    40 |   8 |   8 |
 | Dynamic churn, width 6              |    6 |      6 |       0 |      1 |      1 |         0 |     6 |   0 |   0 |
-| Single-store update + delete        |    2 |      2 |       1 |      1 |      2 |         1 |     3 |   0 |   0 |
+| Single-store update + delete        |    1 |      1 |       0 |      1 |      1 |         0 |     3 |   0 |   0 |
 | Cross-scope transaction, depth 3    |    1 |      1 |       0 |      1 |      1 |         0 |     3 |   0 |   0 |
 | Cross-scope update + delete + unset |    1 |      1 |       0 |      1 |      1 |         0 |     4 |   0 |   0 |
 | Cross-scope txn, plan/peer overlap  |    1 |      1 |       0 |      1 |      1 |         0 |     2 |   0 |   0 |


### PR DESCRIPTION
## Summary

Documentation and release-metadata-only corrections ahead of the regenerated beta.18 release:

- **Architecture table** — the "Single-store update + delete" deterministic row in `packages/valdres/test/performance/ARCHITECTURE_PERFORMANCE.md` was stale; updated to the current measured counts (`1 | 1 | 0 | 1 | 1 | 0 | 3 | 0 | 0`), matching the prose below the table (one evaluation, zero duplicates).
- **`.changeset/scope-async-observer-gates.md`** (PR #260) — populated with a user-facing patch note: `onChange`/`onCommitEnd` listeners attached only to unrelated store trees no longer force an otherwise unobserved async atom settlement onto the heavier observer propagation/reporting path.
- **`.changeset/store-tree-runtime-sidecar.md`** (PR #267) — populated with a user-facing patch note: a throw during commit-forest settlement collection no longer leaves commit depth above zero and permanently silences future `onCommitEnd` delivery; multi-root commit boundaries still close, preserving first-error behavior.

The existing changeset filenames are reused to preserve attribution to #260 and #267. No generated release output is touched — the Changesets automation regenerates beta.18 after this lands.

## Validation

- `ARCHITECTURE_REPORT=1 bun --filter 'valdres' test:architecture` — 27 pass, 0 fail; the "Single-store update + delete" report emits exactly the table's counts (`selectorEvaluations: 1`, `selectorSettlements: 1`, `duplicateSelectorSettlements: 0`, `affectedStoresSettled: 1`, `storeSettlementPasses: 1`, `duplicateStoreSettlements: 0`, `dependencyEdgeVisits: 3`, `schedulerQueueEnqueues: 0`, `schedulerQueueDequeues: 0`)
- `bun --filter 'valdres' test` — 1229 tests, 0 fail
- `bun run docs:build` — clean (199 pages)
- `bun run scripts/gen-readmes.ts --check` — all 33 READMEs in sync
- `bunx changeset status --since=origin/main` — `valdres` bumped at patch
- `bunx prettier --check` on all three files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)