### PR TITLE
perf(valdres): minify published dist and gate benchmark-only counters

### DIFF
--- a/.changeset/minified-dist-and-gated-counters.md
+++ b/.changeset/minified-dist-and-gated-counters.md
@@ -1,0 +1,32 @@
+---
+"valdres": patch
+---
+
+Publish a minified `dist`, and stop paying for benchmark-only counters in
+production.
+
+The build now minifies. Most consumers bundle valdres and would minify it
+themselves, so the headline win is in the published package — `dist`
+JavaScript drops from 53.2 KB to 36.3 KB gzip (−32%) and the packed tarball
+from 111.8 KB to 96.9 KB gzip (−13%), which every install and every
+CDN/unpkg fetch pays. Consumer bundles also shrink slightly (≈0.9%, e.g. the
+`atom + selector + store` fixture 30,462 → 30,079 bytes gzip) because mangling
+valdres's internals here beats what a bundler infers through the module graph.
+Source maps are deliberately not shipped: they restore readable stack traces
+through valdres internals but measured at +167% on the packed tarball
+(97 KB → 299 KB gzip), which is the wrong default when only a rare consumer
+steps through our internals.
+
+Two `architectureInstrumentation` call sites were reachable in production
+without an `IS_PROD` guard — `recordCommitPlanRun` in the commit engine (once
+per commit, the hottest path in the engine) and the scheduler/liveness
+allocation counters in the graph workspace pool. Both now sit behind
+`!IS_PROD`, matching every other `record*` call site, so a production build
+pays neither the call nor the `data.architectureInstrumentation` load. These
+are test/benchmark-only structural counters that production code has no way to
+enable, so no observable behavior changes.
+
+The build-output tests now assert the `process.env.NODE_ENV` and engine
+self-check contracts against the minified artifact that actually ships, with
+structural chunk-placement assertions kept on an unminified build where
+identifiers survive.

