### PR TITLE
fix(valdres): true no-op for equal-value txn writes on root store

### DIFF
--- a/.changeset/fix-equal-value-txn-write.md
+++ b/.changeset/fix-equal-value-txn-write.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Fix `writeAtoms` so an equal-value transaction write is a true no-op on a
+root store: it no longer overwrites the stored reference with the new
+(deep-equal) value, and no longer bumps the tree revision or invalidates
+cold selector caches. The scope-shadow pinning behavior on scoped stores is
+unchanged.

--- a/packages/valdres/src/lib/writeAtoms.test.ts
+++ b/packages/valdres/src/lib/writeAtoms.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, mock, test } from "bun:test"
+import { atom } from "../atom"
+import { selector } from "../selector"
+import { store } from "../store"
+import { getStoreData } from "./getStoreData"
+
+describe("writeAtoms equal-value branch", () => {
+    test("txn.set of a deep-equal object preserves the stored reference like a direct set", () => {
+        const rootStore = store()
+        const original = { a: 1 }
+        const source = atom(original)
+
+        rootStore.set(source, { a: 1 })
+        expect(rootStore.get(source)).toBe(original)
+
+        rootStore.txn(({ set }) => set(source, { a: 1 }))
+        expect(rootStore.get(source)).toBe(original)
+    })
+
+    test("an equal-value txn write does not bump tree.revision or re-evaluate a cold selector", () => {
+        const rootStore = store()
+        const source = atom(1)
+        const callback = mock(get => ({ value: get(source) }))
+        const derived = selector(callback)
+
+        const first = rootStore.get(derived)
+        expect(callback).toHaveBeenCalledTimes(1)
+
+        rootStore.txn(({ set }) => set(source, 1))
+
+        expect(getStoreData(rootStore).tree.revision).toBe(0)
+        expect(rootStore.get(derived)).toBe(first)
+        expect(callback).toHaveBeenCalledTimes(1)
+    })
+})

--- a/packages/valdres/src/lib/writeAtoms.ts
+++ b/packages/valdres/src/lib/writeAtoms.ts
@@ -96,7 +96,9 @@ export const writeAtoms = (
                 ) {
                     atom.attach(data)
                 }
-                setValueInData(atom, value, data)
+                if (data.parent && !data.values.has(atom)) {
+                    setValueInData(atom, value, data)
+                }
             }
             // No placeholder to resolve here: equal settled values have none,
             // and an equal own promise is already coordinated by its first write.

--- a/packages/valdres/src/utils/hydrate.test.ts
+++ b/packages/valdres/src/utils/hydrate.test.ts
@@ -173,14 +173,16 @@ describe("hydrate", () => {
         expect(fresh.get(idEqual)).toEqual({ id: 1, rev: 1 })
 
         // hydrate writes through txn.set, so the atom's custom equal applies
-        // exactly as in any transaction: an `equal` incoming value is written
-        // without notifying (no propagation, no subscriber fire).
+        // exactly as in any transaction: an `equal` incoming value is a true
+        // no-op on a root store — the existing reference is kept, nothing is
+        // written, and there is no notification (no propagation, no
+        // subscriber fire). This mirrors direct store.set()'s equal branch.
         const warm = store()
         warm.set(idEqual, { id: 1, rev: 99 })
         const subscriber = mock(() => {})
         warm.sub(idEqual, subscriber)
         hydrate(warm, payload)
-        expect(warm.get(idEqual)).toEqual({ id: 1, rev: 1 })
+        expect(warm.get(idEqual)).toEqual({ id: 1, rev: 99 })
         expect(subscriber).toHaveBeenCalledTimes(0)
     })
 


### PR DESCRIPTION
## Summary
- `writeAtoms`' equal-value branch called `setValueInData` unconditionally, so a `txn.set` of a deep-equal value overwrote the stored object reference, bumped `tree.revision`, and invalidated cold selector caches — even on a root store.
- `setAtom.ts` already gates this write on `data.parent && !data.values.has(atom)` (it only needs to run to pin a scope shadow). This applies the same gate in `writeAtoms.ts` so both write paths agree, and a root-store equal txn write becomes a true no-op.

## Test plan
- [x] Added `packages/valdres/src/lib/writeAtoms.test.ts` with two red-green tests, confirmed both failed on unmodified code:
  - `txn.set` of a deep-equal object preserves the stored reference exactly like a direct `set`
  - an equal-value `txn` write does not bump `tree.revision` or re-evaluate a cold selector
- [x] Both tests pass after the fix
- [x] `bun --filter '*' test` — no regressions vs. baseline (remaining failures are pre-existing missing-dependency errors unrelated to this change, confirmed via `git stash`)
- [x] Changeset added (`valdres`: patch)