### PR TITLE
fix(valdres): invalidate selector caches across transaction levels

### DIFF
--- a/.changeset/txn-cross-level-selector-cache.md
+++ b/.changeset/txn-cross-level-selector-cache.md
@@ -1,0 +1,9 @@
+---
+"valdres": patch
+---
+
+Fix stale selector reads across transaction levels. A scoped transaction
+evaluates selectors through its parent's draft, but a write only marked its own
+level's cache dirty — so a root-level `set` left a scope (and a `parentScope`
+write left the scope that opened it) serving the pre-write value for the rest of
+the transaction. Writes now invalidate every selector cache in the working tree.

--- a/packages/valdres/src/lib/transaction.test.ts
+++ b/packages/valdres/src/lib/transaction.test.ts
@@ -733,6 +733,45 @@ describe("transaction", () => {
         })
     })
 
+    test("root-level set invalidates a scoped selector cache in the same txn", () => {
+        const count = atom(1)
+        const doubled = selector(get => get(count) * 2)
+        const rootStore = store()
+        rootStore.scope("Child1")
+
+        rootStore.txn(txn => {
+            txn.scope("Child1", childTxn => {
+                expect(childTxn.get(doubled)).toBe(2)
+            })
+            txn.set(count, 5)
+            // The scope evaluates `doubled` through the root draft, so the
+            // root's write has to invalidate the scope's cache too.
+            txn.scope("Child1", childTxn => {
+                expect(childTxn.get(doubled)).toBe(10)
+            })
+        })
+
+        expect(rootStore.get(doubled)).toBe(10)
+    })
+
+    test("parentScope set invalidates the scoped selector cache in the same txn", () => {
+        const count = atom(1)
+        const doubled = selector(get => get(count) * 2)
+        const rootStore = store()
+        const childStore = rootStore.scope("Child1")
+
+        childStore.txn(txn => {
+            expect(txn.get(doubled)).toBe(2)
+            txn.parentScope(parentTxn => {
+                parentTxn.set(count, 5)
+            })
+            expect(txn.get(doubled)).toBe(10)
+        })
+
+        expect(childStore.get(doubled)).toBe(10)
+        expect(rootStore.get(doubled)).toBe(10)
+    })
+
     test("family in scopes", () => {
         const userAtomFamily = atomFamily()
         const rootStore = store()

--- a/packages/valdres/src/lib/transaction.ts
+++ b/packages/valdres/src/lib/transaction.ts
@@ -362,7 +362,7 @@ export class TransactionContext {
         // (last write wins, regardless of order). Symmetric to `unset` dropping
         // any buffered set.
         draft.unsets?.delete(atom)
-        if (!draft.dirty) draft.dirty = true
+        this.invalidateSelectorCache()
         if (isFamilyAtom(atom)) {
             const ownFamilyValue = draft.values.has(atom.family)
                 ? draft.values.get(atom.family)
@@ -432,7 +432,7 @@ export class TransactionContext {
             draft.values.set(atom, resolved)
             if (!staged) {
                 staged = true
-                if (!draft.dirty) draft.dirty = true
+                this.invalidateSelectorCache()
             }
             if (!draft.hasCommitEffects && atom.onSet) {
                 draft.hasCommitEffects = true
@@ -921,8 +921,30 @@ export class TransactionContext {
         return this._draft.selectorCache
     }
 
+    /** Invalidate every selector cache a write at this level can affect.
+     *
+     *  A scoped context evaluates selectors against its OWN data but resolves
+     *  their atom reads through `this.get` — which falls through to the parent
+     *  transaction's draft. So a write anywhere in a working tree can change
+     *  what a selector cached at another level would return, and a per-level
+     *  dirty flag would keep serving the pre-write value. Mark the whole tree
+     *  instead; each level clears its own cache lazily on its next selector
+     *  read (see `get`).
+     *
+     *  The single-store hot path — no parent, no scopes — never leaves the
+     *  first two lines. */
     private invalidateSelectorCache() {
         if (!this._draft.dirty) this._draft.dirty = true
+        if (!this._parentTransaction && !this._scopedTransactions) return
+        this.rootTransaction().markTreeSelectorCachesDirty()
+    }
+
+    private markTreeSelectorCachesDirty(): void {
+        if (!this._draft.dirty) this._draft.dirty = true
+        if (!this._scopedTransactions) return
+        for (const scopedTxn of this._scopedTransactions.values()) {
+            scopedTxn.markTreeSelectorCachesDirty()
+        }
     }
 
     private get selectorRuntime(): SelectorEvaluationRuntime {


### PR DESCRIPTION
## The bug

`TransactionContext.get` caches selector evaluations per level in `_draft.selectorCache` and clears that cache when `_draft.dirty` is set. But a scoped context evaluates selectors against its **own** store data while resolving their atom reads through `this.get`, which falls through to the **parent** transaction's draft — and `set` marked only its own level dirty.

So a write at one level never invalidated a cache at another level of the same working tree. Inside a single transaction:

```ts
rootStore.txn(txn => {
    txn.scope("Child1", child => child.get(doubled))  // 2, cached in the scope
    txn.set(count, 5)                                 // marks only the root dirty
    txn.scope("Child1", child => child.get(doubled))  // 2 — stale
})
```

Same staleness from the other direction: a child that has read a selector, then writes the dep via `parentScope`, keeps reading the pre-write value.

## The fix

`invalidateSelectorCache()` now marks the whole working tree — walk to `rootTransaction()`, then recurse through `_scopedTransactions`. Each level still clears its own cache lazily on its next selector read, so the `get` path is unchanged.

`set` and `batchSetFamilyAtoms` had inlined `if (!draft.dirty) draft.dirty = true`; both now route through the same helper, so every write path (`set`, `batchSetFamilyAtoms`, `del`, `unset`, `reset`) invalidates consistently.

**Why whole-tree rather than the minimal self-plus-descendants:** a scoped `set` of a family atom re-clones the family index *upward* via `cloneFamilyIntoTxn`'s `moveUpIfParent`, so upward invalidation isn't obviously unnecessary, and over-invalidation only ever costs a recompute. The single-store hot path exits after two `undefined` field checks and never walks.

## Tests

Two tests added to `transaction.test.ts`, both confirmed red before the fix (returning the stale `2` instead of `10`):

- `root-level set invalidates a scoped selector cache in the same txn`
- `parentScope set invalidates the scoped selector cache in the same txn`

## Verification

- `packages/valdres`: 1234 pass / 0 fail, including `test/oracle` (80 pass).
- Whole monorepo `bun --filter '*' test`: 0 failures in every package.
- `bun run typecheck`, `bun run docs:build`, `gen-readmes --check`: clean.
- `test/performance/transaction.bench.ts` before/after is identical within noise — the gated `txn: staged set + selector read` is 583ns on both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)