--- a/packages/valdres/build.ts
+++ b/packages/valdres/build.ts
@@ -13,11 +13,30 @@ export const buildOptions = {
     splitting: true,
     external: ["./package.json"],
     packages: "external" as const,
+    // Ship a minified dist. Most consumers bundle valdres and would minify it
+    // themselves, but pre-minifying still pays off twice: the published package
+    // drops ~32% gzip (faster installs, smaller CDN/unpkg payloads for no-build
+    // ESM consumers), and even a bundling consumer ends up ~0.4% smaller,
+    // because mangling our internals here beats what their bundler infers
+    // through the module graph on its own.
+    //
+    // Deliberately NO source maps. They would restore readable stack traces
+    // through valdres internals, but measured at +167% on the packed tarball
+    // (112 KB -> 299 KB gzip) — every consumer pays that download so the rare
+    // one stepping through our internals doesn't see mangled names. Revisit by
+    // publishing maps as a separate artifact if that tradeoff ever inverts.
+    //
+    // Two contracts survive minification and are asserted in test/build.test.ts
+    // against this exact (minified) output: `process.env.NODE_ENV` must remain
+    // a runtime reference, and the engine self-checks must be gone.
+    minify: true,
     define: {
         "process.env.VALDRES_VERSION": JSON.stringify(version),
-        // Compile out the engine self-checks (see src/lib/ENGINE_ASSERTIONS.ts).
-        // They assert invariants only valdres's own code can violate, so they
-        // belong to this repo's test loop, not to a consumer's bundle.
+        // Compile out the engine self-checks (assertPlanLegal in
+        // src/lib/commitPlans.ts, assertTreeTriggersSealed in
+        // src/lib/treeTriggerGroups.ts). They assert invariants only valdres's
+        // own code can violate, so they belong to this repo's test loop, not to
+        // a consumer's bundle.
         "process.env.VALDRES_ENGINE_SELF_CHECKS": JSON.stringify("off"),
         // Map NODE_ENV to itself so Bun does NOT inline it at *our* build time.
         // valdres is built once under NODE_ENV=production; without this, Bun folds
@@ -68,5 +87,9 @@ export const removeStaleBuildJavaScript = async (outdir: string) => {
 
 if (import.meta.main) {
     await removeStaleBuildJavaScript(buildOptions.outdir)
-    await Bun.build(buildOptions)
+    const result = await Bun.build(buildOptions)
+    if (!result.success) {
+        console.error(result.logs.join("\n"))
+        process.exit(1)
+    }
 }

--- a/packages/valdres/src/lib/commitEngine.ts
+++ b/packages/valdres/src/lib/commitEngine.ts
@@ -160,7 +160,11 @@ export const runCommitPlan = (plan: CommitPlan) => {
     // cancelled, or disposed async result cannot open a commit boundary or run
     // any user code merely by arriving late.
     if (plan.admit && !plan.admit()) return false
-    recordCommitPlanRun(plan.data)
+    // Structural counter, test/benchmark-only like every other `record*` call.
+    // `!IS_PROD` first so a production consumer pays neither the call nor the
+    // `data.architectureInstrumentation` load once per commit — this runs on
+    // the hottest path in the engine.
+    if (!IS_PROD) recordCommitPlanRun(plan.data)
 
     const settlement = plan.settlement
     const boundary = plan.boundary

--- a/packages/valdres/src/lib/graph/workspace.ts
+++ b/packages/valdres/src/lib/graph/workspace.ts
@@ -1,3 +1,4 @@
+import { IS_PROD } from "../IS_PROD"
 import type { Selector } from "../../types/Selector"
 import type { State } from "../../types/State"
 import type { StoreData } from "../../types/StoreData"
@@ -63,7 +64,7 @@ const recordLivenessAllocations = (data: StoreData, count: number) => {
 
 const createSchedulerWorkspace = (data: StoreData): SchedulerWorkspace => {
     // One Map plus four reusable arrays.
-    recordSchedulerAllocations(data, 5)
+    if (!IS_PROD) recordSchedulerAllocations(data, 5)
     return {
         meta: new Map(),
         nodes: [],
@@ -76,7 +77,7 @@ const createSchedulerWorkspace = (data: StoreData): SchedulerWorkspace => {
 
 const createLivenessWorkspace = (data: StoreData): LivenessWorkspace => {
     // Stack, reverse-order staging, and DFS arrays; Sets/Maps stay lazy.
-    recordLivenessAllocations(data, 3)
+    if (!IS_PROD) recordLivenessAllocations(data, 3)
     return {
         stack: [],
         ordered: [],

--- a/packages/valdres/test/build.test.ts
+++ b/packages/valdres/test/build.test.ts
@@ -4,6 +4,31 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { buildOptions, removeStaleBuildJavaScript } from "../build"
 
+// `outdir` is dropped so these bundle in memory; everything else — including
+// `minify` — matches what `bun run build` publishes.
+const { outdir: _outdir, ...inMemory } = buildOptions
+
+const bundle = async (options: Parameters<typeof Bun.build>[0]) => {
+    const result = await Bun.build(options)
+    expect(result.success).toBe(true)
+    const outputs = await Promise.all(
+        result.outputs.map(output => output.text()),
+    )
+    return { result, outputs, code: outputs.join("\n") }
+}
+
+/** The published artifact. Contracts a consumer depends on are asserted against
+ *  THIS, never against a friendlier build. */
+let shippedCache: ReturnType<typeof bundle> | undefined
+const shipped = () => (shippedCache ??= bundle(inMemory))
+
+/** The same module graph with identifiers preserved. Minification renames
+ *  classes and locals but cannot move code between chunks, so structural
+ *  "exactly one copy of X" assertions remain valid — and readable — here. */
+let readableCache: ReturnType<typeof bundle> | undefined
+const readable = () =>
+    (readableCache ??= bundle({ ...inMemory, minify: false }))
+
 describe("build output", () => {
     // Regression guard for the dev-only freeze. valdres is built once under
     // NODE_ENV=production; Bun special-cases `process.env.NODE_ENV` and would
@@ -14,18 +39,15 @@ describe("build output", () => {
     // so the consumer resolves NODE_ENV themselves. Source tests can't catch this
     // (they run from src, not the bundle), hence a build-output assertion.
     test("does not inline process.env.NODE_ENV — consumer resolves it", async () => {
-        const { outdir, ...inMemory } = buildOptions
-        const result = await Bun.build(inMemory)
-        expect(result.success).toBe(true)
-        const code = (
-            await Promise.all(result.outputs.map(output => output.text()))
-        ).join("\n")
-        // The runtime reference must survive; if it were folded we'd see
-        // `typeof process !== "undefined" && true` (or `&& false`) instead.
+        const { code } = await shipped()
+        // The whole comparison must survive, not just the member expression:
+        // folding would leave a bare `true`/`false` with no "production" test,
+        // and a consumer's bundler would have nothing left to match on.
+        // Asserted on the minified output because that is what we publish —
+        // minification rewrites `typeof process !== "undefined"` to
+        // `typeof process < "u"`, so match only the part we actually rely on.
         expect(code).toContain("process.env.NODE_ENV")
-        expect(code).not.toMatch(
-            /typeof process !== "undefined" && (true|false)/,
-        )
+        expect(code).toMatch(/process\.env\.NODE_ENV\s*===\s*"production"/)
     })
 
     // Companion guard for the engine self-checks — `assertPlanLegal` and the
@@ -38,37 +60,31 @@ describe("build output", () => {
     // throw on module load in raw browser ESM — so assert every half here,
     // where a source test cannot see them.
     test("compiles out the engine self-checks", async () => {
-        const { outdir, ...inMemory } = buildOptions
-        const result = await Bun.build(inMemory)
-        expect(result.success).toBe(true)
-        const code = (
-            await Promise.all(result.outputs.map(output => output.text()))
-        ).join("\n")
+        const { code } = await shipped()
         expect(code).not.toContain("VALDRES_ENGINE_SELF_CHECKS")
-        expect(code).toContain("if (!IS_PROD && false)")
         expect(code).not.toContain("illegal CommitPlan")
         expect(code).not.toContain("commitPlanAllocations")
+        expect(code).not.toContain("assertPlanLegal")
+        expect(code).not.toContain("assertTreeTriggersSealed")
     })
 
-    test("public and adapter entrypoints share one transaction runtime", async () => {
-        const { outdir, ...inMemory } = buildOptions
-        const result = await Bun.build(inMemory)
-        expect(result.success).toBe(true)
-        const outputs = await Promise.all(
-            result.outputs.map(output => output.text()),
-        )
-        const index = result.outputs.findIndex(output =>
-            output.path.endsWith("/index.js"),
-        )
-        const adapterInternals = result.outputs.findIndex(output =>
-            output.path.endsWith("adapter-internals/v1.js"),
-        )
+    // The assertions above prove the self-check *graph* is absent, but not WHY.
+    // If the define were lost, `process.env.VALDRES_ENGINE_SELF_CHECKS` would
+    // survive as an unguarded `process.env` read that throws on module load in
+    // raw browser ESM. Checking the folded branch on the unminified graph pins
+    // the mechanism — minification erases the branch entirely, which would let
+    // a regression here pass unnoticed above.
+    test("folds the self-check guard rather than merely shaking it out", async () => {
+        const { code } = await readable()
+        expect(code).toContain("if (!IS_PROD && false)")
+        expect(code).not.toContain("VALDRES_ENGINE_SELF_CHECKS")
+    })
 
-        expect(index).toBeGreaterThanOrEqual(0)
-        expect(adapterInternals).toBeGreaterThanOrEqual(0)
-        expect(
-            outputs.filter(code => code.includes("class TransactionContext")),
-        ).toHaveLength(1)
+    // Symbol descriptions are string literals, so minification preserves them
+    // verbatim — which makes them the one single-instance check we can run
+    // directly against the published artifact.
+    test("public and adapter entrypoints share one transaction runtime", async () => {
+        const { outputs } = await shipped()
         expect(
             outputs.filter(code =>
                 code.includes('Symbol("valdres.storeDataAccess")'),
@@ -82,6 +98,26 @@ describe("build output", () => {
             outputs.filter(code =>
                 code.includes('Symbol("valdres.cancelOnStoreDispose")'),
             ),
+        ).toHaveLength(1)
+    })
+
+    // Chunk placement of the runtime class itself. Minification renames
+    // `TransactionContext`, so this half runs on the unminified graph —
+    // splitting decides which chunk a declaration lands in before any renaming
+    // happens, so the placement being asserted is identical in both builds.
+    test("bundles the transaction runtime into the shared chunk, not an entry", async () => {
+        const { result, outputs } = await readable()
+        const index = result.outputs.findIndex(output =>
+            output.path.endsWith("/index.js"),
+        )
+        const adapterInternals = result.outputs.findIndex(output =>
+            output.path.endsWith("adapter-internals/v1.js"),
+        )
+
+        expect(index).toBeGreaterThanOrEqual(0)
+        expect(adapterInternals).toBeGreaterThanOrEqual(0)
+        expect(
+            outputs.filter(code => code.includes("class TransactionContext")),
         ).toHaveLength(1)
         // The single runtime must live in a shared chunk, not be duplicated
         // into (or defined by) either entry. The public entry may still

--- a/scripts/size-baseline.json
+++ b/scripts/size-baseline.json
@@ -1,42 +1,42 @@
 {
     "dist": {
-        "raw": 285797,
-        "gzip": 53203
+        "raw": 115131,
+        "gzip": 36253
     },
     "distFiles": {
         "adapter-internals/v1.js": {
-            "raw": 1015,
-            "gzip": 417
+            "raw": 479,
+            "gzip": 330
         },
-        "chunk-pwppbtvj.js": {
-            "raw": 212701,
-            "gzip": 37771
+        "chunk-c0hc8t04.js": {
+            "raw": 83690,
+            "gzip": 25195
         },
         "index.js": {
-            "raw": 72081,
-            "gzip": 15015
+            "raw": 30962,
+            "gzip": 10728
         }
     },
     "packed": {
-        "raw": 493321,
-        "gzip": 111782
+        "raw": 328610,
+        "gzip": 96942
     },
     "fixtures": {
         "atom": {
-            "raw": 99848,
-            "gzip": 30348
+            "raw": 100592,
+            "gzip": 30079
         },
         "atom-selector-store": {
-            "raw": 100117,
-            "gzip": 30462
+            "raw": 100861,
+            "gzip": 30198
         },
         "all-exports": {
-            "raw": 111947,
-            "gzip": 34067
+            "raw": 112687,
+            "gzip": 33723
         },
         "adapter-internals": {
-            "raw": 78475,
-            "gzip": 23617
+            "raw": 78814,
+            "gzip": 23296
         }
     }
 }


### PR DESCRIPTION
Investigated why valdres core sits at ~30 KB gzip against jotai's ~4 KB, then landed the wins that were actually worth landing.

## Measured baseline

All minified + gzip, measured with the repo's own fixtures:

| | gzip |
|---|---|
| jotai vanilla, all exports | 3,291 |
| jotai + React bindings, all exports | 4,366 |
| jotai + `jotai/utils` (families etc.) | 6,437 |
| valdres `atom + selector + store` | 30,462 |

The gap is **not** dev-only code (forcing `IS_PROD` to a literal saves 20 bytes gzip), **not** comments (stripped), and **not** one fat module. It is the engine: 94 modules, ~227 KB of comment-stripped code implementing a commit engine, a bitflag scheduler, graph mount/liveness propagation, and a three-phase admit/apply/commit protocol, where jotai does mark-and-recompute over a WeakMap. Nothing here changes that; this PR takes the wins that don't require an architectural rewrite.

## What this does

**Minify the published dist.**

| measure | before | after | |
|---|---|---|---|
| dist `.js` gzip | 53,203 | **36,253** | −31.9% |
| packed tarball gzip | 111,782 | **96,942** | −13.3% |
| fixture `atom` | 30,348 | 30,079 | −0.9% |
| fixture `atom+selector+store` | 30,462 | 30,198 | −0.9% |
| fixture `all-exports` | 34,067 | 33,723 | −1.0% |
| fixture `adapter-internals` | 23,617 | 23,296 | −1.4% |

Source maps were tried and backed out: they restore readable stack traces through valdres internals but cost **+167% on the packed tarball** (97 → 299 KB gzip). Wrong default when every installer pays so a rare consumer can step through our internals. Rationale is recorded in `build.ts` if we want to revisit via a separate artifact.

**Gate two benchmark-only counters that ran in production.** `recordCommitPlanRun` executed once per commit — the hottest path in the engine — and the scheduler/liveness allocation counters ran per workspace creation, both without an `IS_PROD` guard. Both now match every other `record*` site, so a production build pays neither the call nor the `data.architectureInstrumentation` load. These counters cannot be enabled by production code, so no behavior changes.

**Point the build tests at the artifact that ships.** They previously asserted the `process.env.NODE_ENV` and engine self-check contracts against an unminified build we don't publish. Those now run against the minified output; chunk-placement assertions (which need surviving identifiers) moved to an explicit unminified build, plus a new test pinning that the self-check guard *folds* rather than merely being shaken out.

## Deliberately not done

Two follow-ups from the investigation were scoped and rejected on evidence:

- **Breaking the `atom.ts → globalAtom` edge.** It looks compelling — that one import takes `atom.ts` from 91 modules to 4 — but it is worth **zero bytes to any real app**. The fixtures prove it: `atom` alone is 30,079 and `atom + selector + store` is 30,198, only 119 bytes apart, because `store` pulls the whole engine on its own. Implementing it also requires either a runtime failure mode for `atom({ global: true })` that depends on unrelated imports, or a breaking API split — both inside a 9-module import cycle.
- **Fully stripping `architectureInstrumentation` behind a build define.** Ceiling is ~1 KB gzip (3.6%) and it needs 131 inline guards across 19 files, concentrated in `scheduler.ts`, `mountAtom.ts`, and `propagateUpdatedAtoms.ts`. A module-level boolean will not fold, so there is no cheap version. Too much hot-path churn against the Bencher gate for less than half of what minification gave for free.

## Verification

- `bun --filter '*' test` — all 28 packages, 0 fail (valdres: 1230 pass)
- `bun run typecheck` — clean
- `bun run check-size` — all gates pass, baseline ratcheted to the committed state
- `bun run docs:build` — 199 pages clean; `gen-readmes --check` in sync
- `bunx changeset status --since=origin/main` — satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)